### PR TITLE
Fix timer issue

### DIFF
--- a/api/oc_ri.c
+++ b/api/oc_ri.c
@@ -432,6 +432,10 @@ poll_event_callback_timers(oc_list_t list, struct oc_memb *cb_pool)
         OC_PROCESS_CONTEXT_BEGIN(&timed_callback_events);
         oc_etimer_restart(&event_cb->timer);
         OC_PROCESS_CONTEXT_END(&timed_callback_events);
+
+        //fix: if next node is removed/freed by current callback function, it will crash.        
+        event_cb = oc_list_head(list);
+        continue;
       }
     }
 


### PR DESCRIPTION
if the next timer is deleted by current timer's callback function,
the timer list is broken.