### PR TITLE
api: fix oc_delayed_delete_resource function

### DIFF
--- a/api/cloud/oc_cloud.c
+++ b/api/cloud/oc_cloud.c
@@ -24,6 +24,7 @@
 #include "oc_collection.h"
 #include "oc_core_res.h"
 #include "oc_network_monitor.h"
+#include "api/oc_server_api_internal.h"
 #ifdef OC_SECURITY
 #include "security/oc_tls.h"
 #include "security/oc_pstat.h"

--- a/api/cloud/oc_cloud.c
+++ b/api/cloud/oc_cloud.c
@@ -343,6 +343,8 @@ oc_cloud_manager_stop(oc_cloud_context_t *ctx)
 int
 oc_cloud_init(void)
 {
+  oc_set_on_delayed_delete_resource_cb(oc_cloud_delete_resource);
+
   size_t device;
   for (device = 0; device < oc_core_get_num_devices(); device++) {
     oc_cloud_context_t *ctx =

--- a/api/oc_server_api.c
+++ b/api/oc_server_api.c
@@ -18,6 +18,7 @@
 #include "messaging/coap/oc_coap.h"
 #include "messaging/coap/separate.h"
 #include "oc_api.h"
+#include "oc_server_api_internal.h"
 
 #ifdef OC_SECURITY
 #include "security/oc_store.h"

--- a/api/oc_server_api.c
+++ b/api/oc_server_api.c
@@ -18,7 +18,10 @@
 #include "messaging/coap/oc_coap.h"
 #include "messaging/coap/separate.h"
 #include "oc_api.h"
+
+#if defined(OC_CLOUD) && defined(OC_SERVER)
 #include "oc_server_api_internal.h"
+#endif /* OC_CLOUD && OC_SERVER */
 
 #ifdef OC_SECURITY
 #include "security/oc_store.h"
@@ -36,9 +39,9 @@
 
 static size_t query_iterator;
 
-#ifdef OC_SERVER
+#if defined(OC_CLOUD) && defined(OC_SERVER)
 static oc_delete_resource_cb_t g_delayed_delete_resource_cb = NULL;
-#endif // OC_SERVER
+#endif /* OC_CLOUD && OC_SERVER */
 
 int
 oc_add_device(const char *uri, const char *rt, const char *name,
@@ -471,19 +474,23 @@ oc_delete_resource(oc_resource_t *resource)
   return oc_ri_delete_resource(resource);
 }
 
+#ifdef OC_CLOUD
 void
 oc_set_on_delayed_delete_resource_cb(oc_delete_resource_cb_t callback)
 {
   g_delayed_delete_resource_cb = callback;
 }
+#endif /* OC_CLOUD */
 
 static oc_event_callback_retval_t
 oc_delayed_delete_resource_cb(void *data)
 {
   oc_resource_t *resource = (oc_resource_t *)data;
+#ifdef OC_CLOUD
   if (g_delayed_delete_resource_cb) {
     g_delayed_delete_resource_cb(resource);
   }
+#endif /* OC_CLOUD */
   oc_delete_resource(resource);
   return OC_EVENT_DONE;
 }

--- a/api/oc_server_api.c
+++ b/api/oc_server_api.c
@@ -35,6 +35,10 @@
 
 static size_t query_iterator;
 
+#ifdef OC_SERVER
+static oc_delete_resource_cb_t g_delayed_delete_resource_cb = NULL;
+#endif // OC_SERVER
+
 int
 oc_add_device(const char *uri, const char *rt, const char *name,
               const char *spec_version, const char *data_model_version,
@@ -466,13 +470,19 @@ oc_delete_resource(oc_resource_t *resource)
   return oc_ri_delete_resource(resource);
 }
 
+void
+oc_set_on_delayed_delete_resource_cb(oc_delete_resource_cb_t callback)
+{
+  g_delayed_delete_resource_cb = callback;
+}
+
 static oc_event_callback_retval_t
 oc_delayed_delete_resource_cb(void *data)
 {
   oc_resource_t *resource = (oc_resource_t *)data;
-#ifdef OC_CLOUD
-  /* oc_cloud_delete_resource(resource); */
-#endif
+  if (g_delayed_delete_resource_cb) {
+    g_delayed_delete_resource_cb(resource);
+  }
   oc_delete_resource(resource);
   return OC_EVENT_DONE;
 }

--- a/api/oc_server_api_internal.h
+++ b/api/oc_server_api_internal.h
@@ -1,0 +1,40 @@
+/*
+// Copyright (c) 2021 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+#ifndef OC_SERVER_API_INTERNAL_H
+#define OC_SERVER_API_INTERNAL_H
+
+#include "oc_api.h"
+
+/**
+ * @brief Callback invoked on resource before it is deleted by
+ * oc_delayed_delete_resource.
+ *
+ * @param resource Resource to be deleted
+ */
+typedef void (*oc_delete_resource_cb_t)(oc_resource_t *resource);
+
+/**
+ * Sets the callback that gets invoked by oc_delayed_delete_resource
+ * before each resource is deleted.
+ *
+ * @param callback The callback to set or NULL to unset it. If the function
+ *                 is invoked a second time, then the previously set callback is
+ *                 simply replaced.
+ */
+void oc_set_on_delayed_delete_resource_cb(oc_delete_resource_cb_t callback);
+
+#endif /* OC_SERVER_API_INTERNAL_H */

--- a/api/oc_server_api_internal.h
+++ b/api/oc_server_api_internal.h
@@ -17,6 +17,8 @@
 #ifndef OC_SERVER_API_INTERNAL_H
 #define OC_SERVER_API_INTERNAL_H
 
+#ifdef OC_CLOUD
+
 #include "oc_api.h"
 
 /**
@@ -36,5 +38,7 @@ typedef void (*oc_delete_resource_cb_t)(oc_resource_t *resource);
  *                 simply replaced.
  */
 void oc_set_on_delayed_delete_resource_cb(oc_delete_resource_cb_t callback);
+
+#endif /* OC_CLOUD */
 
 #endif /* OC_SERVER_API_INTERNAL_H */

--- a/include/oc_api.h
+++ b/include/oc_api.h
@@ -1153,24 +1153,6 @@ bool oc_add_resource(oc_resource_t *resource);
 bool oc_delete_resource(oc_resource_t *resource);
 
 /**
- * @brief Callback invoked on resource before it is deleted by
- * oc_delayed_delete_resource.
- *
- * @param resource Resource to be deleted
- */
-typedef void (*oc_delete_resource_cb_t)(oc_resource_t *resource);
-
-/**
- * Sets the callback that gets invoked by oc_delayed_delete_resource
- * before each resource is deleted.
- *
- * @param callback The callback to set or NULL to unset it. If the function
- *                 is invoked a second time, then the previously set callback is
- *                 simply replaced.
- */
-void oc_set_on_delayed_delete_resource_cb(oc_delete_resource_cb_t callback);
-
-/**
  * Schedule a callback to remove a resource.
  *
  * @param[in] resource the resource to delete

--- a/include/oc_api.h
+++ b/include/oc_api.h
@@ -1153,6 +1153,24 @@ bool oc_add_resource(oc_resource_t *resource);
 bool oc_delete_resource(oc_resource_t *resource);
 
 /**
+ * @brief Callback invoked on resource before it is deleted by
+ * oc_delayed_delete_resource.
+ *
+ * @param resource Resource to be deleted
+ */
+typedef void (*oc_delete_resource_cb_t)(oc_resource_t *resource);
+
+/**
+ * Sets the callback that gets invoked by oc_delayed_delete_resource
+ * before each resource is deleted.
+ *
+ * @param callback The callback to set or NULL to unset it. If the function
+ *                 is invoked a second time, then the previously set callback is
+ *                 simply replaced.
+ */
+void oc_set_on_delayed_delete_resource_cb(oc_delete_resource_cb_t callback);
+
+/**
  * Schedule a callback to remove a resource.
  *
  * @param[in] resource the resource to delete


### PR DESCRIPTION
Do not invoke oc_cloud_delete_resource directly
in oc_server_api.c, because not all targets link
with oc_cloud source code. Instead assign
oc_cloud_delete_resource to global pointer if
cloud is enabled and invoke this pointer (if set).