### PR TITLE
Persist cloud store after cps and last_error were reset.

### DIFF
--- a/api/cloud/oc_cloud.c
+++ b/api/cloud/oc_cloud.c
@@ -116,6 +116,7 @@ cloud_deregister_on_reset_internal(oc_cloud_context_t *ctx,
   cloud_manager_stop(ctx);
   ctx->last_error = 0;
   ctx->store.cps = 0;
+  cloud_store_dump(&ctx->store);
 }
 #endif /* OC_SECURITY */
 
@@ -137,10 +138,10 @@ oc_cloud_reset_context(size_t device)
 #endif /* OC_SECURITY */
 
   cloud_store_initialize(&ctx->store);
-  cloud_store_dump(&ctx->store);
   cloud_manager_stop(ctx);
   ctx->last_error = 0;
   ctx->store.cps = 0;
+  cloud_store_dump(&ctx->store);
   return 0;
 }
 


### PR DESCRIPTION
It could happen, that after a `OC_RESET` the cloud store does not reset the values for `cps` (i.e. the reset value for `cps` is only in memory). That can cause the cloud manager to enter a wrong state, when the iotivity-lite server is restarted.

This PR fixes the issue.

Pleaes review: @jkralik