### PR TITLE
api/cloud: make Time to Live configurable

### DIFF
--- a/api/cloud/oc_cloud.c
+++ b/api/cloud/oc_cloud.c
@@ -30,6 +30,13 @@
 #include "security/oc_pstat.h"
 #endif /* OC_SECURITY */
 
+/**
+ * Value of 0 means that the check which removes links after their Time to Live
+ * property expires should be skipped. Thus the Time to Live of such link
+ * is unlimited. This is the default value for the Time to Live property.
+ */
+#define RD_PUBLISH_TTL_UNLIMITED 0
+
 OC_LIST(cloud_context_list);
 OC_MEMB(cloud_context_pool, oc_cloud_context_t, OC_MAX_NUM_DEVICES);
 
@@ -370,6 +377,7 @@ oc_cloud_init(void)
       cloud_store_initialize(&ctx->store);
     }
 #endif
+    ctx->time_to_live = RD_PUBLISH_TTL_UNLIMITED;
 
     oc_list_add(cloud_context_list, ctx);
 

--- a/api/cloud/oc_cloud_apis.c
+++ b/api/cloud/oc_cloud_apis.c
@@ -168,6 +168,12 @@ oc_cloud_get_token_expiry(oc_cloud_context_t *ctx)
   return (int)ctx->expires_in;
 }
 
+void
+oc_cloud_set_published_resources_ttl(oc_cloud_context_t *ctx, uint32_t ttl)
+{
+  ctx->time_to_live = ttl;
+}
+
 static void
 cloud_logout_internal(oc_client_response_t *data)
 {

--- a/api/cloud/oc_cloud_rd.c
+++ b/api/cloud/oc_cloud_rd.c
@@ -156,7 +156,7 @@ publish_resources(oc_cloud_context_t *ctx)
   }
 
   rd_publish(ctx->cloud_ep, ctx->rd_publish_resources, ctx->device,
-             publish_resources_handler, LOW_QOS, ctx);
+             ctx->time_to_live, publish_resources_handler, LOW_QOS, ctx);
 }
 
 int
@@ -308,6 +308,7 @@ oc_cloud_publish_resources(size_t device)
   }
   return -1;
 }
+
 #else  /* OC_CLOUD*/
 typedef int dummy_declaration;
 #endif /* !OC_CLOUD */

--- a/api/cloud/rd_client.c
+++ b/api/cloud/rd_client.c
@@ -26,8 +26,6 @@
 #include <inttypes.h>
 #include <stdlib.h>
 
-#define RD_PUBLISH_TTL 86400
-
 static void
 _add_resource_payload(CborEncoder *parent, oc_resource_t *resource, char *rel,
                       int64_t ins)
@@ -52,7 +50,7 @@ _add_resource_payload(CborEncoder *parent, oc_resource_t *resource, char *rel,
 
 static bool
 rd_publish_with_device_id(oc_endpoint_t *endpoint, oc_link_t *links,
-                          const char *id, const char *name,
+                          const char *id, const char *name, uint32_t ttl,
                           oc_response_handler_t handler, oc_qos_t qos,
                           void *user_data)
 {
@@ -66,7 +64,7 @@ rd_publish_with_device_id(oc_endpoint_t *endpoint, oc_link_t *links,
     oc_rep_start_root_object();
     oc_rep_set_text_string(root, di, id);
     oc_rep_set_text_string(root, n, name);
-    oc_rep_set_int(root, lt, RD_PUBLISH_TTL);
+    oc_rep_set_int(root, lt, ttl);
 
     oc_rep_set_array(root, links);
     oc_link_t *link = links;
@@ -87,7 +85,8 @@ rd_publish_with_device_id(oc_endpoint_t *endpoint, oc_link_t *links,
 
 bool
 rd_publish(oc_endpoint_t *endpoint, oc_link_t *links, size_t device,
-           oc_response_handler_t handler, oc_qos_t qos, void *user_data)
+           uint32_t ttl, oc_response_handler_t handler, oc_qos_t qos,
+           void *user_data)
 {
   char uuid[OC_UUID_LEN] = { 0 };
   oc_device_info_t *device_info = oc_core_get_device_info(device);
@@ -104,14 +103,14 @@ rd_publish(oc_endpoint_t *endpoint, oc_link_t *links, size_t device,
     oc_list_add((oc_list_t)link_p, link_d);
 
     status = rd_publish_with_device_id(endpoint, link_p, uuid,
-                                       oc_string(device_info->name), handler,
-                                       qos, user_data);
+                                       oc_string(device_info->name), ttl,
+                                       handler, qos, user_data);
     oc_delete_link(link_p);
     oc_delete_link(link_d);
   } else {
     status = rd_publish_with_device_id(endpoint, links, uuid,
-                                       oc_string(device_info->name), handler,
-                                       qos, user_data);
+                                       oc_string(device_info->name), ttl,
+                                       handler, qos, user_data);
   }
 
   return status;

--- a/api/cloud/rd_client.c
+++ b/api/cloud/rd_client.c
@@ -64,7 +64,7 @@ rd_publish_with_device_id(oc_endpoint_t *endpoint, oc_link_t *links,
     oc_rep_start_root_object();
     oc_rep_set_text_string(root, di, id);
     oc_rep_set_text_string(root, n, name);
-    oc_rep_set_int(root, lt, ttl);
+    oc_rep_set_int(root, ttl, ttl);
 
     oc_rep_set_array(root, links);
     oc_link_t *link = links;

--- a/api/cloud/rd_client.h
+++ b/api/cloud/rd_client.h
@@ -39,15 +39,18 @@ extern "C" {
   @brief Publish RD resource to Resource Directory.
   @param endpoint The endpoint of the RD.
   @param links This is the resource which we need to register to RD.
-   If null, oic/p and oic/d resources will be published.
+    If null, oic/p and oic/d resources will be published.
   @param device Index of the device for an unique identifier.
+  @param ttl Time in seconds to indicate a RD, i.e. how long to keep this
+    published item.
   @param handler To refer to the request sent out on behalf of calling this API.
   @param qos Quality of service.
   @param user_data The user data passed from the registration function.
   @return Returns true if success.
 */
 bool rd_publish(oc_endpoint_t *endpoint, oc_link_t *links, size_t device,
-                oc_response_handler_t handler, oc_qos_t qos, void *user_data);
+                uint32_t ttl, oc_response_handler_t handler, oc_qos_t qos,
+                void *user_data);
 
 /**
   @brief Delete RD resource from Resource Directory.

--- a/api/cloud/unittest/rd_client_test.cpp
+++ b/api/cloud/unittest/rd_client_test.cpp
@@ -63,7 +63,7 @@ oc_endpoint_t TestRDClient::s_endpoint;
 TEST_F(TestRDClient, rd_publish_p)
 {
   // When
-  bool ret = rd_publish(&s_endpoint, NULL, 0, onPostResponse, LOW_QOS, NULL);
+  bool ret = rd_publish(&s_endpoint, NULL, 0, 0, onPostResponse, LOW_QOS, NULL);
 
   // Then
   EXPECT_TRUE(ret);
@@ -75,7 +75,7 @@ TEST_F(TestRDClient, rd_publish_f)
   oc_endpoint_t *ep = NULL;
 
   // When
-  bool ret = rd_publish(ep, NULL, 0, NULL, LOW_QOS, NULL);
+  bool ret = rd_publish(ep, NULL, 0, 0, NULL, LOW_QOS, NULL);
 
   // Then
   EXPECT_FALSE(ret);

--- a/include/oc_cloud.h
+++ b/include/oc_cloud.h
@@ -99,6 +99,7 @@ typedef struct oc_cloud_context_t
   uint8_t retry_refresh_token_count;
   oc_cloud_error_t last_error;
   uint16_t expires_in;
+  uint32_t time_to_live; /**< Time to live of published resources in seconds */
 
   oc_link_t *rd_publish_resources;
   oc_link_t *rd_published_resources;
@@ -124,6 +125,14 @@ int oc_cloud_refresh_token(oc_cloud_context_t *ctx, oc_cloud_cb_t cb,
                            void *data);
 
 int oc_cloud_get_token_expiry(oc_cloud_context_t *ctx);
+
+/**
+ * @brief Set Time to Live value in the provided cloud context.
+ *
+ * @param ctx Cloud context to update, must not be NULL.
+ * @param ttl Time to live value in seconds.
+ */
+void oc_cloud_set_published_resources_ttl(oc_cloud_context_t *ctx, uint32_t ttl);
 
 int oc_cloud_add_resource(oc_resource_t *resource);
 void oc_cloud_delete_resource(oc_resource_t *resource);


### PR DESCRIPTION
Instead of hardcoded Time to Live value of
86400 seconds (=1 day) for published resources,
add configurable member to oc_cloud_context_t.

By default the ttl value is now set to 0 in
initializer, but can be modified by a setter
to the desired value.