### PR TITLE
api/cloud: don't schedule unnecessary republishing of links

### DIFF
--- a/api/cloud/oc_cloud.c
+++ b/api/cloud/oc_cloud.c
@@ -30,13 +30,6 @@
 #include "security/oc_pstat.h"
 #endif /* OC_SECURITY */
 
-/**
- * Value of 0 means that the check which removes links after their Time to Live
- * property expires should be skipped. Thus the Time to Live of such link
- * is unlimited. This is the default value for the Time to Live property.
- */
-#define RD_PUBLISH_TTL_UNLIMITED 0
-
 OC_LIST(cloud_context_list);
 OC_MEMB(cloud_context_pool, oc_cloud_context_t, OC_MAX_NUM_DEVICES);
 

--- a/api/cloud/oc_cloud_internal.h
+++ b/api/cloud/oc_cloud_internal.h
@@ -31,6 +31,13 @@
 extern "C" {
 #endif
 
+/**
+ * Value of 0 means that the check which removes links after their Time to Live
+ * property expires should be skipped. Thus the Time to Live of such link
+ * is unlimited. This is the default value for the Time to Live property.
+ */
+#define RD_PUBLISH_TTL_UNLIMITED 0
+
 typedef struct cloud_conf_update_t
 {
   char *access_token; /**< Access Token resolved with an auth code. */
@@ -97,6 +104,19 @@ bool cloud_access_refresh_access_token(oc_endpoint_t *endpoint, const char *uid,
                                        oc_response_handler_t handler,
                                        void *user_data);
 
+/**
+ * @brief Update resource links after manager status change.
+ *
+ * If cloud is in logged in state the function executes several resource links
+ * updates: deletes links scheduled to be deleted, publishes links scheduled
+ * to be published and republishes links that were already published.
+ * Additionally, if Time to Live property is not equal to RD_PUBLISH_TTL_UNLIMITED
+ * then published links are scheduled to be republished each hour. (If
+ * cloud_rd_manager_status_changed function is triggered again before the scheduled
+ * time passes the republishing is rescheduled with updated time.)
+ *
+ * @param ctx Cloud context, must not be NULL
+ */
 void cloud_rd_manager_status_changed(oc_cloud_context_t *ctx);
 void cloud_rd_deinit(oc_cloud_context_t *ctx);
 

--- a/api/cloud/oc_cloud_rd.c
+++ b/api/cloud/oc_cloud_rd.c
@@ -258,7 +258,9 @@ cloud_rd_manager_status_changed(oc_cloud_context_t *ctx)
     publish_published_resources(ctx);
     delete_resources(ctx, false);
     oc_remove_delayed_callback(ctx, publish_published_resources);
-    oc_set_delayed_callback(ctx, publish_published_resources, ONE_HOUR);
+    if (ctx->time_to_live != RD_PUBLISH_TTL_UNLIMITED) {
+      oc_set_delayed_callback(ctx, publish_published_resources, ONE_HOUR);
+    }
   } else {
     oc_remove_delayed_callback(ctx, publish_published_resources);
   }

--- a/include/oc_cloud.h
+++ b/include/oc_cloud.h
@@ -101,9 +101,9 @@ typedef struct oc_cloud_context_t
   uint16_t expires_in;
   uint32_t time_to_live; /**< Time to live of published resources in seconds */
 
-  oc_link_t *rd_publish_resources;
-  oc_link_t *rd_published_resources;
-  oc_link_t *rd_delete_resources;
+  oc_link_t *rd_publish_resources;   /**< Resource links to publish */
+  oc_link_t *rd_published_resources; /**< Resource links already published */
+  oc_link_t *rd_delete_resources;    /**< Resource links to delete */
   bool rd_delete_all;
 
   oc_resource_t *cloud_conf;


### PR DESCRIPTION
If resouce links Time to Live is unlimited then republishing
published resource links each hour is not necessary.