### PR TITLE
fix: deduplicate message for blockwise

### DIFF
--- a/messaging/coap/engine.c
+++ b/messaging/coap/engine.c
@@ -403,8 +403,10 @@ coap_receive(oc_message_t *msg)
 
           if (response_buffer && (response_buffer->next_block_offset -
                                   block2_offset) > block2_size) {
-            oc_blockwise_free_response_buffer(response_buffer);
-            response_buffer = NULL;
+            // UDP transfer can duplicate messages and we want to avoid terminate BWT, so we drop the message. 
+            OC_DBG("dropped message because message was already provided for block2");
+            coap_clear_transaction(transaction);
+            return 0;
           }
 
           if (response_buffer) {


### PR DESCRIPTION
UDP packets can be duplicated by a router, switch, docker...
So if you run over 1000 devices at docker and duplication of packet
occurs during the blockwise transfer, then BWT is terminated by sending
a reset message. eg you find 999 devices over discovery.
So to avoid such an issue we drop duplicated messages for BWT.