### PR TITLE
fix: during the wait for closing TLS connection, drop commands

### DIFF
--- a/api/oc_main.h
+++ b/api/oc_main.h
@@ -39,6 +39,9 @@ typedef struct oc_random_pin_t
 
 bool oc_main_initialized(void);
 
+void oc_set_drop_commands(size_t device, bool drop);
+bool oc_drop_command(size_t device);
+
 #ifdef __cplusplus
 }
 #endif

--- a/api/oc_main.h
+++ b/api/oc_main.h
@@ -39,7 +39,26 @@ typedef struct oc_random_pin_t
 
 bool oc_main_initialized(void);
 
+/**
+ * Set acceptance of new commands(GET/PUT/POST/DELETE) for logical device
+ *
+ * The device drops/accepts new commands when the drop is set to true/false.
+ *
+ * @note If OC_SECURITY is set, this call is used to drop all new incoming 
+ *       commands during closing TLS sessions (CLOSE_ALL_TLS_SESSIONS).
+ *
+ * @param[in] device index of the logical device
+ * @param[in] drop set whether all new commands will be accepted/dropped
+ */
 void oc_set_drop_commands(size_t device, bool drop);
+
+/**
+ * Get status of dropping of logical device.
+ *
+ * @param[in] device the index of the logical device
+ *
+ * @return true if the device dropping new commands
+ */
 bool oc_drop_command(size_t device);
 
 #ifdef __cplusplus

--- a/apps/cloud_server.c
+++ b/apps/cloud_server.c
@@ -631,6 +631,11 @@ factory_presets_cb(size_t device, void *data)
   (void)device;
   (void)data;
 #if defined(OC_SECURITY) && defined(OC_PKI)
+  // preserve name after factory reset
+  oc_device_info_t* dev = oc_core_get_device_info(device);
+  oc_free_string(&dev->name);
+  oc_new_string(&dev->name, device_name, strlen(device_name));
+
   unsigned char cloud_ca[4096];
   size_t cert_len = 4096;
   if (read_pem("pki_certs/cloudca.pem", (char *)cloud_ca, &cert_len) < 0) {

--- a/messaging/coap/engine.c
+++ b/messaging/coap/engine.c
@@ -51,6 +51,7 @@
 #include <string.h>
 
 #include "api/oc_events.h"
+#include "api/oc_main.h"
 #include "oc_api.h"
 #include "oc_buffer.h"
 
@@ -167,6 +168,7 @@ close_all_tls_sessions(void *data)
 {
   size_t device = (size_t)data;
   oc_close_all_tls_sessions_for_device(device);
+  oc_set_drop_commands(device, false);
   return OC_EVENT_DONE;
 }
 #endif /* OC_SECURITY */
@@ -348,6 +350,10 @@ coap_receive(oc_message_t *msg)
           }
 
           if (!request_buffer && block1_num == 0) {
+            if (oc_drop_command(msg->endpoint.device) && message->code >= COAP_GET && message->code <= COAP_DELETE) {
+              OC_WRN("cannot process new request during closing TLS sessions");
+              goto init_reset_message;
+            }
             OC_DBG("creating new block-wise request buffer");
             request_buffer = oc_blockwise_alloc_request_buffer(
               href, href_len, &msg->endpoint, message->code,
@@ -451,6 +457,10 @@ coap_receive(oc_message_t *msg)
                   message->uri_query, message->uri_query_len,
                   OC_BLOCKWISE_SERVER);
                 if (!request_buffer) {
+                  if (oc_drop_command(msg->endpoint.device) && message->code >= COAP_GET && message->code <= COAP_DELETE)  {
+                    OC_WRN("cannot process new request during closing TLS sessions");
+                    goto init_reset_message;
+                  }
                   request_buffer = oc_blockwise_alloc_request_buffer(
                     href, href_len, &msg->endpoint, message->code,
                     OC_BLOCKWISE_SERVER);
@@ -477,6 +487,10 @@ coap_receive(oc_message_t *msg)
           goto init_reset_message;
         } else {
           OC_DBG("no block options; processing regular request");
+          if (oc_drop_command(msg->endpoint.device) && message->code >= COAP_GET && message->code <= COAP_DELETE)  {
+            OC_WRN("cannot process new request during closing TLS sessions");
+            goto init_reset_message;
+          }
 #ifdef OC_TCP
           if ((msg->endpoint.flags & TCP &&
                incoming_block_len <= (uint32_t)OC_MAX_APP_DATA_SIZE) ||
@@ -885,6 +899,7 @@ send_message:
 
 #ifdef OC_SECURITY
   if (coap_status_code == CLOSE_ALL_TLS_SESSIONS) {
+    oc_set_drop_commands(msg->endpoint.device, true);
     oc_set_delayed_callback((void *)msg->endpoint.device,
                             &close_all_tls_sessions, 2);
   }


### PR DESCRIPTION
When factory reset occurs, the device waits(2s) for closing TLS
connections. And during these 2s someone starts owning the device
again, he fails because the device closes all connections including
owning connection. For that, we drop all commands which come for
that time.

FYI: @ondrejtomcik, @Danielius1922 