### PR TITLE
improve logging (reducing output)

### DIFF
--- a/port/oc_log.h
+++ b/port/oc_log.h
@@ -15,11 +15,36 @@
 */
 /**
   @file
+  
+  generic logging functions:
+  - OC_LOGipaddr
+    prints the endpoint information to stdout
+  - OC_LOGbytes
+    prints the bytes to stdout
+  - OC_DBG
+    prints information as Debug level
+  - OC_WRN
+    prints information as Warning level
+  - OC_ERR
+    prints information as Error level
+
+  compile flags:
+  - OC_DEBUG
+    enables output of logging functions
+  - OC_NO_LOG_BYTES 
+    disables output of OC_LOGbytes logging function
+    if OC_DEBUG is enabled.
 */
 #ifndef OC_LOG_H
 #define OC_LOG_H
 
 #include <stdio.h>
+#include <string.h>
+#ifdef WIN32
+#define __FILENAME__ (strrchr(__FILE__, '\\') ? strrchr(__FILE__, '\\') + 1 : __FILE__)
+#else
+#define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#endif
 
 #ifdef __ANDROID__
 #include "android/oc_log_android.h"
@@ -171,28 +196,34 @@ extern "C"
 #else  /* ! __ANDROID */
 #define OC_LOG(level, ...)                                                     \
   do {                                                                         \
-    PRINT("%s: %s <%s:%d>: ", level, __FILE__, __func__, __LINE__);            \
+    PRINT("%s: %s <%s:%d>: ", level, __FILENAME__, __func__, __LINE__);            \
     PRINT(__VA_ARGS__);                                                        \
     PRINT("\n");                                                               \
   } while (0)
+
 #define OC_LOGipaddr(endpoint)                                                 \
   do {                                                                         \
-    PRINT("DEBUG: %s <%s:%d>: ", __FILE__, __func__, __LINE__);                \
+    PRINT("DEBUG: %s <%s:%d>: ", __FILENAME__, __func__, __LINE__);                \
     PRINTipaddr(endpoint);                                                     \
     PRINT("\n");                                                               \
   } while (0)
+
+#ifndef OC_NO_LOG_BYTES
 #define OC_LOGbytes(bytes, length)                                             \
   do {                                                                         \
-    PRINT("DEBUG: %s <%s:%d>: ", __FILE__, __func__, __LINE__);                \
+    PRINT("DEBUG: %s <%s:%d>: ", __FILENAME__, __func__, __LINE__);                \
     uint16_t i;                                                                \
     for (i = 0; i < length; i++)                                               \
       PRINT(" %02X", bytes[i]);                                                \
     PRINT("\n");                                                               \
   } while (0)
+#else
+#endif /* NO_LOG_BYTES */
 #endif /* __ANDROID__ */
-#define OC_DBG(...) OC_LOG("DEBUG", __VA_ARGS__)
-#define OC_WRN(...) OC_LOG("WARNING", __VA_ARGS__)
-#define OC_ERR(...) OC_LOG("ERROR", __VA_ARGS__)
+
+#define OC_DBG(...) OC_LOG("D", __VA_ARGS__)
+#define OC_WRN(...) OC_LOG("W", __VA_ARGS__)
+#define OC_ERR(...) OC_LOG("E", __VA_ARGS__)
 #else
 #define OC_LOG(...)
 #define OC_DBG(...)


### PR DESCRIPTION
- reduce length of  
DEBUG ==> D
  WARNING ==> W
  ERROR ==> E
and reduce the __FILE__ to print only the filename without path