### PR TITLE
Add CMake Buildsystem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,5 @@ service/resource-directory/client/unittest/obj
 
 #vscode setting files
 .vscode
+
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,7 @@ endif()
 
 if(OC_DEBUG_ENABLED)
     target_compile_definitions(iotivity-common INTERFACE OC_DEBUG)
+    target_compile_definitions(mbedcrypto PUBLIC OC_DEBUG)
 endif()
 
 if(OC_CLOUD_ENABLED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,10 +70,11 @@ target_sources(iotivity-port INTERFACE
 )
 
 if(WIN32)
-target_sources(iotivity-port INTERFACE
-    ${PORT_DIR}/mutex.c
-    ${PORT_DIR}/network_addresses.c
-)
+    target_sources(iotivity-port INTERFACE
+        ${PORT_DIR}/mutex.c
+        ${PORT_DIR}/network_addresses.c
+    )
+    target_compile_definitions(iotivity-port INTERFACE OC_IPV4)
 endif()
 
 if(UNIX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.13)
+project(iotivity-lite)
+
+# Patch mbedtls
+include(mbedtls-patch.cmake)
+
+# Do not build anything except for the library
+option(ENABLE_PROGRAMS "Build mbed TLS programs." OFF)
+option(ENABLE_TESTING "Build mbed TLS tests." OFF)
+# Configurable dynamic memory use
+set(OC_DYNAMIC_ALLOCATION_ENABLED ON CACHE BOOL "Enable dynamic memory allocation within the OCF stack and MBedtls.")
+
+# If an mbedtls platform layer is defined, add it to the mbedtls list of libs
+if(TARGET mbedtls-plat)
+    set(libs ${libs} mbedtls-plat)
+endif()
+
+add_subdirectory(${PROJECT_SOURCE_DIR}/deps/mbedtls)
+
+target_include_directories(mbedcrypto PUBLIC
+    ${PROJECT_SOURCE_DIR}/port/linux
+    ${PROJECT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/deps/mbedtls/include
+)
+
+#target_compile_definitions(mbedcrypto
+#    PUBLIC
+#    MBEDTLS_CONFIG_FILE=\"combined_mbedtls_config.h\"
+#)
+
+if(TARGET mbedcrypto-plat)
+	target_link_libraries(mbedcrypto PUBLIC mbedcrypto-plat)
+endif()
+
+if(OC_DYNAMIC_ALLOCATION_ENABLED)
+    target_compile_definitions(mbedcrypto PUBLIC OC_DYNAMIC_ALLOCATION)
+endif()
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,6 +236,15 @@ target_link_libraries(iotivity-server-client PRIVATE
 )
 target_link_libraries(iotivity-server-client PUBLIC iotivity-common)
 
+
+if(PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    # Add clang-format target
+    add_custom_target(format
+        COMMAND ${CMAKE_COMMAND} -P ${PROJECT_SOURCE_DIR}/tools/clang-format.cmake
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    )
+endif()
+
 add_subdirectory(apps)
 add_subdirectory(onboarding_tool)
 add_subdirectory(deps)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,12 @@ include(mbedtls-patch.cmake)
 # Do not build anything except for the library
 option(ENABLE_PROGRAMS "Build mbed TLS programs." OFF)
 option(ENABLE_TESTING "Build mbed TLS tests." OFF)
-# Configurable dynamic memory use
+
 set(OC_DYNAMIC_ALLOCATION_ENABLED ON CACHE BOOL "Enable dynamic memory allocation within the OCF stack and MBedtls.")
+set(OC_SECURITY_ENABLED ON CACHE BOOL "Enable security")
+set(OC_PKI_ENABLED ON CACHE BOOL "Enable PKI security")
+set(OC_CLOUD_ENABLED OFF CACHE BOOL "Enable cloud communications")
+set(OC_DEBUG_ENABLED OFF CACHE BOOL "Enable debug messages")
 
 # If an mbedtls platform layer is defined, add it to the mbedtls list of libs
 if(TARGET mbedtls-plat)
@@ -26,10 +30,6 @@ target_include_directories(mbedcrypto PUBLIC
 
 if(TARGET mbedcrypto-plat)
 	target_link_libraries(mbedcrypto PUBLIC mbedcrypto-plat)
-endif()
-
-if(OC_DYNAMIC_ALLOCATION_ENABLED)
-    target_compile_definitions(mbedcrypto PUBLIC OC_DYNAMIC_ALLOCATION)
 endif()
 
 
@@ -151,41 +151,53 @@ target_include_directories(iotivity-coap INTERFACE
 
 target_link_libraries(iotivity-coap INTERFACE iotivity-port)
 
-# Client and server versions of Iotivity
-add_library(iotivity-client INTERFACE)
+if(OC_DYNAMIC_ALLOCATION_ENABLED)
+    target_compile_definitions(mbedcrypto PUBLIC OC_DYNAMIC_ALLOCATION)
+endif()
 
-target_link_libraries(iotivity-client INTERFACE
-    iotivity-coap
-    iotivity-common
-    iotivity-api
-)
+if(OC_SECURITY_ENABLED)
+    target_compile_definitions(mbedcrypto PUBLIC OC_SECURITY)
+endif()
 
-target_compile_definitions(iotivity-client INTERFACE OC_CLIENT)
-
-add_library(iotivity-server INTERFACE)
-
-target_link_libraries(iotivity-server INTERFACE
-    iotivity-coap
-    iotivity-common
-    iotivity-api
-)
-
-target_compile_definitions(iotivity-server INTERFACE OC_SERVER)
-
-# Configurable debugging
-set(OC_DEBUG_ENABLED OFF CACHE BOOL "Enable debug messages from the Iotivity stack.")
+if(OC_PKI_ENABLED)
+    target_compile_definitions(mbedcrypto PUBLIC OC_PKI)
+endif()
 
 if(OC_DEBUG_ENABLED)
-    target_compile_definitions(iotivity-server INTERFACE OC_DEBUG)
-    target_compile_definitions(iotivity-client INTERFACE OC_DEBUG)
     target_compile_definitions(iotivity-common INTERFACE OC_DEBUG)
 endif()
 
-# TODO remove cascoda from this var
-if(CASCODA_BUILD_OCF_PKI)
-    target_compile_definitions(mbedcrypto PUBLIC OC_PKI)
+if(OC_CLOUD_ENABLED)
+    target_compile_definitions(iotivity-common INTERFACE OC_CLOUD)
 endif()
 
 add_library(iotivity-secure-server)
 target_link_libraries(iotivity-secure-server PRIVATE iotivity-server)
 target_compile_definitions(iotivity-secure-server PUBLIC OC_SERVER OC_SECURITY)
+
+# Client and server versions of Iotivity
+add_library(iotivity-client)
+target_compile_definitions(iotivity-client PUBLIC OC_CLIENT)
+target_link_libraries(iotivity-client
+    iotivity-coap
+    iotivity-common
+    iotivity-api
+)
+
+add_library(iotivity-server)
+target_compile_definitions(iotivity-server PUBLIC OC_SERVER)
+target_link_libraries(iotivity-server
+    iotivity-coap
+    iotivity-common
+    iotivity-api
+)
+
+add_library(iotivity-server-client)
+target_compile_definitions(iotivity-server-client PUBLIC OC_SERVER OC_CLIENT)
+target_link_libraries(iotivity-server-client
+    iotivity-coap
+    iotivity-common
+    iotivity-api
+)
+
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,8 @@ endif()
 
 add_library(iotivity-port INTERFACE)
 
+target_include_directories(iotivity-port INTERFACE BEFORE ${PORT_DIR})
+
 target_sources(iotivity-port INTERFACE
     ${PORT_DIR}/abort.c
     ${PORT_DIR}/clock.c
@@ -70,10 +72,6 @@ target_sources(iotivity-port INTERFACE
     ${PORT_DIR}/network_addresses.c
 )
 endif()
-
-target_include_directories(iotivity-port INTERFACE
-    ${PORT_DIR}
-)
 
 if(UNIX)
     target_link_libraries(iotivity-port INTERFACE pthread m)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,36 +53,6 @@ if(MSVC)
     target_compile_options(mbedx509 PRIVATE /W1 /WX-)
 endif()
 
-add_library(iotivity-port INTERFACE)
-
-target_include_directories(iotivity-port INTERFACE 
-    ${PORT_DIR}
-    ${PROJECT_SOURCE_DIR}/port
-)
-
-target_sources(iotivity-port INTERFACE
-    ${PORT_DIR}/abort.c
-    ${PORT_DIR}/clock.c
-    ${PORT_DIR}/ipadapter.c
-    ${PORT_DIR}/random.c
-    ${PORT_DIR}/storage.c
-    ${PORT_DIR}/tcpadapter.c
-)
-
-if(WIN32)
-    target_sources(iotivity-port INTERFACE
-        ${PORT_DIR}/mutex.c
-        ${PORT_DIR}/network_addresses.c
-    )
-    target_compile_definitions(iotivity-port INTERFACE OC_IPV4)
-endif()
-
-if(UNIX)
-    target_link_libraries(iotivity-port INTERFACE pthread m)
-elseif(WIN32)
-    target_link_libraries(iotivity-port INTERFACE bcrypt iphlpapi)
-endif()
-
 # Iotivity API
 add_library(iotivity-api INTERFACE)
 
@@ -245,6 +215,7 @@ if(PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     )
 endif()
 
+add_subdirectory(port)
 add_subdirectory(apps)
 add_subdirectory(onboarding_tool)
 add_subdirectory(deps)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,8 @@ endif()
 
 if(UNIX)
     target_link_libraries(iotivity-port INTERFACE pthread m)
+elseif(WIN32)
+    target_link_libraries(iotivity-port INTERFACE bcrypt iphlpapi)
 endif()
 
 # Iotivity API

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ set(OC_SECURITY_ENABLED ON CACHE BOOL "Enable security")
 set(OC_PKI_ENABLED ON CACHE BOOL "Enable PKI security")
 set(OC_CLOUD_ENABLED OFF CACHE BOOL "Enable cloud communications")
 set(OC_DEBUG_ENABLED OFF CACHE BOOL "Enable debug messages")
+set(OC_IDD_API_ENABLED ON CACHE BOOL "Enable the Introspection Device Data API")
 
 # If an mbedtls platform layer is defined, add it to the mbedtls list of libs
 if(TARGET mbedtls-plat)
@@ -172,6 +173,10 @@ if(OC_CLOUD_ENABLED)
     target_compile_definitions(iotivity-common INTERFACE OC_CLOUD)
 endif()
 
+if(OC_IDD_API_ENABLED)
+    target_compile_definitions(iotivity-common INTERFACE OC_IDD_API)
+endif()
+
 # Client and server versions of Iotivity
 add_library(iotivity-client)
 target_compile_definitions(iotivity-client PUBLIC OC_CLIENT)
@@ -180,6 +185,7 @@ target_link_libraries(iotivity-client PRIVATE
     iotivity-api
 )
 target_link_libraries(iotivity-client PUBLIC iotivity-common)
+target_include_directories(iotivity-client PUBLIC ${PROJECT_SOURCE_DIR}/include)
 
 add_library(iotivity-server)
 target_compile_definitions(iotivity-server PUBLIC OC_SERVER)
@@ -188,6 +194,7 @@ target_link_libraries(iotivity-server PRIVATE
     iotivity-api
 )
 target_link_libraries(iotivity-server PUBLIC iotivity-common)
+target_include_directories(iotivity-server PUBLIC ${PROJECT_SOURCE_DIR}/include)
 
 add_library(iotivity-server-client)
 target_compile_definitions(iotivity-server-client PUBLIC OC_SERVER OC_CLIENT)
@@ -196,6 +203,7 @@ target_link_libraries(iotivity-server-client PRIVATE
     iotivity-api
 )
 target_link_libraries(iotivity-server-client PUBLIC iotivity-common)
+target_include_directories(iotivity-server-client PUBLIC ${PROJECT_SOURCE_DIR}/include)
 
 add_subdirectory(apps)
 add_subdirectory(onboarding_tool)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,6 @@
 cmake_minimum_required(VERSION 3.13)
 project(iotivity-lite)
 
-# Detect the platform and pick the right port
-if(UNIX)
-    set(PORT_DIR ${PROJECT_SOURCE_DIR}/port/linux)
-elseif(WIN32)
-    set(PORT_DIR ${PROJECT_SOURCE_DIR}/port/windows)
-endif()
-
 # Patch mbedtls
 set(OC_REAPPLY_MBEDTLS_PATCHES ON CACHE BOOL "")
 if(OC_REAPPLY_MBEDTLS_PATCHES)
@@ -37,11 +30,12 @@ endif()
 add_subdirectory(${PROJECT_SOURCE_DIR}/deps/mbedtls)
 
 target_include_directories(mbedcrypto PUBLIC
-    ${PORT_DIR}
     ${PROJECT_SOURCE_DIR}
     ${PROJECT_SOURCE_DIR}/include
     ${PROJECT_SOURCE_DIR}/deps/mbedtls/include
 )
+
+target_link_libraries(mbedcrypto PRIVATE iotivity-port)
 
 if(TARGET mbedcrypto-plat)
 	target_link_libraries(mbedcrypto PUBLIC mbedcrypto-plat)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,19 @@
 cmake_minimum_required(VERSION 3.13)
 project(iotivity-lite)
 
+# Detect the platform and pick the right port
+if(UNIX)
+    set(PORT_DIR ${PROJECT_SOURCE_DIR}/port/linux)
+elseif(WIN32)
+    set(PORT_DIR ${PROJECT_SOURCE_DIR}/port/windows)
+endif()
+
 # Patch mbedtls
 set(OC_REAPPLY_MBEDTLS_PATCHES ON CACHE BOOL "")
 if(OC_REAPPLY_MBEDTLS_PATCHES)
     include(mbedtls-patch.cmake)
     set(OC_REAPPLY_MBEDTLS_PATCHES OFF CACHE BOOL 
-        "By default, mbedTLS patches are applied upon the first CMake Configure."
-        "Set this to ON to reapply the patches on the next configure" 
+        "By default, mbedTLS patches are applied upon the first CMake Configure. Set this to ON to reapply the patches on the next configure."
          FORCE
     )
 endif()
@@ -31,7 +37,7 @@ endif()
 add_subdirectory(${PROJECT_SOURCE_DIR}/deps/mbedtls)
 
 target_include_directories(mbedcrypto PUBLIC
-    ${PROJECT_SOURCE_DIR}/port/linux
+    ${PORT_DIR}
     ${PROJECT_SOURCE_DIR}
     ${PROJECT_SOURCE_DIR}/include
     ${PROJECT_SOURCE_DIR}/deps/mbedtls/include
@@ -45,16 +51,16 @@ endif()
 add_library(iotivity-port INTERFACE)
 
 target_sources(iotivity-port INTERFACE
-    ${PROJECT_SOURCE_DIR}/port/linux/abort.c
-    ${PROJECT_SOURCE_DIR}/port/linux/clock.c
-    ${PROJECT_SOURCE_DIR}/port/linux/ipadapter.c
-    ${PROJECT_SOURCE_DIR}/port/linux/random.c
-    ${PROJECT_SOURCE_DIR}/port/linux/storage.c
-    ${PROJECT_SOURCE_DIR}/port/linux/tcpadapter.c
+    ${PORT_DIR}/abort.c
+    ${PORT_DIR}/clock.c
+    ${PORT_DIR}/ipadapter.c
+    ${PORT_DIR}/random.c
+    ${PORT_DIR}/storage.c
+    ${PORT_DIR}/tcpadapter.c
 )
 
 target_include_directories(iotivity-port INTERFACE
-    ${PROJECT_SOURCE_DIR}/port/linux
+    ${PORT_DIR}
 )
 
 # Iotivity API

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,7 +185,6 @@ target_link_libraries(iotivity-client PRIVATE
     iotivity-api
 )
 target_link_libraries(iotivity-client PUBLIC iotivity-common)
-target_include_directories(iotivity-client PUBLIC ${PROJECT_SOURCE_DIR}/include)
 
 add_library(iotivity-server)
 target_compile_definitions(iotivity-server PUBLIC OC_SERVER)
@@ -194,7 +193,6 @@ target_link_libraries(iotivity-server PRIVATE
     iotivity-api
 )
 target_link_libraries(iotivity-server PUBLIC iotivity-common)
-target_include_directories(iotivity-server PUBLIC ${PROJECT_SOURCE_DIR}/include)
 
 add_library(iotivity-server-client)
 target_compile_definitions(iotivity-server-client PUBLIC OC_SERVER OC_CLIENT)
@@ -203,7 +201,6 @@ target_link_libraries(iotivity-server-client PRIVATE
     iotivity-api
 )
 target_link_libraries(iotivity-server-client PUBLIC iotivity-common)
-target_include_directories(iotivity-server-client PUBLIC ${PROJECT_SOURCE_DIR}/include)
 
 add_subdirectory(apps)
 add_subdirectory(onboarding_tool)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,11 @@ if(TARGET mbedcrypto-plat)
 	target_link_libraries(mbedcrypto PUBLIC mbedcrypto-plat)
 endif()
 
+# do not treat warnings as errors on Windows
+if(MSVC)
+    target_compile_options(mbedtls PRIVATE /W1 /WX-)
+    target_compile_options(mbedx509 PRIVATE /W1 /WX-)
+endif()
 
 add_library(iotivity-port INTERFACE)
 
@@ -62,6 +67,10 @@ target_sources(iotivity-port INTERFACE
 target_include_directories(iotivity-port INTERFACE
     ${PORT_DIR}
 )
+
+if(UNIX)
+    target_link_libraries(iotivity-port INTERFACE pthread m)
+endif()
 
 # Iotivity API
 add_library(iotivity-api INTERFACE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.13)
 project(iotivity-lite)
 
 # Patch mbedtls
+# This is suboptimal - mbedtls is cleaned and patched with every configure
 include(mbedtls-patch.cmake)
 
 # Do not build anything except for the library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,10 @@ endif()
 
 add_library(iotivity-port INTERFACE)
 
-target_include_directories(iotivity-port INTERFACE BEFORE ${PORT_DIR})
+target_include_directories(iotivity-port INTERFACE 
+    ${PORT_DIR}
+    ${PROJECT_SOURCE_DIR}/port
+)
 
 target_sources(iotivity-port INTERFACE
     ${PORT_DIR}/abort.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,13 @@ target_sources(iotivity-port INTERFACE
     ${PORT_DIR}/tcpadapter.c
 )
 
+if(WIN32)
+target_sources(iotivity-port INTERFACE
+    ${PORT_DIR}/mutex.c
+    ${PORT_DIR}/network_addresses.c
+)
+endif()
+
 target_include_directories(iotivity-port INTERFACE
     ${PORT_DIR}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,33 +171,31 @@ if(OC_CLOUD_ENABLED)
     target_compile_definitions(iotivity-common INTERFACE OC_CLOUD)
 endif()
 
-add_library(iotivity-secure-server)
-target_link_libraries(iotivity-secure-server PRIVATE iotivity-server)
-target_compile_definitions(iotivity-secure-server PUBLIC OC_SERVER OC_SECURITY)
-
 # Client and server versions of Iotivity
 add_library(iotivity-client)
 target_compile_definitions(iotivity-client PUBLIC OC_CLIENT)
-target_link_libraries(iotivity-client
+target_link_libraries(iotivity-client PRIVATE
     iotivity-coap
-    iotivity-common
     iotivity-api
 )
+target_link_libraries(iotivity-client PUBLIC iotivity-common)
 
 add_library(iotivity-server)
 target_compile_definitions(iotivity-server PUBLIC OC_SERVER)
-target_link_libraries(iotivity-server
+target_link_libraries(iotivity-server PRIVATE
     iotivity-coap
-    iotivity-common
     iotivity-api
 )
+target_link_libraries(iotivity-server PUBLIC iotivity-common)
 
 add_library(iotivity-server-client)
 target_compile_definitions(iotivity-server-client PUBLIC OC_SERVER OC_CLIENT)
-target_link_libraries(iotivity-server-client
+target_link_libraries(iotivity-server-client PRIVATE
     iotivity-coap
-    iotivity-common
     iotivity-api
 )
+target_link_libraries(iotivity-server-client PUBLIC iotivity-common)
 
-
+add_subdirectory(apps)
+add_subdirectory(onboarding_tool)
+add_subdirectory(deps)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,15 @@ cmake_minimum_required(VERSION 3.13)
 project(iotivity-lite)
 
 # Patch mbedtls
-# This is suboptimal - mbedtls is cleaned and patched with every configure
-include(mbedtls-patch.cmake)
+set(OC_REAPPLY_MBEDTLS_PATCHES ON CACHE BOOL "")
+if(OC_REAPPLY_MBEDTLS_PATCHES)
+    include(mbedtls-patch.cmake)
+    set(OC_REAPPLY_MBEDTLS_PATCHES OFF CACHE BOOL 
+        "By default, mbedTLS patches are applied upon the first CMake Configure."
+        "Set this to ON to reapply the patches on the next configure" 
+         FORCE
+    )
+endif()
 
 # Do not build anything except for the library
 option(ENABLE_PROGRAMS "Build mbed TLS programs." OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,11 +24,6 @@ target_include_directories(mbedcrypto PUBLIC
     ${PROJECT_SOURCE_DIR}/deps/mbedtls/include
 )
 
-#target_compile_definitions(mbedcrypto
-#    PUBLIC
-#    MBEDTLS_CONFIG_FILE=\"combined_mbedtls_config.h\"
-#)
-
 if(TARGET mbedcrypto-plat)
 	target_link_libraries(mbedcrypto PUBLIC mbedcrypto-plat)
 endif()
@@ -37,3 +32,160 @@ if(OC_DYNAMIC_ALLOCATION_ENABLED)
     target_compile_definitions(mbedcrypto PUBLIC OC_DYNAMIC_ALLOCATION)
 endif()
 
+
+add_library(iotivity-port INTERFACE)
+
+target_sources(iotivity-port INTERFACE
+    ${PROJECT_SOURCE_DIR}/port/linux/abort.c
+    ${PROJECT_SOURCE_DIR}/port/linux/clock.c
+    ${PROJECT_SOURCE_DIR}/port/linux/ipadapter.c
+    ${PROJECT_SOURCE_DIR}/port/linux/random.c
+    ${PROJECT_SOURCE_DIR}/port/linux/storage.c
+    ${PROJECT_SOURCE_DIR}/port/linux/tcpadapter.c
+)
+
+target_include_directories(iotivity-port INTERFACE
+    ${PROJECT_SOURCE_DIR}/port/linux
+)
+
+# Iotivity API
+add_library(iotivity-api INTERFACE)
+
+target_sources(iotivity-api INTERFACE
+    ${PROJECT_SOURCE_DIR}/api/oc_base64.c
+    ${PROJECT_SOURCE_DIR}/api/oc_blockwise.c
+    ${PROJECT_SOURCE_DIR}/api/oc_buffer.c
+    ${PROJECT_SOURCE_DIR}/api/oc_client_api.c
+    ${PROJECT_SOURCE_DIR}/api/oc_clock.c
+    ${PROJECT_SOURCE_DIR}/api/oc_collection.c
+    ${PROJECT_SOURCE_DIR}/api/oc_core_res.c
+    ${PROJECT_SOURCE_DIR}/api/oc_discovery.c
+    ${PROJECT_SOURCE_DIR}/api/oc_endpoint.c
+    ${PROJECT_SOURCE_DIR}/api/oc_enums.c
+    ${PROJECT_SOURCE_DIR}/api/oc_helpers.c
+    ${PROJECT_SOURCE_DIR}/api/oc_main.c
+    ${PROJECT_SOURCE_DIR}/api/oc_mnt.c
+    ${PROJECT_SOURCE_DIR}/api/oc_network_events.c
+    ${PROJECT_SOURCE_DIR}/api/oc_rep.c
+    ${PROJECT_SOURCE_DIR}/api/oc_resource_factory.c
+    ${PROJECT_SOURCE_DIR}/api/oc_ri.c
+    ${PROJECT_SOURCE_DIR}/api/oc_server_api.c
+    ${PROJECT_SOURCE_DIR}/api/oc_session_events.c
+    ${PROJECT_SOURCE_DIR}/api/oc_swupdate.c
+    ${PROJECT_SOURCE_DIR}/api/oc_uuid.c
+    ${PROJECT_SOURCE_DIR}/api/c-timestamp/timestamp_compare.c
+    ${PROJECT_SOURCE_DIR}/api/c-timestamp/timestamp_format.c
+    ${PROJECT_SOURCE_DIR}/api/c-timestamp/timestamp_parse.c
+    ${PROJECT_SOURCE_DIR}/api/c-timestamp/timestamp_tm.c
+    ${PROJECT_SOURCE_DIR}/api/c-timestamp/timestamp_valid.c
+)
+
+target_include_directories(iotivity-api INTERFACE
+    ${PROJECT_SOURCE_DIR}/
+    ${PROJECT_SOURCE_DIR}/api
+    ${PROJECT_SOURCE_DIR}/api/c-timestamp
+    ${PROJECT_SOURCE_DIR}/include
+)
+
+# Core functions used by Iotivity
+add_library(iotivity-common INTERFACE)
+
+target_sources(iotivity-common INTERFACE
+    # Utilities that are used deep within Iotivity
+    ${PROJECT_SOURCE_DIR}/util/oc_etimer.c
+    ${PROJECT_SOURCE_DIR}/util/oc_list.c
+    ${PROJECT_SOURCE_DIR}/util/oc_memb.c
+    ${PROJECT_SOURCE_DIR}/util/oc_mem_trace.c
+    ${PROJECT_SOURCE_DIR}/util/oc_mmem.c
+    ${PROJECT_SOURCE_DIR}/util/oc_process.c
+    ${PROJECT_SOURCE_DIR}/util/oc_timer.c
+    # Security
+    ${PROJECT_SOURCE_DIR}/security/oc_acl.c
+    ${PROJECT_SOURCE_DIR}/security/oc_ael.c
+    ${PROJECT_SOURCE_DIR}/security/oc_audit.c
+    ${PROJECT_SOURCE_DIR}/security/oc_certs.c
+    ${PROJECT_SOURCE_DIR}/security/oc_cred.c
+    ${PROJECT_SOURCE_DIR}/security/oc_csr.c
+    ${PROJECT_SOURCE_DIR}/security/oc_doxm.c
+    ${PROJECT_SOURCE_DIR}/security/oc_keypair.c
+    ${PROJECT_SOURCE_DIR}/security/oc_obt.c
+    ${PROJECT_SOURCE_DIR}/security/oc_obt_certs.c
+    ${PROJECT_SOURCE_DIR}/security/oc_obt_otm_cert.c
+    ${PROJECT_SOURCE_DIR}/security/oc_obt_otm_justworks.c
+    ${PROJECT_SOURCE_DIR}/security/oc_obt_otm_randompin.c
+    ${PROJECT_SOURCE_DIR}/security/oc_pki.c
+    ${PROJECT_SOURCE_DIR}/security/oc_pstat.c
+    ${PROJECT_SOURCE_DIR}/security/oc_roles.c
+    ${PROJECT_SOURCE_DIR}/security/oc_sdi.c
+    ${PROJECT_SOURCE_DIR}/security/oc_sp.c
+    ${PROJECT_SOURCE_DIR}/security/oc_store.c
+    ${PROJECT_SOURCE_DIR}/security/oc_svr.c
+    ${PROJECT_SOURCE_DIR}/security/oc_tls.c
+
+)
+
+target_include_directories(iotivity-common INTERFACE
+    ${PROJECT_SOURCE_DIR}/
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/deps/tinycbor/src
+    ${PROJECT_SOURCE_DIR}/security
+)
+
+target_link_libraries(iotivity-common INTERFACE iotivity-port mbedtls tinycbor-master)
+
+# Iotivity's implementation of CoAP
+add_library(iotivity-coap INTERFACE)
+
+target_sources(iotivity-coap INTERFACE
+    ${PROJECT_SOURCE_DIR}/messaging/coap/coap.c
+    ${PROJECT_SOURCE_DIR}/messaging/coap/coap_signal.c
+    ${PROJECT_SOURCE_DIR}/messaging/coap/engine.c
+    ${PROJECT_SOURCE_DIR}/messaging/coap/observe.c
+    ${PROJECT_SOURCE_DIR}/messaging/coap/separate.c
+    ${PROJECT_SOURCE_DIR}/messaging/coap/transactions.c
+)
+
+target_include_directories(iotivity-coap INTERFACE
+    ${PROJECT_SOURCE_DIR}/messaging/coap/
+)
+
+target_link_libraries(iotivity-coap INTERFACE iotivity-port)
+
+# Client and server versions of Iotivity
+add_library(iotivity-client INTERFACE)
+
+target_link_libraries(iotivity-client INTERFACE
+    iotivity-coap
+    iotivity-common
+    iotivity-api
+)
+
+target_compile_definitions(iotivity-client INTERFACE OC_CLIENT)
+
+add_library(iotivity-server INTERFACE)
+
+target_link_libraries(iotivity-server INTERFACE
+    iotivity-coap
+    iotivity-common
+    iotivity-api
+)
+
+target_compile_definitions(iotivity-server INTERFACE OC_SERVER)
+
+# Configurable debugging
+set(OC_DEBUG_ENABLED OFF CACHE BOOL "Enable debug messages from the Iotivity stack.")
+
+if(OC_DEBUG_ENABLED)
+    target_compile_definitions(iotivity-server INTERFACE OC_DEBUG)
+    target_compile_definitions(iotivity-client INTERFACE OC_DEBUG)
+    target_compile_definitions(iotivity-common INTERFACE OC_DEBUG)
+endif()
+
+# TODO remove cascoda from this var
+if(CASCODA_BUILD_OCF_PKI)
+    target_compile_definitions(mbedcrypto PUBLIC OC_PKI)
+endif()
+
+add_library(iotivity-secure-server)
+target_link_libraries(iotivity-secure-server PRIVATE iotivity-server)
+target_compile_definitions(iotivity-secure-server PUBLIC OC_SERVER OC_SECURITY)

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -33,4 +33,5 @@ target_link_libraries(simpleclient
 )
 file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/simpleclient_creds)
 
+# include file used to compile the Device Builder application
 include(device-builder.cmake OPTIONAL)

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -24,7 +24,7 @@ if(UNIX)
         ${iotivity-lite_SOURCE_DIR}/api/oc_introspection.c
     )
     target_link_libraries(simpleclient
-        iotivity-client
+        iotivity-server-client
     )
     file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/simpleclient_creds)
 

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -9,6 +9,7 @@ target_link_libraries(simpleserver
     pthread
     m
 )
+file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/simpleserver_creds)
 
 add_executable(simpleserver_pki
     ${PROJECT_SOURCE_DIR}/simpleserver_pki.c
@@ -19,6 +20,7 @@ target_link_libraries(simpleserver_pki
     pthread
     m
 )
+file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/simpleserver_pki_creds)
 
 add_executable(simpleclient
     ${PROJECT_SOURCE_DIR}/simpleclient.c
@@ -29,3 +31,4 @@ target_link_libraries(simpleclient
     pthread
     m
 )
+file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/simpleclient_creds)

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -53,7 +53,7 @@ elseif(WIN32)
         ${iotivity-lite_SOURCE_DIR}/api/oc_introspection.c
     )
     target_link_libraries(simpleclient
-        iotivity-client
+        iotivity-server-client
     )
     file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/simpleclient_creds)
 endif()

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -43,5 +43,5 @@ if(EXISTS ${PROJECT_SOURCE_DIR}/device_builder_server.c)
         pthread
         m
     )
-    file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/device_builder_server)
+    file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/device_builder_server_creds)
 endif()

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -1,7 +1,7 @@
 project(iotivity-lite-apps)
 
 add_executable(simpleserver
-    ${PROJECT_SOURCE_DIR}/simpleserver
+    ${PROJECT_SOURCE_DIR}/simpleserver.c
     ${iotivity-lite_SOURCE_DIR}/api/oc_introspection.c
 )
 target_link_libraries(simpleserver
@@ -11,10 +11,10 @@ target_link_libraries(simpleserver
 )
 
 add_executable(simpleserver_pki
-    ${PROJECT_SOURCE_DIR}/simpleserver.c
+    ${PROJECT_SOURCE_DIR}/simpleserver_pki.c
     ${iotivity-lite_SOURCE_DIR}/api/oc_introspection.c
 )
-target_link_libraries(simpleserver
+target_link_libraries(simpleserver_pki
     iotivity-server-client
     pthread
     m

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -1,41 +1,61 @@
 project(iotivity-lite-apps)
 
-add_executable(simpleserver
-    ${PROJECT_SOURCE_DIR}/simpleserver.c
-    ${iotivity-lite_SOURCE_DIR}/api/oc_introspection.c
-)
-target_link_libraries(simpleserver
-    iotivity-server-client
-)
-file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/simpleserver_creds)
-
-add_executable(simpleserver_pki
-    ${PROJECT_SOURCE_DIR}/simpleserver_pki.c
-    ${iotivity-lite_SOURCE_DIR}/api/oc_introspection.c
-)
-target_link_libraries(simpleserver_pki
-    iotivity-server-client
-)
-file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/simpleserver_pki_creds)
-
-add_executable(simpleclient
-    ${PROJECT_SOURCE_DIR}/simpleclient.c
-    ${iotivity-lite_SOURCE_DIR}/api/oc_introspection.c
-)
-target_link_libraries(simpleclient
-    iotivity-client
-)
-file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/simpleclient_creds)
-
-if(EXISTS ${PROJECT_SOURCE_DIR}/device_builder_server.c)
-    add_executable(device_builder_server
-        ${PROJECT_SOURCE_DIR}/device_builder_server.c
+if(UNIX)
+    add_executable(simpleserver
+        ${PROJECT_SOURCE_DIR}/simpleserver.c
         ${iotivity-lite_SOURCE_DIR}/api/oc_introspection.c
     )
-    target_link_libraries(device_builder_server
+    target_link_libraries(simpleserver
         iotivity-server-client
     )
-    file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/device_builder_server_creds)
+    file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/simpleserver_creds)
+
+    add_executable(simpleserver_pki
+        ${PROJECT_SOURCE_DIR}/simpleserver_pki.c
+        ${iotivity-lite_SOURCE_DIR}/api/oc_introspection.c
+    )
+    target_link_libraries(simpleserver_pki
+        iotivity-server-client
+    )
+    file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/simpleserver_pki_creds)
+
+    add_executable(simpleclient
+        ${PROJECT_SOURCE_DIR}/simpleclient.c
+        ${iotivity-lite_SOURCE_DIR}/api/oc_introspection.c
+    )
+    target_link_libraries(simpleclient
+        iotivity-client
+    )
+    file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/simpleclient_creds)
+
+    if(EXISTS ${PROJECT_SOURCE_DIR}/device_builder_server.c)
+        add_executable(device_builder_server
+            ${PROJECT_SOURCE_DIR}/device_builder_server.c
+            ${iotivity-lite_SOURCE_DIR}/api/oc_introspection.c
+        )
+        target_link_libraries(device_builder_server
+            iotivity-server-client
+        )
+        file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/device_builder_server_creds)
+    endif()
+elseif(WIN32)
+    add_executable(simpleserver
+        ${PROJECT_SOURCE_DIR}/simpleserver_windows.c
+        ${iotivity-lite_SOURCE_DIR}/api/oc_introspection.c
+    )
+    target_link_libraries(simpleserver
+        iotivity-server-client
+    )
+    file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/simpleserver_creds)
+
+    add_executable(simpleclient
+        ${PROJECT_SOURCE_DIR}/simpleclient_windows.c
+        ${iotivity-lite_SOURCE_DIR}/api/oc_introspection.c
+    )
+    target_link_libraries(simpleclient
+        iotivity-client
+    )
+    file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/simpleclient_creds)
 endif()
 
 # copy credentials, used by example applications.

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -6,8 +6,6 @@ add_executable(simpleserver
 )
 target_link_libraries(simpleserver
     iotivity-server-client
-    pthread
-    m
 )
 file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/simpleserver_creds)
 
@@ -17,8 +15,6 @@ add_executable(simpleserver_pki
 )
 target_link_libraries(simpleserver_pki
     iotivity-server-client
-    pthread
-    m
 )
 file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/simpleserver_pki_creds)
 
@@ -28,8 +24,6 @@ add_executable(simpleclient
 )
 target_link_libraries(simpleclient
     iotivity-client
-    pthread
-    m
 )
 file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/simpleclient_creds)
 
@@ -40,8 +34,6 @@ if(EXISTS ${PROJECT_SOURCE_DIR}/device_builder_server.c)
     )
     target_link_libraries(device_builder_server
         iotivity-server-client
-        pthread
-        m
     )
     file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/device_builder_server_creds)
 endif()

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -1,3 +1,31 @@
-project(apps)
+project(iotivity-lite-apps)
 
+add_executable(simpleserver
+    ${PROJECT_SOURCE_DIR}/simpleserver
+    ${iotivity-lite_SOURCE_DIR}/api/oc_introspection.c
+)
+target_link_libraries(simpleserver
+    iotivity-server-client
+    pthread
+    m
+)
 
+add_executable(simpleserver_pki
+    ${PROJECT_SOURCE_DIR}/simpleserver.c
+    ${iotivity-lite_SOURCE_DIR}/api/oc_introspection.c
+)
+target_link_libraries(simpleserver
+    iotivity-server-client
+    pthread
+    m
+)
+
+add_executable(simpleclient
+    ${PROJECT_SOURCE_DIR}/simpleclient.c
+    ${iotivity-lite_SOURCE_DIR}/api/oc_introspection.c
+)
+target_link_libraries(simpleclient
+    iotivity-client
+    pthread
+    m
+)

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -32,3 +32,5 @@ target_link_libraries(simpleclient
     m
 )
 file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/simpleclient_creds)
+
+include(device-builder.cmake OPTIONAL)

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -1,0 +1,3 @@
+project(apps)
+
+

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -45,3 +45,10 @@ if(EXISTS ${PROJECT_SOURCE_DIR}/device_builder_server.c)
     )
     file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/device_builder_server_creds)
 endif()
+
+# copy credentials, used by example applications.
+add_custom_target(copy-pki-certs ALL
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+    ${PROJECT_SOURCE_DIR}/pki_certs
+    ${PROJECT_BINARY_DIR}/pki_certs
+)

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -33,5 +33,15 @@ target_link_libraries(simpleclient
 )
 file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/simpleclient_creds)
 
-# include file used to compile the Device Builder application
-include(device-builder.cmake OPTIONAL)
+if(EXISTS ${PROJECT_SOURCE_DIR}/device_builder_server.c)
+    add_executable(device_builder_server
+        ${PROJECT_SOURCE_DIR}/device_builder_server.c
+        ${iotivity-lite_SOURCE_DIR}/api/oc_introspection.c
+    )
+    target_link_libraries(device_builder_server
+        iotivity-server-client
+        pthread
+        m
+    )
+    file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/device_builder_server)
+endif()

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -1,0 +1,13 @@
+project(iotivity-deps)
+
+add_library(tinycbor-master
+    ${PROJECT_SOURCE_DIR}/tinycbor/src/cborerrorstrings.c
+    ${PROJECT_SOURCE_DIR}/tinycbor/src/cborencoder.c
+    ${PROJECT_SOURCE_DIR}/tinycbor/src/cborencoder_close_container_checked.c
+    ${PROJECT_SOURCE_DIR}/tinycbor/src/cborparser.c
+    ${PROJECT_SOURCE_DIR}/tinycbor/src/cborpretty.c
+)
+
+target_include_directories(tinycbor-master PUBLIC
+    ${PROJECT_SOURCE_DIR}/tinycbor/src
+)

--- a/mbedtls-patch.cmake
+++ b/mbedtls-patch.cmake
@@ -1,0 +1,38 @@
+# This is the iotivity-lite patch tool (originally written in make) ported to cmake so
+# that it can run cross-platform. It applies the collection of patches in iotivity-lite/patches/
+# to mbedtls. This should be run in the Iotivity source directory.
+cmake_minimum_required (VERSION 3.13)
+
+# Find git
+find_package(Git)
+
+if(NOT Git_FOUND)
+	message(FATAL_ERROR "Could not find 'git' tool for iotivity mbedtls patching")
+endif()
+
+message("iotivity patch utils found")
+
+set(IOTIVITY_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+set(MBEDTLS_SRC_DIR "${IOTIVITY_SRC_DIR}/deps/mbedtls")
+set(IOTIVITY_PATCH_DIR "${IOTIVITY_SRC_DIR}/patches")
+
+if(EXISTS "${MBEDTLS_SRC_DIR}/.git")
+	message("cleaning mbedtls...")
+	execute_process(COMMAND ${GIT_EXECUTABLE} -C ${MBEDTLS_SRC_DIR} clean -fdx)
+	execute_process(COMMAND ${GIT_EXECUTABLE} -C ${MBEDTLS_SRC_DIR} reset --hard)
+	message("mbedtls cleaned")
+endif()
+
+execute_process(COMMAND ${GIT_EXECUTABLE} -C ${IOTIVITY_SRC_DIR} submodule update --init)
+
+message("submodules initialised")
+
+file(GLOB PATCHES "${IOTIVITY_PATCH_DIR}/*.patch")
+
+foreach(PATCH IN LISTS PATCHES)
+	message("Running patch ${PATCH}")
+	execute_process(
+		COMMAND ${GIT_EXECUTABLE} apply ${PATCH}
+		WORKING_DIRECTORY ${MBEDTLS_SRC_DIR}
+	)
+endforeach()

--- a/onboarding_tool/CMakeLists.txt
+++ b/onboarding_tool/CMakeLists.txt
@@ -1,0 +1,12 @@
+project(onboarding_tool)
+
+add_executable(onboarding_tool
+    ${PROJECT_SOURCE_DIR}/obtmain.c
+    ${iotivity-lite_SOURCE_DIR}/api/oc_introspection.c
+)
+
+target_link_libraries(onboarding_tool PRIVATE 
+    iotivity-client
+    pthread
+    m
+)

--- a/onboarding_tool/CMakeLists.txt
+++ b/onboarding_tool/CMakeLists.txt
@@ -1,21 +1,21 @@
 project(onboarding_tool)
 
-add_executable(onboarding_tool
-    ${PROJECT_SOURCE_DIR}/obtmain.c
-    ${iotivity-lite_SOURCE_DIR}/api/oc_introspection.c
-)
+if(UNIX)
+    add_executable(onboarding_tool
+        ${PROJECT_SOURCE_DIR}/obtmain.c
+        ${iotivity-lite_SOURCE_DIR}/api/oc_introspection.c
+    )
 
-target_link_libraries(onboarding_tool
-    iotivity-client
-    pthread
-    m
-)
+    target_link_libraries(onboarding_tool
+        iotivity-client
+    )
 
-file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/onboarding_tool_creds)
+    file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/onboarding_tool_creds)
 
-# copy credentials
-add_custom_target(copy-pki-certs-obt ALL
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-    ${iotivity-lite-apps_SOURCE_DIR}/pki_certs
-    ${PROJECT_BINARY_DIR}/pki_certs
-)
+    # copy credentials
+    add_custom_target(copy-pki-certs-obt ALL
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${iotivity-lite-apps_SOURCE_DIR}/pki_certs
+        ${PROJECT_BINARY_DIR}/pki_certs
+    )
+endif()

--- a/onboarding_tool/CMakeLists.txt
+++ b/onboarding_tool/CMakeLists.txt
@@ -12,3 +12,10 @@ target_link_libraries(onboarding_tool
 )
 
 file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/onboarding_tool_creds)
+
+# copy credentials
+add_custom_target(copy-pki-certs-obt ALL
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+    ${iotivity-lite-apps_SOURCE_DIR}/pki_certs
+    ${PROJECT_BINARY_DIR}/pki_certs
+)

--- a/onboarding_tool/CMakeLists.txt
+++ b/onboarding_tool/CMakeLists.txt
@@ -5,7 +5,7 @@ add_executable(onboarding_tool
     ${iotivity-lite_SOURCE_DIR}/api/oc_introspection.c
 )
 
-target_link_libraries(onboarding_tool PRIVATE 
+target_link_libraries(onboarding_tool
     iotivity-client
     pthread
     m

--- a/onboarding_tool/CMakeLists.txt
+++ b/onboarding_tool/CMakeLists.txt
@@ -10,3 +10,5 @@ target_link_libraries(onboarding_tool
     pthread
     m
 )
+
+file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/onboarding_tool_creds)

--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -1,0 +1,34 @@
+# This CMakeLists can only build the port for Linux & Windows
+if(UNIX OR WIN32)
+    project(iotivity-lite-port)
+
+    add_library(iotivity-port INTERFACE)
+
+    target_include_directories(iotivity-port INTERFACE 
+	${PORT_DIR}
+	${PROJECT_SOURCE_DIR}/port
+    )
+    
+    target_sources(iotivity-port INTERFACE
+	${PORT_DIR}/abort.c
+	${PORT_DIR}/clock.c
+	${PORT_DIR}/ipadapter.c
+	${PORT_DIR}/random.c
+	${PORT_DIR}/storage.c
+	${PORT_DIR}/tcpadapter.c
+    )
+    
+    if(WIN32)
+	target_sources(iotivity-port INTERFACE
+	    ${PORT_DIR}/mutex.c
+	    ${PORT_DIR}/network_addresses.c
+	)
+	target_compile_definitions(iotivity-port INTERFACE OC_IPV4)
+    endif()
+    
+    if(UNIX)
+	target_link_libraries(iotivity-port INTERFACE pthread m)
+    elseif(WIN32)
+	target_link_libraries(iotivity-port INTERFACE bcrypt iphlpapi)
+    endif()
+endif()

--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -1,34 +1,42 @@
 # This CMakeLists can only build the port for Linux & Windows
 if(UNIX OR WIN32)
-    project(iotivity-lite-port)
+	project(iotivity-lite-port)
+
+	# Detect the platform and pick the right port
+	if(UNIX)
+        set(PORT_DIR ${PROJECT_SOURCE_DIR}/linux)
+	elseif(WIN32)
+        set(PORT_DIR ${PROJECT_SOURCE_DIR}/windows)
+	endif()
+
 
     add_library(iotivity-port INTERFACE)
 
     target_include_directories(iotivity-port INTERFACE 
-	${PORT_DIR}
-	${PROJECT_SOURCE_DIR}/port
+        ${PORT_DIR}
+        ${PROJECT_SOURCE_DIR}
     )
     
     target_sources(iotivity-port INTERFACE
-	${PORT_DIR}/abort.c
-	${PORT_DIR}/clock.c
-	${PORT_DIR}/ipadapter.c
-	${PORT_DIR}/random.c
-	${PORT_DIR}/storage.c
-	${PORT_DIR}/tcpadapter.c
+        ${PORT_DIR}/abort.c
+        ${PORT_DIR}/clock.c
+        ${PORT_DIR}/ipadapter.c
+        ${PORT_DIR}/random.c
+        ${PORT_DIR}/storage.c
+        ${PORT_DIR}/tcpadapter.c
     )
     
     if(WIN32)
-	target_sources(iotivity-port INTERFACE
-	    ${PORT_DIR}/mutex.c
-	    ${PORT_DIR}/network_addresses.c
-	)
-	target_compile_definitions(iotivity-port INTERFACE OC_IPV4)
+        target_sources(iotivity-port INTERFACE
+            ${PORT_DIR}/mutex.c
+            ${PORT_DIR}/network_addresses.c
+        )
+        target_compile_definitions(iotivity-port INTERFACE OC_IPV4)
     endif()
     
     if(UNIX)
-	target_link_libraries(iotivity-port INTERFACE pthread m)
+        target_link_libraries(iotivity-port INTERFACE pthread m)
     elseif(WIN32)
-	target_link_libraries(iotivity-port INTERFACE bcrypt iphlpapi)
+        target_link_libraries(iotivity-port INTERFACE bcrypt iphlpapi)
     endif()
 endif()

--- a/tools/clang-format.cmake
+++ b/tools/clang-format.cmake
@@ -1,0 +1,37 @@
+cmake_minimum_required (VERSION 3.11)
+
+# Create list of all source files
+file(GLOB_RECURSE iotivity_allsource *.c *.cpp *.h *.hpp)
+# Remove third party code
+list(FILTER iotivity_allsource EXCLUDE REGEX "deps/")
+
+# Find clang-format
+find_program(
+	CLANG_FORMAT_EXE
+	NAMES "clang-format-6.0"
+	      "clang-format"
+	DOC "Path to clang-format executable"
+	)
+if(NOT CLANG_FORMAT_EXE)
+	message(FATAL_ERROR "clang-format not found.")
+else()
+	message(STATUS "clang-format found: ${CLANG_FORMAT_EXE}")
+endif()
+
+execute_process(
+	COMMAND ${CLANG_FORMAT_EXE} -version
+	OUTPUT_VARIABLE CLANG_VERSION
+	)
+
+# version check
+if(NOT ${CLANG_VERSION} MATCHES "version 6\.0")
+	message(FATAL_ERROR "clang-format must be version 6.0")
+endif()
+
+# Run clang format
+list(LENGTH iotivity_allsource LIST_LEN)
+math(EXPR LIST_LEN "${LIST_LEN} - 1")
+foreach(INDEX RANGE 0 ${LIST_LEN} 8)
+	list(SUBLIST iotivity_allsource ${INDEX} 8 TMP_PATH)
+	execute_process(COMMAND ${CLANG_FORMAT_EXE} -i -style=file ${TMP_PATH})
+endforeach()


### PR DESCRIPTION
This pull request:

- adds a CMake build system capable of building Iotivity-Lite on UNIX and Windows (tested using the Visual Studio project generator)
- adds `format` target, which will run `clang-format` locally & apply the changes to your working directory

Iotivity is set up to be built on all platforms, but only the Windows & Linux ports are built by CMake. Ports for other platforms must provide their own `iotivity-port` CMake target that the rest of the code links against.