### PR TITLE
fix failure in CT1.2.21

### DIFF
--- a/messaging/coap/separate.c
+++ b/messaging/coap/separate.c
@@ -177,9 +177,6 @@ coap_separate_resume(void *response, coap_separate_t *separate_store,
   if (separate_store->token_len) {
     coap_set_token(response, separate_store->token, separate_store->token_len);
   }
-  if (separate_store->observe == 0) {
-    coap_set_header_observe(response, 0);
-  }
 }
 /*---------------------------------------------------------------------------*/
 void


### PR DESCRIPTION
In order to ensure CSRs work on embedded devices, /oic/sec/csr had been
configured to respond using separate responses (empty ACK followed by
payload in a separate message.) However, these separate responses still
contained the CoAP Observe header, even though the resource is not
capable of handling Observe requests, which is in violation of RFC7641
section 4.1.

This commit ensures that the Observe header is not added to separate
response messages.