### PR TITLE
oc_event_callback: fix double free memory

### DIFF
--- a/api/oc_ri.c
+++ b/api/oc_ri.c
@@ -83,6 +83,8 @@ OC_LIST(timed_callbacks);
 OC_MEMB(event_callbacks_s, oc_event_callback_t,
         1 + OCF_D * OC_MAX_NUM_DEVICES + OC_MAX_APP_RESOURCES +
           OC_MAX_NUM_CONCURRENT_REQUESTS * 2);
+static oc_event_callback_t *currently_processed_event_cb;
+static bool currently_processed_event_cb_delete;
 
 OC_PROCESS(timed_callback_events, "OC timed callbacks");
 
@@ -538,12 +540,19 @@ oc_ri_remove_timed_event_callback(void *cb_data, oc_trigger_t event_callback)
 
   while (event_cb != NULL) {
     if (event_cb->data == cb_data && event_cb->callback == event_callback) {
-      OC_PROCESS_CONTEXT_BEGIN(&timed_callback_events);
-      oc_etimer_stop(&event_cb->timer);
-      OC_PROCESS_CONTEXT_END(&timed_callback_events);
-      oc_list_remove(timed_callbacks, event_cb);
-      oc_memb_free(&event_callbacks_s, event_cb);
-      break;
+      if (currently_processed_event_cb == event_cb) {
+        // We can't remove the currently processed delayed callback because when
+        // the callback returns OC_EVENT_DONE, a double release occurs. So we
+        // set up the flag to remove it, and when it's over, we've removed it.
+        currently_processed_event_cb_delete = true;
+      } else {
+        OC_PROCESS_CONTEXT_BEGIN(&timed_callback_events);
+        oc_etimer_stop(&event_cb->timer);
+        OC_PROCESS_CONTEXT_END(&timed_callback_events);
+        oc_list_remove(timed_callbacks, event_cb);
+        oc_memb_free(&event_callbacks_s, event_cb);
+        break;
+      }
     }
     event_cb = event_cb->next;
   }
@@ -576,9 +585,11 @@ poll_event_callback_timers(oc_list_t list, struct oc_memb *cb_pool)
 
   while (event_cb != NULL) {
     next = event_cb->next;
-
     if (oc_etimer_expired(&event_cb->timer)) {
-      if (event_cb->callback(event_cb->data) == OC_EVENT_DONE) {
+      currently_processed_event_cb = event_cb;
+      currently_processed_event_cb_delete = false;
+      if ((event_cb->callback(event_cb->data) == OC_EVENT_DONE) ||
+          currently_processed_event_cb_delete) {
         oc_list_remove(list, event_cb);
         oc_memb_free(cb_pool, event_cb);
         event_cb = oc_list_head(list);
@@ -594,6 +605,8 @@ poll_event_callback_timers(oc_list_t list, struct oc_memb *cb_pool)
 
     event_cb = next;
   }
+  currently_processed_event_cb = NULL;
+  currently_processed_event_cb_delete = false;
 }
 
 static void

--- a/apps/simpleserver.c
+++ b/apps/simpleserver.c
@@ -212,7 +212,6 @@ register_resources(void)
   oc_add_resource(res_binaryswitch);
 }
 
-
 #ifdef OC_SECURITY
 void
 random_pin_cb(const unsigned char *pin, size_t pin_len, void *data)
@@ -221,8 +220,6 @@ random_pin_cb(const unsigned char *pin, size_t pin_len, void *data)
   PRINT("\n\nRandom PIN: %.*s\n\n", (int)pin_len, pin);
 }
 #endif /* OC_SECURITY */
-
-
 
 static void
 signal_event_loop(void)


### PR DESCRIPTION
We can't remove the currently processed delayed callback because when
the callback returns OC_EVENT_DONE, a double release occurs. So we set up
the flag to remove it, and when it's over, we've removed it.

```
[root@image]# cat asan.txt
=================================================================
==24==ERROR: AddressSanitizer: attempting double-free on 0x606000b87d80 in thread T0:
    #0 0x7fc5e8121277 in __interceptor_free (/usr/lib/libasan.so.5+0x107277)
    #1 0x7fc5e7ebfa03 in _oc_memb_free ./iotivity-lite/util/oc_memb.c:159
    #2 0x7fc5e7ed3f7f in poll_event_callback_timers ./iotivity-lite/api/oc_ri.c:464
    #3 0x7fc5e7ed4027 in check_event_callbacks ./iotivity-lite/api/oc_ri.c:486
    #4 0x7fc5e7ed67c0 in process_thread_timed_callback_events ./iotivity-lite/api/oc_ri.c:1617
    #5 0x7fc5e7ebff15 in call_process ./iotivity-lite/util/oc_process.c:178
    #6 0x7fc5e7ec01d9 in do_event ./iotivity-lite/util/oc_process.c:298
    #7 0x7fc5e7ec01f5 in oc_process_run ./iotivity-lite/util/oc_process.c:312
    #8 0x7fc5e7ececc0 in oc_main_poll ./iotivity-lite/api/oc_main.c:283
    #9 0x55ce8b07e34d in main ./src/server.cpp:369
    #10 0x7fc5e7945d0a in __libc_start_main (/lib/libc.so.6+0x26d0a)
    #11 0x55ce8b07c4e9 in _start (/usr/bin/xr-cm-agent-2.2.0+0x54e9)
 
0x606000b87d80 is located 0 bytes inside of 56-byte region [0x606000b87d80,0x606000b87db8)
freed by thread T0 here:
    #0 0x7fc5e8121277 in __interceptor_free (/usr/lib/libasan.so.5+0x107277)
    #1 0x7fc5e7ebfa03 in _oc_memb_free ./iotivity-lite/util/oc_memb.c:159
    #2 0x7fc5e7ed3df3 in oc_ri_remove_timed_event_callback ./iotivity-lite/api/oc_ri.c:426
    #3 0x7fc5e7ed6a4a in oc_remove_delayed_callback ./iotivity-lite/api/oc_server_api.c:121
    #4 0x7fc5e7f13117 in cloud_login_handler ./iotivity-lite/api/cloud/oc_cloud_manager.c:351
    #5 0x7fc5e7ed5a74 in notify_client_cb_503 ./iotivity-lite/api/oc_ri.c:1247
    #6 0x7fc5e7ed5c20 in oc_ri_free_client_cbs_by_endpoint ./iotivity-lite/api/oc_ri.c:1285
    #7 0x7fc5e7f03d5a in oc_tls_free_peer ./iotivity-lite/security/oc_tls.c:315
    #8 0x7fc5e7f068cd in oc_tls_close_connection ./iotivity-lite/security/oc_tls.c:1470
    #9 0x7fc5e7f0fe19 in cloud_close_endpoint ./iotivity-lite/api/cloud/oc_cloud.c:94
    #10 0x7fc5e7f104c3 in cloud_reconnect ./iotivity-lite/api/cloud/oc_cloud.c:296
    #11 0x7fc5e7f12719 in reconnect ./iotivity-lite/api/cloud/oc_cloud_manager.c:90
    #12 0x7fc5e7f132d2 in cloud_login ./iotivity-lite/api/cloud/oc_cloud_manager.c:389
    #13 0x7fc5e7ed3f55 in poll_event_callback_timers ./iotivity-lite/api/oc_ri.c:462
    #14 0x7fc5e7ed4027 in check_event_callbacks ./iotivity-lite/api/oc_ri.c:486
    #15 0x7fc5e7ed67c0 in process_thread_timed_callback_events ./iotivity-lite/api/oc_ri.c:1617
    #16 0x7fc5e7ebff15 in call_process ./iotivity-lite/util/oc_process.c:178
    #17 0x7fc5e7ec01d9 in do_event ./iotivity-lite/util/oc_process.c:298
    #18 0x7fc5e7ec01f5 in oc_process_run ./iotivity-lite/util/oc_process.c:312
    #19 0x7fc5e7ececc0 in oc_main_poll ./iotivity-lite/api/oc_main.c:283
    #20 0x55ce8b07e34d in main ./src/server.cpp:369
    #21 0x7fc5e7945d0a in __libc_start_main (/lib/libc.so.6+0x26d0a)
 
previously allocated by thread T0 here:
    #0 0x7fc5e812180e in calloc (/usr/lib/libasan.so.5+0x10780e)
    #1 0x7fc5e7ebf8b0 in _oc_memb_alloc ./iotivity-lite/util/oc_memb.c:95
    #2 0x7fc5e7ed3e2f in oc_ri_add_timed_event_callback_ticks ./iotivity-lite/api/oc_ri.c:438
    #3 0x7fc5e7ed6a24 in oc_set_delayed_callback ./iotivity-lite/api/oc_server_api.c:115
    #4 0x7fc5e7f132ac in cloud_login ./iotivity-lite/api/cloud/oc_cloud_manager.c:385
    #5 0x7fc5e7ed3f55 in poll_event_callback_timers ./iotivity-lite/api/oc_ri.c:462
    #6 0x7fc5e7ed4027 in check_event_callbacks ./iotivity-lite/api/oc_ri.c:486
    #7 0x7fc5e7ed67c0 in process_thread_timed_callback_events ./iotivity-lite/api/oc_ri.c:1617
    #8 0x7fc5e7ebff15 in call_process ./iotivity-lite/util/oc_process.c:178
    #9 0x7fc5e7ec01d9 in do_event ./iotivity-lite/util/oc_process.c:298
    #10 0x7fc5e7ec01f5 in oc_process_run ./iotivity-lite/util/oc_process.c:312
    #11 0x7fc5e7ececc0 in oc_main_poll ./iotivity-lite/api/oc_main.c:283
    #12 0x55ce8b07e34d in main ./src/server.cpp:369
    #13 0x7fc5e7945d0a in __libc_start_main (/lib/libc.so.6+0x26d0a)
 
SUMMARY: AddressSanitizer: double-free (/usr/lib/libasan.so.5+0x107277) in __interceptor_free
==24==ABORTING
```