### PR TITLE
Revert "revert separate response modifications"

### DIFF
--- a/apps/cloud_proxy.c
+++ b/apps/cloud_proxy.c
@@ -1015,8 +1015,9 @@ get_local_resource_response(oc_client_response_t *data)
   print_rep(value_list, false);
   free(value_list);
 
-  memcpy(delay_response->buffer, data->_payload, (int)data->_payload_len);
-  delay_response->len = data->_payload_len;
+  memcpy(delay_response->response_state->buffer, data->_payload,
+         (int)data->_payload_len);
+  delay_response->response_state->payload_size = data->_payload_len;
 
   oc_send_separate_response(delay_response, data->code);
 
@@ -1087,8 +1088,9 @@ post_local_resource_response(oc_client_response_t *data)
   print_rep(value_list, false);
   free(value_list);
 
-  memcpy(delay_response->buffer, data->_payload, (int)data->_payload_len);
-  delay_response->len = data->_payload_len;
+  memcpy(delay_response->response_state->buffer, data->_payload,
+         (int)data->_payload_len);
+  delay_response->response_state->payload_size = data->_payload_len;
 
   oc_send_separate_response(delay_response, data->code);
 
@@ -1189,8 +1191,9 @@ delete_local_resource_response(oc_client_response_t *data)
   print_rep(value_list, false);
   free(value_list);
 
-  memcpy(delay_response->buffer, data->_payload, (int)data->_payload_len);
-  delay_response->len = data->_payload_len;
+  memcpy(delay_response->response_state->buffer, data->_payload,
+         (int)data->_payload_len);
+  delay_response->response_state->payload_size = data->_payload_len;
 
   oc_send_separate_response(delay_response, data->code);
 

--- a/messaging/coap/oc_coap.h
+++ b/messaging/coap/oc_coap.h
@@ -20,6 +20,8 @@
 #include "oc_ri.h"
 #include "separate.h"
 #include "util/oc_list.h"
+#include "oc_ri.h"
+#include "oc_blockwise.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -29,12 +31,7 @@ struct oc_separate_response_s
 {
   OC_LIST_STRUCT(requests);
   int active;
-#ifdef OC_DYNAMIC_ALLOCATION
-  uint8_t *buffer;
-#else  /* OC_DYNAMIC_ALLOCATION */
-  uint8_t buffer[OC_MAX_APP_DATA_SIZE];
-#endif /* !OC_DYNAMIC_ALLOCATION */
-  size_t len;
+  oc_blockwise_state_t *response_state;
 };
 
 struct oc_response_buffer_s

--- a/messaging/coap/separate.c
+++ b/messaging/coap/separate.c
@@ -87,9 +87,6 @@ coap_separate_accept(void *request, oc_separate_response_t *separate_response,
 
   if (separate_response->active == 0) {
     OC_LIST_STRUCT_INIT(separate_response, requests);
-#ifdef OC_DYNAMIC_ALLOCATION
-    separate_response->buffer = (uint8_t *)malloc(OC_MAX_APP_DATA_SIZE);
-#endif /* OC_DYNAMIC_ALLOCATION */
   }
 
   coap_packet_t *const coap_req = (coap_packet_t *)request;
@@ -115,7 +112,7 @@ coap_separate_accept(void *request, oc_separate_response_t *separate_response,
     oc_list_add(separate_response->requests, separate_store);
 
     /* store correct response type */
-    separate_store->type = COAP_TYPE_NON;
+    separate_store->type = COAP_TYPE_CON;
 
     memcpy(separate_store->token, coap_req->token, coap_req->token_len);
     separate_store->token_len = coap_req->token_len;


### PR DESCRIPTION
This patch saves significant amounts of memory while using separate responses by reusing the application buffer used in blockwise transfers.

This reverts commit 3bb9584da8b82b5b6385d3ed79445b47a3a5d138.