### PR TITLE
Remove a false positive error printout

### DIFF
--- a/api/oc_blockwise.c
+++ b/api/oc_blockwise.c
@@ -90,7 +90,6 @@ oc_blockwise_free_buffer(oc_list_t list, struct oc_memb *pool,
 {
 
   if (!buffer) {
-    OC_ERR("buffer is NULL");
     return;
   }
 


### PR DESCRIPTION
Remove a false positive error printout from function oc_blockwise_free_buffer.