### PR TITLE
cloud: correctly delete created resources on reset

### DIFF
--- a/api/cloud/oc_cloud_rd.c
+++ b/api/cloud/oc_cloud_rd.c
@@ -286,11 +286,23 @@ oc_cloud_delete_resource(oc_resource_t *res)
   }
   oc_link_t *publish =
     rd_link_remove_by_resource(&ctx->rd_publish_resources, res);
-  if (publish != NULL) {
-    oc_delete_link(publish);
-  }
+  oc_delete_link(publish);
+
   oc_link_t *published =
     rd_link_remove_by_resource(&ctx->rd_published_resources, res);
+
+#ifdef OC_SECURITY
+  oc_sec_pstat_t *pstat = oc_sec_get_pstat(res->device);
+  if (pstat->s == OC_DOS_RESET || pstat->s == OC_DOS_RFOTM) {
+    oc_delete_link(published);
+
+    oc_link_t *delete =
+      rd_link_remove_by_resource(&ctx->rd_delete_resources, res);
+    oc_delete_link(delete);
+    return;
+  }
+#endif /* OC_SECURITY */
+
   if (published != NULL) {
     if (published->resource) {
       published->resource = NULL;

--- a/include/oc_cloud.h
+++ b/include/oc_cloud.h
@@ -136,9 +136,32 @@ int oc_cloud_get_token_expiry(oc_cloud_context_t *ctx);
 void oc_cloud_set_published_resources_ttl(oc_cloud_context_t *ctx,
                                           uint32_t ttl);
 
+/**
+ * @brief Publish resource to cloud.
+ *
+ * Function checks that resource is contained in list of published or to-be
+ * published resources. If it is, the function does nothing. If it is not, then
+ * the resource is added to the to-be published resources list and a publish
+ * request with this list is sent to the cloud server.
+ *
+ * @param resource the resource to be published
+ */
 int oc_cloud_add_resource(oc_resource_t *resource);
+
+/**
+ * @brief Unpublish resource from cloud.
+ *
+ * @param resource the resource to be unpublished
+ */
 void oc_cloud_delete_resource(oc_resource_t *resource);
+
+/**
+ * @brief Republish previously published devices.
+ *
+ * @param device the device index
+ */
 int oc_cloud_publish_resources(size_t device);
+
 int oc_cloud_discover_resources(oc_cloud_context_t *ctx,
                                 oc_discovery_all_handler_t handler,
                                 void *user_data);

--- a/security/oc_pstat.c
+++ b/security/oc_pstat.c
@@ -184,9 +184,6 @@ oc_pstat_handle_state(oc_sec_pstat_t *ps, size_t device, bool from_storage,
 #endif /* OC_PKI */
     oc_sec_sp_default(device);
 #ifdef OC_SERVER
-#if defined(OC_COLLECTIONS) && defined(OC_COLLECTIONS_IF_CREATE)
-    oc_rt_factory_free_created_resources(device);
-#endif /* OC_COLLECTIONS && OC_COLLECTIONS_IF_CREATE */
     coap_remove_observers_on_dos_change(device, true);
 #endif /* OC_SERVER */
     ps->p = false;
@@ -391,8 +388,18 @@ oc_pstat_handle_state(oc_sec_pstat_t *ps, size_t device, bool from_storage,
   }
   memmove(&pstat[device], ps, sizeof(oc_sec_pstat_t));
 #ifdef OC_SERVER
-  if (ps->s == OC_DOS_RFNOP) {
+  switch (ps->s) {
+  case OC_DOS_RESET:
+  case OC_DOS_RFOTM:
+#if defined(OC_COLLECTIONS) && defined(OC_COLLECTIONS_IF_CREATE)
+    oc_rt_factory_free_created_resources(device);
+#endif /* OC_COLLECTIONS && OC_COLLECTIONS_IF_CREATE */
+    break;
+  case OC_DOS_RFNOP:
     coap_remove_observers_on_dos_change(device, false);
+    break;
+  default:
+    break;
   }
 #endif /* OC_SERVER */
   OC_DBG("oc_pstat: leaving pstat_handle_state");


### PR DESCRIPTION
On factory reset dynamically created resources are deleted by
oc_rt_factory_free_created_resources. The function is however
called after device id has been reset to a new random value.
Deletion is executed only after a resource is unpublished from
the cloud, but the unpublish requests never suceed because
the cloud does not recognize the new device ID and thus
the created devices remain in to-be-deleted state forever.
The issue is fixed by not generating unpublish request during
factory reset and proceeding to the deletion directly.