### PR TITLE
Fix misaligned memory access on 32 bit ARM

### DIFF
--- a/api/oc_ri.c
+++ b/api/oc_ri.c
@@ -937,7 +937,7 @@ oc_ri_invoke_coap_entity_handler(void *request, void *response, uint8_t *buffer,
   coap_get_header_content_format(request, &cf);
 
   /* Read the accept CoAP option in the request */
-  oc_content_format_t accept = 0;
+  unsigned int accept = 0;
   coap_get_header_accept(request, &accept);
 
   if (uri_query_len) {


### PR DESCRIPTION
`oc_content_format_t` and `unsigned int` are not guaranteed to have the same memory size & alignment requirements across all platforms & compilers. This pull request ensures that the correct types are passed around in order to avoid this issue.