### PR TITLE
cloud: don't republish resources after refresh

### DIFF
--- a/api/cloud/oc_cloud.c
+++ b/api/cloud/oc_cloud.c
@@ -121,6 +121,7 @@ oc_cloud_clear_context(oc_cloud_context_t *ctx)
 {
   oc_assert(ctx != NULL);
 
+  cloud_rd_reset_context(ctx);
   cloud_close_endpoint(ctx->cloud_ep);
   memset(ctx->cloud_ep, 0, sizeof(oc_endpoint_t));
   ctx->cloud_ep_state = OC_SESSION_DISCONNECTED;

--- a/api/cloud/oc_cloud_internal.h
+++ b/api/cloud/oc_cloud_internal.h
@@ -144,7 +144,27 @@ bool cloud_access_refresh_access_token(oc_endpoint_t *endpoint, const char *uid,
  * @param ctx Cloud context, must not be NULL
  */
 void cloud_rd_manager_status_changed(oc_cloud_context_t *ctx);
+
+/**
+ * @brief Deallocate all resource directory context member variables.
+ *
+ * Deallocate the list of to be published resources, the list of published
+ * resources and the list of to be deleted resources. Remove delayed callback
+ * that republishes resources (if it's active).
+ *
+ * @param ctx Cloud context, must not be NULL
+ */
 void cloud_rd_deinit(oc_cloud_context_t *ctx);
+
+/**
+ * @brief Reset resource directory context member variables.
+ *
+ * Items in the list of published resources are moved to the list of to be
+ * published resources. The list of to be deleted resources is cleared.
+ *
+ * @param ctx Cloud context, must not be NULL
+ */
+void cloud_rd_reset_context(oc_cloud_context_t *ctx);
 
 void cloud_manager_start(oc_cloud_context_t *ctx);
 void cloud_manager_stop(oc_cloud_context_t *ctx);

--- a/api/cloud/oc_cloud_rd.c
+++ b/api/cloud/oc_cloud_rd.c
@@ -215,11 +215,7 @@ delete_resources_handler(oc_client_response_t *data)
     return;
   if (data->code != OC_STATUS_DELETED)
     goto error;
-  while (ctx->rd_delete_resources) {
-    oc_link_t *link = rd_link_pop(&ctx->rd_delete_resources);
-    oc_delete_link(link);
-  }
-
+  rd_link_free(&ctx->rd_delete_resources);
 error : {
 }
 }
@@ -251,19 +247,21 @@ delete_resources(oc_cloud_context_t *ctx, bool all)
 void
 cloud_rd_manager_status_changed(oc_cloud_context_t *ctx)
 {
-  if (ctx->store.status & OC_CLOUD_LOGGED_IN) {
-    if (ctx->store.status & OC_CLOUD_REFRESHED_TOKEN) {
-      // when refresh occurs we don't want to publish resources.
-      return;
-    }
-    publish_published_resources(ctx);
-    delete_resources(ctx, false);
+  if (!(ctx->store.status & OC_CLOUD_LOGGED_IN)) {
     oc_remove_delayed_callback(ctx, publish_published_resources);
-    if (ctx->time_to_live != RD_PUBLISH_TTL_UNLIMITED) {
-      oc_set_delayed_callback(ctx, publish_published_resources, ONE_HOUR);
-    }
-  } else {
-    oc_remove_delayed_callback(ctx, publish_published_resources);
+    return;
+  }
+  if (ctx->store.status & OC_CLOUD_REFRESHED_TOKEN) {
+    // when refresh occurs we don't want to publish resources.
+    return;
+  }
+  if (ctx->rd_publish_resources) {
+    publish_resources(ctx);
+  }
+  delete_resources(ctx, false);
+  oc_remove_delayed_callback(ctx, publish_published_resources);
+  if (ctx->time_to_live != RD_PUBLISH_TTL_UNLIMITED) {
+    oc_set_delayed_callback(ctx, publish_published_resources, ONE_HOUR);
   }
 }
 
@@ -275,6 +273,15 @@ cloud_rd_deinit(oc_cloud_context_t *ctx)
   rd_link_free(&ctx->rd_delete_resources);
   rd_link_free(&ctx->rd_published_resources);
   rd_link_free(&ctx->rd_publish_resources);
+}
+
+void
+cloud_rd_reset_context(oc_cloud_context_t *ctx)
+{
+  oc_remove_delayed_callback(ctx, publish_published_resources);
+
+  rd_link_free(&ctx->rd_delete_resources);
+  move_published_to_publish_resources(ctx);
 }
 
 void

--- a/include/oc_cloud.h
+++ b/include/oc_cloud.h
@@ -105,7 +105,6 @@ typedef struct oc_cloud_context_t
   oc_link_t *rd_publish_resources;   /**< Resource links to publish */
   oc_link_t *rd_published_resources; /**< Resource links already published */
   oc_link_t *rd_delete_resources;    /**< Resource links to delete */
-  bool rd_delete_all;
 
   oc_resource_t *cloud_conf;
 

--- a/swig/swig_interfaces/oc_cloud.i
+++ b/swig/swig_interfaces/oc_cloud.i
@@ -114,7 +114,6 @@ static void jni_cloud_cb(oc_cloud_context_t *ctx, oc_cloud_status_t status, void
 %rename (rdPublishResources) oc_cloud_context_t::rd_publish_resources;
 %rename (rdPublishedResources) oc_cloud_context_t::rd_published_resources;
 %rename (rdDeleteResources) oc_cloud_context_t::rd_delete_resources;
-%rename (rdDeleteAll) oc_cloud_context_t::rd_delete_all;
 %ignore oc_cloud_context_t::cps;
 %rename (cloudConf) oc_cloud_context_t::cloud_conf;
 %rename (cloudManager) oc_cloud_context_t::cloud_manager;


### PR DESCRIPTION
After successful refresh token call, login call is automatically
invoked. And succesful login in turn always invokes republishing
of already published resources to cloud. This is unnecessary,
the only thing that happened was that the access token had its
lifetime extended and this doesn't warant the republishing
of resources.