### PR TITLE
Add function to encode CborNullType value

### DIFF
--- a/api/oc_rep.c
+++ b/api/oc_rep.c
@@ -595,6 +595,9 @@ oc_rep_get_value(oc_rep_t *rep, oc_rep_value_type_t type, const char *key,
         (rep_value->type == type)) {
       OC_DBG("Found the value with %s", key);
       switch (rep_value->type) {
+      case OC_REP_NIL:
+          **(bool **)value = true;
+          break;
       case OC_REP_INT:
         **(int64_t **)value = rep_value->value.integer;
         break;
@@ -642,6 +645,17 @@ oc_rep_get_value(oc_rep_t *rep, oc_rep_value_type_t type, const char *key,
   }
 
   return false;
+}
+
+bool
+oc_rep_is_null(oc_rep_t *rep, const char *key, bool *is_null)
+{
+  if (!is_null) {
+    OC_ERR("Error of input parameters");
+    return false;
+  }
+  return oc_rep_get_value(rep, OC_REP_NIL, key, (void **)&is_null,
+                          (size_t *)NULL);
 }
 
 bool

--- a/api/oc_rep.c
+++ b/api/oc_rep.c
@@ -596,8 +596,8 @@ oc_rep_get_value(oc_rep_t *rep, oc_rep_value_type_t type, const char *key,
       OC_DBG("Found the value with %s", key);
       switch (rep_value->type) {
       case OC_REP_NIL:
-          **(bool **)value = true;
-          break;
+        **(bool **)value = true;
+        break;
       case OC_REP_INT:
         **(int64_t **)value = rep_value->value.integer;
         break;

--- a/api/unittest/reptest.cpp
+++ b/api/unittest/reptest.cpp
@@ -63,50 +63,50 @@ TEST(TestRep, RepToJson_null)
  */
 TEST(TestRep, OCRepSetGetNull)
 {
-    /*buffer for oc_rep_t */
-    uint8_t buf[1024];
-    oc_rep_new(&buf[0], 1024);
+  /*buffer for oc_rep_t */
+  uint8_t buf[1024];
+  oc_rep_new(&buf[0], 1024);
 
-    /* add null value to root object */
-    oc_rep_start_root_object();
-    oc_rep_set_null(root, nothing);
-    oc_rep_end_root_object();
+  /* add null value to root object */
+  oc_rep_start_root_object();
+  oc_rep_set_null(root, nothing);
+  oc_rep_end_root_object();
 
-    /* convert CborEncoder to oc_rep_t */
-    const uint8_t *payload = oc_rep_get_encoder_buf();
-    int payload_len = oc_rep_get_encoded_payload_size();
-    EXPECT_NE(payload_len, -1);
-    struct oc_memb rep_objects = { sizeof(oc_rep_t), 0, 0, 0, 0 };
-    oc_rep_set_pool(&rep_objects);
-    oc_rep_t *rep = NULL;
-    oc_parse_rep(payload, payload_len, &rep);
-    ASSERT_TRUE(rep != NULL);
+  /* convert CborEncoder to oc_rep_t */
+  const uint8_t *payload = oc_rep_get_encoder_buf();
+  int payload_len = oc_rep_get_encoded_payload_size();
+  EXPECT_NE(payload_len, -1);
+  struct oc_memb rep_objects = { sizeof(oc_rep_t), 0, 0, 0, 0 };
+  oc_rep_set_pool(&rep_objects);
+  oc_rep_t *rep = NULL;
+  oc_parse_rep(payload, payload_len, &rep);
+  ASSERT_TRUE(rep != NULL);
 
-    bool is_null = false;
-    EXPECT_TRUE(oc_rep_is_null(rep, "nothing", &is_null));
-    EXPECT_TRUE(is_null);
-    /* error handling */
-    EXPECT_FALSE(oc_rep_is_null(NULL, "nothing", &is_null));
-    EXPECT_FALSE(oc_rep_is_null(rep, NULL, &is_null));
-    EXPECT_FALSE(oc_rep_is_null(rep, "nothing", NULL));
-    EXPECT_FALSE(oc_rep_is_null(rep, "not_the_key", &is_null));
+  bool is_null = false;
+  EXPECT_TRUE(oc_rep_is_null(rep, "nothing", &is_null));
+  EXPECT_TRUE(is_null);
+  /* error handling */
+  EXPECT_FALSE(oc_rep_is_null(NULL, "nothing", &is_null));
+  EXPECT_FALSE(oc_rep_is_null(rep, NULL, &is_null));
+  EXPECT_FALSE(oc_rep_is_null(rep, "nothing", NULL));
+  EXPECT_FALSE(oc_rep_is_null(rep, "not_the_key", &is_null));
 
-    char *json;
-    size_t json_size;
-    json_size = oc_rep_to_json(rep, NULL, 0, false);
-    json = (char *)malloc(json_size + 1);
-    oc_rep_to_json(rep, json, json_size + 1, false);
-    EXPECT_STREQ("{\"nothing\":null}", json);
-    free(json);
-    json = NULL;
-    json_size = oc_rep_to_json(rep, NULL, 0, true);
-    json = (char *)malloc(json_size + 1);
-    oc_rep_to_json(rep, json, json_size + 1, true);
-    EXPECT_STREQ("{\n  \"nothing\" : null\n}\n", json);
-    free(json);
-    json = NULL;
+  char *json;
+  size_t json_size;
+  json_size = oc_rep_to_json(rep, NULL, 0, false);
+  json = (char *)malloc(json_size + 1);
+  oc_rep_to_json(rep, json, json_size + 1, false);
+  EXPECT_STREQ("{\"nothing\":null}", json);
+  free(json);
+  json = NULL;
+  json_size = oc_rep_to_json(rep, NULL, 0, true);
+  json = (char *)malloc(json_size + 1);
+  oc_rep_to_json(rep, json, json_size + 1, true);
+  EXPECT_STREQ("{\n  \"nothing\" : null\n}\n", json);
+  free(json);
+  json = NULL;
 
-    oc_free_rep(rep);
+  oc_free_rep(rep);
 }
 
 TEST(TestRep, OCRepSetGetDouble)

--- a/api/unittest/reptest.cpp
+++ b/api/unittest/reptest.cpp
@@ -61,6 +61,54 @@ TEST(TestRep, RepToJson_null)
  * framework. End users are not expected to call oc_rep_new, oc_rep_set_pool
  * and oc_parse_rep
  */
+TEST(TestRep, OCRepSetGetNull)
+{
+    /*buffer for oc_rep_t */
+    uint8_t buf[1024];
+    oc_rep_new(&buf[0], 1024);
+
+    /* add null value to root object */
+    oc_rep_start_root_object();
+    oc_rep_set_null(root, nothing);
+    oc_rep_end_root_object();
+
+    /* convert CborEncoder to oc_rep_t */
+    const uint8_t *payload = oc_rep_get_encoder_buf();
+    int payload_len = oc_rep_get_encoded_payload_size();
+    EXPECT_NE(payload_len, -1);
+    struct oc_memb rep_objects = { sizeof(oc_rep_t), 0, 0, 0, 0 };
+    oc_rep_set_pool(&rep_objects);
+    oc_rep_t *rep = NULL;
+    oc_parse_rep(payload, payload_len, &rep);
+    ASSERT_TRUE(rep != NULL);
+
+    bool is_null = false;
+    EXPECT_TRUE(oc_rep_is_null(rep, "nothing", &is_null));
+    EXPECT_TRUE(is_null);
+    /* error handling */
+    EXPECT_FALSE(oc_rep_is_null(NULL, "nothing", &is_null));
+    EXPECT_FALSE(oc_rep_is_null(rep, NULL, &is_null));
+    EXPECT_FALSE(oc_rep_is_null(rep, "nothing", NULL));
+    EXPECT_FALSE(oc_rep_is_null(rep, "not_the_key", &is_null));
+
+    char *json;
+    size_t json_size;
+    json_size = oc_rep_to_json(rep, NULL, 0, false);
+    json = (char *)malloc(json_size + 1);
+    oc_rep_to_json(rep, json, json_size + 1, false);
+    EXPECT_STREQ("{\"nothing\":null}", json);
+    free(json);
+    json = NULL;
+    json_size = oc_rep_to_json(rep, NULL, 0, true);
+    json = (char *)malloc(json_size + 1);
+    oc_rep_to_json(rep, json, json_size + 1, true);
+    EXPECT_STREQ("{\n  \"nothing\" : null\n}\n", json);
+    free(json);
+    json = NULL;
+
+    oc_free_rep(rep);
+}
+
 TEST(TestRep, OCRepSetGetDouble)
 {
 

--- a/include/oc_rep.h
+++ b/include/oc_rep.h
@@ -1086,7 +1086,7 @@ void oc_free_rep(oc_rep_t *rep);
  *
  * @param rep oc_rep_t to check for null value
  * @param key the key name for the null value
- * @param value the return null check value
+ * @param is_null the return null check value
  *
  * @return true if key and value are found and returned.
  *

--- a/include/oc_rep.h
+++ b/include/oc_rep.h
@@ -142,6 +142,8 @@ CborError oc_rep_encoder_create_array(CborEncoder *encoder,
 CborError oc_rep_encode_floating_point(CborEncoder *encoder, CborType fpType,
                                        const void *value);
 
+CborError oc_rep_encode_null(CborEncoder *encoder);
+
 /**
  * Get a pointer to the cbor object with the given `name`
  *

--- a/include/oc_rep.h
+++ b/include/oc_rep.h
@@ -329,7 +329,7 @@ CborError oc_rep_encode_null(CborEncoder *encoder);
  *     oc_rep_end_root_object();
  * ~~~
  *
- * @see oc_rep_is_nul
+ * @see oc_rep_is_null
  */
 #define oc_rep_set_null(object, key)                                           \
   do {                                                                         \

--- a/include/oc_rep.h
+++ b/include/oc_rep.h
@@ -313,6 +313,31 @@ CborError oc_rep_encode_null(CborEncoder *encoder);
   } while (0)
 
 /**
+ * Add an null `value` to the cbor `object` under the `key` name
+ * Example:
+ *
+ * To build the an object with the following cbor value
+ *
+ *     {
+ *       "nothing": null
+ *     }
+ *
+ * The following code could be used:
+ * ~~~{.c}
+ *     oc_rep_begin_root_object();
+ *     oc_rep_set_null(root, nothing);
+ *     oc_rep_end_root_object();
+ * ~~~
+ *
+ * @see oc_rep_is_nul
+ */
+#define oc_rep_set_null(object, key)                                           \
+  do {                                                                         \
+    g_err |= oc_rep_encode_text_string(&object##_map, #key, strlen(#key));     \
+    g_err |= oc_rep_encode_null(&object##_map);                                \
+  } while (0)
+
+/**
  * This macro has been replaced with oc_rep_begin_array
  *
  * @see oc_rep_start_array
@@ -1047,6 +1072,27 @@ int oc_parse_rep(const uint8_t *payload, int payload_size,
                  oc_rep_t **value_list);
 
 void oc_free_rep(oc_rep_t *rep);
+
+/**
+ * Check for a null value from an `oc_rep_t`
+ *
+ * Example:
+ * ~~~{.c}
+ *         bool is_null = false;
+ *         if( true == oc_rep_is_null(rep, "nothing", &is_null)) {
+ *             printf("Nothing is: %s\n", is_null ? "null": "not null");
+ *         }
+ * ~~~
+ *
+ * @param rep oc_rep_t to check for null value
+ * @param key the key name for the null value
+ * @param value the return null check value
+ *
+ * @return true if key and value are found and returned.
+ *
+ * @see oc_rep_set_null
+ */
+bool oc_rep_is_null(oc_rep_t *rep, const char *key, bool *is_null);
 
 /**
  * Read an integer from an `oc_rep_t`


### PR DESCRIPTION
Add missing functions to encode a OC_REP_NIL value type to CborNullType.