### PR TITLE
Fix compilation with custom OC_WRN definition

### DIFF
--- a/api/oc_rep.c
+++ b/api/oc_rep.c
@@ -216,14 +216,13 @@ oc_rep_get_encoded_payload_size(void)
 {
   convert_offset_to_ptr(&g_encoder);
   size_t size = cbor_encoder_get_buffer_size(&g_encoder, g_buf);
-#ifdef OC_DEBUG
   size_t needed = cbor_encoder_get_extra_bytes_needed(&g_encoder);
-#endif
   convert_ptr_to_offset(&g_encoder);
   if (g_err == CborErrorOutOfMemory) {
     OC_WRN("Insufficient memory: Increase OC_MAX_APP_DATA_SIZE to "
            "accomodate a larger payload(+%d)",
            (int)needed);
+    (void)needed;
   }
   if (g_err != CborNoError)
     return -1;


### PR DESCRIPTION
@JonasAnderssonn this was the simplest solution to your problem, but it's a bit fragile. If anybody adds a similar log you'll have the same problem again (how did you manage to sneak a custom `OC_WRN` past the compiler anyway? I guess you're compiling on a platform without `-Werror`).

@jkralik maybe we could add a new macro - `OC_LOG_CUSTOM` or something like that and when it is defined then in oc_log.h no `OC_LOG*` macros are defined and the implementer must provide definitions in a prefix header.