### PR TITLE
Update github workflow for Windows

### DIFF
--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -1,6 +1,6 @@
 name: CMake Windows
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
@@ -20,7 +20,7 @@ jobs:
             name: "Windows Latest MSVC", artifact: "Windows-MSVC.tar.xz",
             os: windows-latest,
             build_type: "Release", cc: "cl", cxx: "cl",
-            environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat"
+            environment_script: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat"
           }
         #- {
         #    name: "Windows Latest MinGW", artifact: "Windows-MinGW.tar.xz",
@@ -48,7 +48,7 @@ jobs:
       run: |
         set(ninja_version "1.9.0")
         set(cmake_version "3.16.2")
-        
+
         message(STATUS "Using host CMake version: ${CMAKE_VERSION}")
 
         if ("${{ runner.os }}" STREQUAL "Windows")
@@ -91,10 +91,15 @@ jobs:
         set(ENV{CXX} ${{ matrix.config.cxx }})
 
         if ("${{ runner.os }}" STREQUAL "Windows" AND NOT "x${{ matrix.config.environment_script }}" STREQUAL "x")
+          message(STATUS "Set Windows environment")
           execute_process(
             COMMAND "${{ matrix.config.environment_script }}" && set
             OUTPUT_FILE environment_script_output.txt
+            RESULT_VARIABLE result
           )
+          if (NOT result EQUAL 0)
+            message(FATAL_ERROR "Bad exit status")
+          endif()
           file(STRINGS environment_script_output.txt output_lines)
           foreach(line IN LISTS output_lines)
             if (line MATCHES "^([a-zA-Z0-9_-]+)=(.*)$")
@@ -105,6 +110,7 @@ jobs:
 
         file(TO_CMAKE_PATH "$ENV{GITHUB_WORKSPACE}/ninja" ninja_program)
 
+        message(STATUS "Create Ninja build system")
         execute_process(
           COMMAND ${{ steps.cmake_and_ninja.outputs.cmake_dir }}/cmake
             -S .


### PR DESCRIPTION
Virtual environment windows-latest now defaults to windows-2022. Update workflows to work with this new environment.