### PR TITLE
Fix cloud registration during initialization

### DIFF
--- a/api/cloud/oc_cloud.c
+++ b/api/cloud/oc_cloud.c
@@ -409,7 +409,7 @@ oc_cloud_shutdown(void)
     if (ctx) {
       cloud_rd_deinit(ctx);
       cloud_manager_stop(ctx);
-      cloud_store_deinit(&ctx->store);
+      cloud_store_initialize(&ctx->store);
       cloud_close_endpoint(ctx->cloud_ep);
       oc_free_endpoint(ctx->cloud_ep);
       oc_list_remove(cloud_context_list, ctx);

--- a/api/cloud/oc_cloud_apis.c
+++ b/api/cloud/oc_cloud_apis.c
@@ -246,7 +246,7 @@ cloud_deregistered_internal(oc_client_response_t *data)
     ctx->store.status |= OC_CLOUD_FAILURE;
   }
 
-  ctx->store.cps = OC_CPS_READYTOREGISTER;
+  ctx->store.cps = OC_CPS_UNINITIALIZED;
 
   if (p->cb) {
     p->cb(ctx, ctx->store.status, p->data);

--- a/api/cloud/oc_cloud_internal.h
+++ b/api/cloud/oc_cloud_internal.h
@@ -76,7 +76,6 @@ void cloud_close_endpoint(oc_endpoint_t *cloud_ep);
 void cloud_store_dump_async(const oc_cloud_store_t *store);
 void cloud_store_load(oc_cloud_store_t *store);
 void cloud_store_dump(const oc_cloud_store_t *store);
-void cloud_store_deinit(oc_cloud_store_t *store);
 void cloud_store_initialize(oc_cloud_store_t *store);
 void cloud_manager_cb(oc_cloud_context_t *ctx);
 void cloud_set_string(oc_string_t *dst, const char *data, size_t len);

--- a/api/cloud/oc_cloud_manager.c
+++ b/api/cloud/oc_cloud_manager.c
@@ -28,6 +28,7 @@
 #include "util/oc_list.h"
 #include "util/oc_memb.h"
 #ifdef OC_SECURITY
+#include "security/oc_pstat.h"
 #include "security/oc_tls.h"
 #endif /* OC_SECURITY */
 #include <stdint.h>
@@ -122,6 +123,11 @@ cloud_start_process(oc_cloud_context_t *ctx)
 {
   ctx->retry_count = 0;
   ctx->retry_refresh_token_count = 0;
+
+  oc_sec_pstat_t *pstat = oc_sec_get_pstat(ctx->device);
+  if (pstat->s != OC_DOS_RFNOP && pstat->s != OC_DOS_RFPRO) {
+    return;
+  }
 
   if (ctx->store.status == OC_CLOUD_INITIALIZED &&
       ctx->store.cps == OC_CPS_READYTOREGISTER) {

--- a/api/cloud/oc_cloud_manager.c
+++ b/api/cloud/oc_cloud_manager.c
@@ -124,10 +124,12 @@ cloud_start_process(oc_cloud_context_t *ctx)
   ctx->retry_count = 0;
   ctx->retry_refresh_token_count = 0;
 
+#ifdef OC_SECURITY
   oc_sec_pstat_t *pstat = oc_sec_get_pstat(ctx->device);
   if (pstat->s != OC_DOS_RFNOP && pstat->s != OC_DOS_RFPRO) {
     return;
   }
+#endif
 
   if (ctx->store.status == OC_CLOUD_INITIALIZED &&
       ctx->store.cps == OC_CPS_READYTOREGISTER) {

--- a/api/cloud/oc_cloud_manager.c
+++ b/api/cloud/oc_cloud_manager.c
@@ -123,7 +123,8 @@ cloud_start_process(oc_cloud_context_t *ctx)
   ctx->retry_count = 0;
   ctx->retry_refresh_token_count = 0;
 
-  if (ctx->store.status == OC_CLOUD_INITIALIZED) {
+  if (ctx->store.status == OC_CLOUD_INITIALIZED &&
+      ctx->store.cps == OC_CPS_READYTOREGISTER) {
     reset_delayed_callback(ctx, cloud_register, message_timeout[0]);
   } else if (ctx->store.status & OC_CLOUD_REGISTERED) {
     if (cloud_is_permanent_access_token(ctx->store.expires_in)) {

--- a/api/cloud/oc_cloud_store.c
+++ b/api/cloud/oc_cloud_store.c
@@ -244,19 +244,6 @@ cloud_store_decode(oc_rep_t *rep, oc_cloud_store_t *store)
   return 0;
 }
 
-void
-cloud_store_deinit(oc_cloud_store_t *store)
-{
-  cloud_set_string(&store->ci_server, NULL, 0);
-  cloud_set_string(&store->auth_provider, NULL, 0);
-  cloud_set_string(&store->uid, NULL, 0);
-  cloud_set_string(&store->access_token, NULL, 0);
-  cloud_set_string(&store->refresh_token, NULL, 0);
-  cloud_set_string(&store->sid, NULL, 0);
-  store->status = 0;
-  store->expires_in = 0;
-}
-
 static int
 cloud_store_load_internal(const char *store_name, oc_cloud_store_t *store)
 {

--- a/api/cloud/oc_cloud_store.c
+++ b/api/cloud/oc_cloud_store.c
@@ -313,7 +313,7 @@ cloud_store_initialize(oc_cloud_store_t *store)
   cloud_set_string(&store->uid, NULL, 0);
   cloud_set_string(&store->access_token, NULL, 0);
   cloud_set_string(&store->refresh_token, NULL, 0);
-  cloud_set_string(&store->sid, "00000000-0000-0000-0000-000000000000", 36);
+  cloud_set_string(&store->sid, NULL, 0);
   store->status = 0;
   store->expires_in = 0;
 }

--- a/api/cloud/oc_cloud_store.c
+++ b/api/cloud/oc_cloud_store.c
@@ -308,7 +308,7 @@ cloud_store_load_internal(const char *store_name, oc_cloud_store_t *store)
 void
 cloud_store_initialize(oc_cloud_store_t *store)
 {
-  cloud_set_string(&store->ci_server, "coaps+tcp://127.0.0.1", 21);
+  cloud_set_string(&store->ci_server, NULL, 0);
   cloud_set_string(&store->auth_provider, NULL, 0);
   cloud_set_string(&store->uid, NULL, 0);
   cloud_set_string(&store->access_token, NULL, 0);


### PR DESCRIPTION
I noticed that during the initialization of the cloud manager it tries to register to a cloud ([cloud_register](https://github.com/iotivity/iotivity-lite/blob/master/api/cloud/oc_cloud_manager.c#L295) is called), even though there is no cloud configuration stored.

Eventually this leads to the `cps` property of the `/CoapCloudConfResURI` to change to `OC_CPS_FAILED`.

@jkralik proposed to initialize the `cis` property with NULL (instead of "coaps+tcp://127.0.0.1") to fix the issue, but that wasn't enough. I noticed that now `cloud_store_initialize` is basically a duplicate of `cloud_store_deinit`, so I removed `cloud_store_deinit` along the way.

To fix the issue, I added a check `ctx->store.cps == OC_CPS_READYTOREGISTER` in `cloud_start_process` to prevent the call of `cloud_register` during initialization. To make sure that this check does not pass erroneously, I set the `cps` to `OC_CPS_UNINITIALIZED` when the device was deregistered.