### PR TITLE
fixing csr buffer and enforce psk length during add

### DIFF
--- a/security/oc_csr.c
+++ b/security/oc_csr.c
@@ -29,9 +29,9 @@ get_csr(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
 
   size_t device = request->resource->device;
 
-  unsigned char csr[4096];
+  unsigned char csr[512];
 
-  int ret = oc_certs_generate_csr(device, csr, OC_PDU_SIZE);
+  int ret = oc_certs_generate_csr(device, csr, sizeof(csr));
   if (ret != 0) {
     oc_send_response(request, OC_STATUS_INTERNAL_SERVER_ERROR);
     return;

--- a/security/oc_tls.c
+++ b/security/oc_tls.c
@@ -637,9 +637,11 @@ get_psk_cb(void *data, mbedtls_ssl_context *ssl, const unsigned char *identity,
       OC_DBG("oc_tls: Found peer credential");
       memcpy(peer->uuid.id, identity, 16);
       OC_DBG("oc_tls: Setting the key:");
-      OC_LOGbytes(oc_string(cred->privatedata.data), 16);
-      if (mbedtls_ssl_set_hs_psk(
-            ssl, oc_cast(cred->privatedata.data, const uint8_t), 16) != 0) {
+      OC_LOGbytes(oc_string(cred->privatedata.data),
+                  oc_string_len(cred->privatedata.data));
+      if (mbedtls_ssl_set_hs_psk(ssl,
+                                 oc_cast(cred->privatedata.data, const uint8_t),
+                                 oc_string_len(cred->privatedata.data)) != 0) {
         return -1;
       }
       OC_DBG("oc_tls: Set peer credential to SSL handle");


### PR DESCRIPTION
- possible override stack in CSR
- enforce PSK length according [specification](https://openconnectivity.org/specs/OCF_Security_Specification_v2.2.5.pdf) - 13.3.3.1 Symmetric key formatting