### PR TITLE
Add public function to parse ACLs

### DIFF
--- a/include/oc_acl.h
+++ b/include/oc_acl.h
@@ -19,9 +19,13 @@
 #ifndef OC_ACL_COMMON_H
 #define OC_ACL_COMMON_H
 
+#include "oc_export.h"
 #include "oc_ri.h"
 #include "oc_uuid.h"
 #include "util/oc_list.h"
+
+#include <stdbool.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -122,6 +126,42 @@ typedef struct oc_sec_ace_t
   int aceid;                          ///< ACE identifier
   oc_ace_permissions_t permission;    ///< permissions
 } oc_sec_ace_t;
+
+/**
+ * @brief Get access control list of device
+ *
+ * @param device Index of the device
+ * @return oc_sec_creds_t* Access control list
+ */
+OC_API
+oc_sec_acl_t *oc_sec_get_acl(size_t device);
+
+/**
+ * @brief Callback invoked with a created / updated access control entry
+ *
+ * @param rowneruuid Uuid of the resource owner
+ * @param ace New or updated access control entry
+ * @param user_data User data passed from the caller
+ */
+typedef void (*oc_sec_on_apply_acl_cb_t)(oc_uuid_t rowneruuid,
+                                         oc_sec_ace_t *ace, void *user_data);
+
+/**
+ * @brief Parse payload and add/update access control list
+ *
+ * @param rep Payload to parse
+ * @param device Index of the device
+ * @param dumpToStorage Dump the parsed credentials to storage
+ * @param on_apply_ace_cb Callback invoked when a new access control entry is
+ * added or updated
+ * @param on_apply_ace_data User data passed to the on_apply_ace_cb function
+ * @return int -1 On failure
+ * @return int 0 Payload was successfully parsed
+ */
+OC_API
+int oc_sec_apply_acl(oc_rep_t *rep, size_t device, bool dumpToStorage,
+                     oc_sec_on_apply_acl_cb_t on_apply_ace_cb,
+                     void *on_apply_ace_data);
 
 #ifdef __cplusplus
 }

--- a/security/oc_acl_internal.h
+++ b/security/oc_acl_internal.h
@@ -31,11 +31,12 @@ extern "C" {
 
 void oc_sec_acl_init(void);
 void oc_sec_acl_free(void);
-oc_sec_acl_t *oc_sec_get_acl(size_t device);
 void oc_sec_acl_default(size_t device);
 bool oc_sec_encode_acl(size_t device, oc_interface_mask_t iface_mask,
                        bool to_storage);
-bool oc_sec_decode_acl(oc_rep_t *rep, bool from_storage, size_t device);
+bool oc_sec_decode_acl(oc_rep_t *rep, bool from_storage, size_t device,
+                       oc_sec_on_apply_acl_cb_t on_apply_ace_cb,
+                       void *on_apply_ace_data);
 void oc_sec_acl_init(void);
 void post_acl(oc_request_t *request, oc_interface_mask_t iface_mask,
               void *data);

--- a/security/oc_store.c
+++ b/security/oc_store.c
@@ -362,7 +362,7 @@ oc_sec_load_acl(size_t device)
 #endif /* OC_DYNAMIC_ALLOCATION */
     oc_rep_set_pool(&rep_objects);
     oc_parse_rep(oc_store_buf, (int)ret, &rep);
-    oc_sec_decode_acl(rep, true, device);
+    oc_sec_decode_acl(rep, true, device, NULL, NULL);
     oc_free_rep(rep);
   }
 #ifndef OC_APP_DATA_STORAGE_BUFFER


### PR DESCRIPTION
Add oc_sec_apply_acl function to add ACLs to device by parsing them from a payload retrieved from some endpoint.