### PR TITLE
security: simplify public API

### DIFF
--- a/include/oc_acl.h
+++ b/include/oc_acl.h
@@ -151,7 +151,6 @@ typedef void (*oc_sec_on_apply_acl_cb_t)(oc_uuid_t rowneruuid,
  *
  * @param rep Payload to parse
  * @param device Index of the device
- * @param dumpToStorage Dump the parsed credentials to storage
  * @param on_apply_ace_cb Callback invoked when a new access control entry is
  * added or updated
  * @param on_apply_ace_data User data passed to the on_apply_ace_cb function
@@ -159,7 +158,7 @@ typedef void (*oc_sec_on_apply_acl_cb_t)(oc_uuid_t rowneruuid,
  * @return int 0 Payload was successfully parsed
  */
 OC_API
-int oc_sec_apply_acl(oc_rep_t *rep, size_t device, bool dumpToStorage,
+int oc_sec_apply_acl(oc_rep_t *rep, size_t device,
                      oc_sec_on_apply_acl_cb_t on_apply_ace_cb,
                      void *on_apply_ace_data);
 

--- a/include/oc_cred.h
+++ b/include/oc_cred.h
@@ -178,7 +178,6 @@ typedef void (*oc_sec_on_apply_cred_cb_t)(oc_sec_cred_t *cred, void *user_data);
  * @param rep payload to parse
  * @param resource resource of the credentials
  * @param endpoint endpoint of the credentials owner
- * @param dumpToStorage dump the parsed credentials to storage
  * @param on_apply_cred_cb callback invoked when a new credential is added or
  * updated
  * @param on_apply_cred_data user data passed to the on_apply_cred_cb function
@@ -187,7 +186,7 @@ typedef void (*oc_sec_on_apply_cred_cb_t)(oc_sec_cred_t *cred, void *user_data);
  */
 OC_API
 int oc_sec_apply_cred(oc_rep_t *rep, oc_resource_t *resource,
-                      oc_endpoint_t *endpoint, bool dumpToStorage,
+                      oc_endpoint_t *endpoint,
                       oc_sec_on_apply_cred_cb_t on_apply_cred_cb,
                       void *on_apply_cred_data);
 

--- a/security/oc_acl.c
+++ b/security/oc_acl.c
@@ -1135,15 +1135,12 @@ oc_sec_acl_add_bootsrap_acl(size_t device)
 }
 
 int
-oc_sec_apply_acl(oc_rep_t *rep, size_t device, bool dumpToStorage,
+oc_sec_apply_acl(oc_rep_t *rep, size_t device,
                  oc_sec_on_apply_acl_cb_t on_apply_ace_cb,
                  void *on_apply_ace_data)
 {
   if (oc_sec_decode_acl(rep, false, device, on_apply_ace_cb,
                         on_apply_ace_data)) {
-    if (dumpToStorage) {
-      oc_sec_dump_acl(device);
-    }
     return 0;
   }
   return -1;

--- a/security/oc_cred.c
+++ b/security/oc_cred.c
@@ -1384,7 +1384,7 @@ delete_cred(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
 
 int
 oc_sec_apply_cred(oc_rep_t *rep, oc_resource_t *resource,
-                  oc_endpoint_t *endpoint, bool dumpToStorage,
+                  oc_endpoint_t *endpoint,
                   oc_sec_on_apply_cred_cb_t on_apply_cred_cb,
                   void *on_apply_cred_data)
 {
@@ -1449,9 +1449,6 @@ oc_sec_apply_cred(oc_rep_t *rep, oc_resource_t *resource,
     }
     return -1;
   }
-  if (dumpToStorage) {
-    oc_sec_dump_cred(resource->device);
-  }
   return 0;
 }
 
@@ -1462,7 +1459,7 @@ post_cred(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
   (void)data;
 
   bool success = oc_sec_apply_cred(request->request_payload, request->resource,
-                                   request->origin, /*dumpToStorage*/ false,
+                                   request->origin,
                                    /*on_apply_cred_cb*/ NULL,
                                    /*on_apply_cred_data*/ NULL) == 0;
 


### PR DESCRIPTION
Remove dumpToStorage parameters from oc_sec_apply_acl and
oc_sec_apply_cred function. The dump to storage functions
\- oc_sec_dump_acl and oc_sec_dump_cred \- are public and
thus can be invoked directly by the caller.