### PR TITLE
Update swupdate resource

### DIFF
--- a/api/oc_core_res.c
+++ b/api/oc_core_res.c
@@ -728,7 +728,7 @@ oc_core_get_resource_by_uri(const char *uri, size_t device)
   }
 #endif /* OC_SECURITY */
 #ifdef OC_SOFTWARE_UPDATE
-  else if ((strlen(uri) - skip) == 7 && memcmp(uri + skip, "oc/swu", 7) == 0) {
+  else if ((strlen(uri) - skip) == 6 && memcmp(uri + skip, "oc/swu", 6) == 0) {
     type = OCF_SW_UPDATE;
   }
 #endif /* OC_SOFTWARE_UPDATE */

--- a/api/oc_core_res.c
+++ b/api/oc_core_res.c
@@ -728,7 +728,7 @@ oc_core_get_resource_by_uri(const char *uri, size_t device)
   }
 #endif /* OC_SECURITY */
 #ifdef OC_SOFTWARE_UPDATE
-  else if ((strlen(uri) - skip) == 2 && memcmp(uri + skip, "sw", 2) == 0) {
+  else if ((strlen(uri) - skip) == 7 && memcmp(uri + skip, "oic/swu", 7) == 0) {
     type = OCF_SW_UPDATE;
   }
 #endif /* OC_SOFTWARE_UPDATE */

--- a/api/oc_core_res.c
+++ b/api/oc_core_res.c
@@ -728,7 +728,7 @@ oc_core_get_resource_by_uri(const char *uri, size_t device)
   }
 #endif /* OC_SECURITY */
 #ifdef OC_SOFTWARE_UPDATE
-  else if ((strlen(uri) - skip) == 7 && memcmp(uri + skip, "oic/swu", 7) == 0) {
+  else if ((strlen(uri) - skip) == 7 && memcmp(uri + skip, "oc/swu", 7) == 0) {
     type = OCF_SW_UPDATE;
   }
 #endif /* OC_SOFTWARE_UPDATE */

--- a/api/oc_swupdate.c
+++ b/api/oc_swupdate.c
@@ -508,10 +508,6 @@ post_sw(oc_request_t *request, oc_interface_mask_t interfaces, void *user_data)
     if (oc_string_len(rep->name) == 4 &&
         memcmp(oc_string(rep->name), "purl", 4) == 0) {
       if (rep->type != OC_REP_STRING) {
-
-        error_state = true;
-      }
-      if (oc_string_len(rep->value.string) >= 63) {
         error_state = true;
       }
       purl = oc_string(rep->value.string);

--- a/api/oc_swupdate.c
+++ b/api/oc_swupdate.c
@@ -179,15 +179,13 @@ oc_swupdate_notify_new_version_available(size_t device, const char *version,
   oc_new_string(&s->nv, version, strlen(version));
   s->swupdatestate = OC_SWUPDATE_STATE_NSA;
   s->swupdateresult = result;
-  if(result != OC_SWUPDATE_RESULT_SUCCESS)
-  {
+  if(result != OC_SWUPDATE_RESULT_SUCCESS) {
     s->swupdateaction = OC_SWUPDATE_IDLE;
   }
 #ifdef OC_SERVER
   oc_notify_observers(oc_core_get_resource_by_index(OCF_SW_UPDATE, device));
 #endif /* OC_SERVER */
-  if(result == OC_SWUPDATE_RESULT_SUCCESS)
-  {
+  if(result == OC_SWUPDATE_RESULT_SUCCESS) {
     oc_swupdate_perform_action(OC_SWUPDATE_ISVV, device);
   }
 }
@@ -208,15 +206,13 @@ oc_swupdate_notify_downloaded(size_t device, const char *version,
 #endif /* OC_SERVER */
   s->swupdatestate = OC_SWUPDATE_STATE_SVA;
   s->swupdateresult = result;
-  if(result != OC_SWUPDATE_RESULT_SUCCESS)
-  {
+  if(result != OC_SWUPDATE_RESULT_SUCCESS) {
     s->swupdateaction = OC_SWUPDATE_IDLE;
   }
 #ifdef OC_SERVER
   oc_notify_observers(oc_core_get_resource_by_index(OCF_SW_UPDATE, device));
 #endif /* OC_SERVER */
-  if(result == OC_SWUPDATE_RESULT_SUCCESS)
-  {
+  if(result == OC_SWUPDATE_RESULT_SUCCESS) {
     oc_swupdate_perform_action(OC_SWUPDATE_UPGRADE, device);
   }
 }
@@ -529,7 +525,7 @@ post_swu(oc_request_t *request, oc_interface_mask_t interfaces, void *user_data)
       }
       action = str_to_action(oc_string(rep->value.string));
       if(action > OC_SWUPDATE_UPGRADE) {
-          error_state = true;
+        error_state = true;
       }
     }
     if (oc_string_len(rep->name) == 14 &&
@@ -564,7 +560,8 @@ post_swu(oc_request_t *request, oc_interface_mask_t interfaces, void *user_data)
     rep = rep->next;
   }
 
-  if (!error_state && purl && (!cb || !cb->validate_purl || (cb->validate_purl(purl) < 0))) {
+  if (!error_state && purl &&
+      (!cb || !cb->validate_purl || (cb->validate_purl(purl) < 0))) {
     error_state = true;
   }
   if (action != OC_SWUPDATE_IDLE && action <= OC_SWUPDATE_UPGRADE && !ut) {
@@ -611,8 +608,8 @@ oc_create_swupdate_resource(size_t device)
 {
   oc_core_populate_resource(OCF_SW_UPDATE, device, "oic/swu",
                             OC_IF_RW | OC_IF_BASELINE, OC_IF_RW,
-                            OC_SECURE | OC_DISCOVERABLE | OC_OBSERVABLE, get_swu,
-                            0, post_swu, 0, 1, "oic.r.softwareupdate");
+                            OC_SECURE | OC_DISCOVERABLE | OC_OBSERVABLE,
+                            get_swu, 0, post_swu, 0, 1, "oic.r.softwareupdate");
 }
 #else  /* OC_SOFTWARE_UPDATE */
 typedef int dummy_declaration;

--- a/api/oc_swupdate.c
+++ b/api/oc_swupdate.c
@@ -230,6 +230,7 @@ oc_swupdate_notify_done(size_t device, oc_swupdate_result_t result)
 {
   oc_sec_pstat_set_current_mode(device, 0);
   oc_swupdate_t *s = &sw[device];
+  oc_free_string(&s->nv);
   s->swupdateaction = OC_SWUPDATE_IDLE;
   s->swupdatestate = OC_SWUPDATE_STATE_IDLE;
   s->swupdateresult = result;

--- a/api/oc_swupdate.c
+++ b/api/oc_swupdate.c
@@ -471,7 +471,7 @@ oc_swupdate_decode(oc_rep_t *rep, size_t device)
 }
 
 /**
- * post method for "/sw" resource.
+ * post method for "/oic/swu" resource.
  * The function has as input the request body, which are the input values of the
  * POST method.
  * The input values (as a set) are checked if all supplied values are correct.
@@ -483,7 +483,7 @@ oc_swupdate_decode(oc_rep_t *rep, size_t device)
  * @param requestRep the request representation.
  */
 static void
-post_sw(oc_request_t *request, oc_interface_mask_t interfaces, void *user_data)
+post_swu(oc_request_t *request, oc_interface_mask_t interfaces, void *user_data)
 {
   (void)interfaces;
   (void)user_data;
@@ -586,7 +586,7 @@ post_sw(oc_request_t *request, oc_interface_mask_t interfaces, void *user_data)
 }
 
 /**
- * get method for "/sw" resource.
+ * get method for "/oic/swu" resource.
  * function is called to intialize the return values of the GET method.
  * initialisation of the returned values are done from the global property
  * values.
@@ -599,7 +599,7 @@ post_sw(oc_request_t *request, oc_interface_mask_t interfaces, void *user_data)
  */
 
 static void
-get_sw(oc_request_t *request, oc_interface_mask_t interfaces, void *user_data)
+get_swu(oc_request_t *request, oc_interface_mask_t interfaces, void *user_data)
 {
   (void)user_data;
   oc_swupdate_encode(interfaces, request->resource->device);
@@ -609,10 +609,10 @@ get_sw(oc_request_t *request, oc_interface_mask_t interfaces, void *user_data)
 void
 oc_create_swupdate_resource(size_t device)
 {
-  oc_core_populate_resource(OCF_SW_UPDATE, device, "sw",
+  oc_core_populate_resource(OCF_SW_UPDATE, device, "oic/swu",
                             OC_IF_RW | OC_IF_BASELINE, OC_IF_RW,
-                            OC_SECURE | OC_DISCOVERABLE | OC_OBSERVABLE, get_sw,
-                            0, post_sw, 0, 1, "oic.r.softwareupdate");
+                            OC_SECURE | OC_DISCOVERABLE | OC_OBSERVABLE, get_swu,
+                            0, post_swu, 0, 1, "oic.r.softwareupdate");
 }
 #else  /* OC_SOFTWARE_UPDATE */
 typedef int dummy_declaration;

--- a/api/oc_swupdate.c
+++ b/api/oc_swupdate.c
@@ -172,10 +172,11 @@ void
 oc_swupdate_notify_new_version_available(size_t device, const char *version,
                                          oc_swupdate_result_t result)
 {
-  (void)version;
   OC_DBG("new software version %s available for device %zd", version, device);
   oc_sec_pstat_set_current_mode(device, OC_DPM_NSA);
   oc_swupdate_t *s = &sw[device];
+  oc_free_string(&s->nv);
+  oc_new_string(&s->nv, version, strlen(version));
   s->swupdatestate = OC_SWUPDATE_STATE_NSA;
   s->swupdateresult = result;
 #ifdef OC_SERVER

--- a/api/oc_swupdate.c
+++ b/api/oc_swupdate.c
@@ -179,13 +179,13 @@ oc_swupdate_notify_new_version_available(size_t device, const char *version,
   oc_new_string(&s->nv, version, strlen(version));
   s->swupdatestate = OC_SWUPDATE_STATE_NSA;
   s->swupdateresult = result;
-  if(result != OC_SWUPDATE_RESULT_SUCCESS) {
+  if (result != OC_SWUPDATE_RESULT_SUCCESS) {
     s->swupdateaction = OC_SWUPDATE_IDLE;
   }
 #ifdef OC_SERVER
   oc_notify_observers(oc_core_get_resource_by_index(OCF_SW_UPDATE, device));
 #endif /* OC_SERVER */
-  if(result == OC_SWUPDATE_RESULT_SUCCESS) {
+  if (result == OC_SWUPDATE_RESULT_SUCCESS) {
     oc_swupdate_perform_action(OC_SWUPDATE_ISVV, device);
   }
 }
@@ -206,13 +206,13 @@ oc_swupdate_notify_downloaded(size_t device, const char *version,
 #endif /* OC_SERVER */
   s->swupdatestate = OC_SWUPDATE_STATE_SVA;
   s->swupdateresult = result;
-  if(result != OC_SWUPDATE_RESULT_SUCCESS) {
+  if (result != OC_SWUPDATE_RESULT_SUCCESS) {
     s->swupdateaction = OC_SWUPDATE_IDLE;
   }
 #ifdef OC_SERVER
   oc_notify_observers(oc_core_get_resource_by_index(OCF_SW_UPDATE, device));
 #endif /* OC_SERVER */
-  if(result == OC_SWUPDATE_RESULT_SUCCESS) {
+  if (result == OC_SWUPDATE_RESULT_SUCCESS) {
     oc_swupdate_perform_action(OC_SWUPDATE_UPGRADE, device);
   }
 }
@@ -524,7 +524,7 @@ post_swu(oc_request_t *request, oc_interface_mask_t interfaces, void *user_data)
         error_state = true;
       }
       action = str_to_action(oc_string(rep->value.string));
-      if(action > OC_SWUPDATE_UPGRADE) {
+      if (action > OC_SWUPDATE_UPGRADE) {
         error_state = true;
       }
     }

--- a/api/oc_swupdate.c
+++ b/api/oc_swupdate.c
@@ -527,10 +527,10 @@ post_sw(oc_request_t *request, oc_interface_mask_t interfaces, void *user_data)
       if (rep->type != OC_REP_STRING) {
         error_state = true;
       }
-      if (oc_string_len(rep->value.string) >= 63) {
-        error_state = true;
-      }
       action = str_to_action(oc_string(rep->value.string));
+      if(action > OC_SWUPDATE_UPGRADE) {
+          error_state = true;
+      }
     }
     if (oc_string_len(rep->name) == 14 &&
         memcmp(oc_string(rep->name), "swupdateresult", 14) == 0) {

--- a/api/oc_swupdate.c
+++ b/api/oc_swupdate.c
@@ -467,7 +467,7 @@ oc_swupdate_decode(oc_rep_t *rep, size_t device)
 }
 
 /**
- * post method for "/oic/swu" resource.
+ * post method for "/oc/swu" resource.
  * The function has as input the request body, which are the input values of the
  * POST method.
  * The input values (as a set) are checked if all supplied values are correct.
@@ -583,7 +583,7 @@ post_swu(oc_request_t *request, oc_interface_mask_t interfaces, void *user_data)
 }
 
 /**
- * get method for "/oic/swu" resource.
+ * get method for "/oc/swu" resource.
  * function is called to intialize the return values of the GET method.
  * initialisation of the returned values are done from the global property
  * values.
@@ -606,7 +606,7 @@ get_swu(oc_request_t *request, oc_interface_mask_t interfaces, void *user_data)
 void
 oc_create_swupdate_resource(size_t device)
 {
-  oc_core_populate_resource(OCF_SW_UPDATE, device, "oic/swu",
+  oc_core_populate_resource(OCF_SW_UPDATE, device, "oc/swu",
                             OC_IF_RW | OC_IF_BASELINE, OC_IF_RW,
                             OC_SECURE | OC_DISCOVERABLE | OC_OBSERVABLE,
                             get_swu, 0, post_swu, 0, 1, "oic.r.softwareupdate");

--- a/api/oc_swupdate.c
+++ b/api/oc_swupdate.c
@@ -179,10 +179,17 @@ oc_swupdate_notify_new_version_available(size_t device, const char *version,
   oc_new_string(&s->nv, version, strlen(version));
   s->swupdatestate = OC_SWUPDATE_STATE_NSA;
   s->swupdateresult = result;
+  if(result != OC_SWUPDATE_RESULT_SUCCESS)
+  {
+    s->swupdateaction = OC_SWUPDATE_IDLE;
+  }
 #ifdef OC_SERVER
   oc_notify_observers(oc_core_get_resource_by_index(OCF_SW_UPDATE, device));
 #endif /* OC_SERVER */
-  oc_swupdate_perform_action(OC_SWUPDATE_ISVV, device);
+  if(result == OC_SWUPDATE_RESULT_SUCCESS)
+  {
+    oc_swupdate_perform_action(OC_SWUPDATE_ISVV, device);
+  }
 }
 
 void
@@ -201,10 +208,17 @@ oc_swupdate_notify_downloaded(size_t device, const char *version,
 #endif /* OC_SERVER */
   s->swupdatestate = OC_SWUPDATE_STATE_SVA;
   s->swupdateresult = result;
+  if(result != OC_SWUPDATE_RESULT_SUCCESS)
+  {
+    s->swupdateaction = OC_SWUPDATE_IDLE;
+  }
 #ifdef OC_SERVER
   oc_notify_observers(oc_core_get_resource_by_index(OCF_SW_UPDATE, device));
 #endif /* OC_SERVER */
-  oc_swupdate_perform_action(OC_SWUPDATE_UPGRADE, device);
+  if(result == OC_SWUPDATE_RESULT_SUCCESS)
+  {
+    oc_swupdate_perform_action(OC_SWUPDATE_UPGRADE, device);
+  }
 }
 
 void

--- a/api/oc_swupdate.c
+++ b/api/oc_swupdate.c
@@ -564,13 +564,10 @@ post_sw(oc_request_t *request, oc_interface_mask_t interfaces, void *user_data)
     rep = rep->next;
   }
 
-  if (action >= OC_SWUPDATE_UPGRADE || !purl || !ut) {
+  if (!error_state && purl && (!cb || !cb->validate_purl || (cb->validate_purl(purl) < 0))) {
     error_state = true;
   }
-  if (action != OC_SWUPDATE_IDLE && action <= OC_SWUPDATE_UPGRADE && !purl) {
-    error_state = true;
-  }
-  if (purl && (!cb || !cb->validate_purl || (cb->validate_purl(purl) < 0))) {
+  if (action != OC_SWUPDATE_IDLE && action <= OC_SWUPDATE_UPGRADE && !ut) {
     error_state = true;
   }
   /* if the input is ok, then process the input document and assign the global


### PR DESCRIPTION
I would like to propose some changes to the implementation of the software update resource:

- Update the `nv` property in `oc_swupdate_notify_new_version_available`
- Clear the `nv` property in `oc_swupdate_notify_done`
- Perform follow-up action only on success in `oc_swupdate_notify_*` functions, i.e. check the result from the registered implementation before performing the follow-up action automatically.
- Remove the string length restriction for `purl`: IMO 63 characters is too low.
- Allow setting the `purl` property without the need to provide `swupdateaction` and `updatetime` in request: Setting the `purl` is not a timed action, more a configuration step.
- As the software update resource is a DCR, the URL should be prefixed with `oic/` as other DCR. And IMO `swu` is a better name for the resource. @SiMet: Would this change impact the certification tests?