### PR TITLE
security: fix removing trust anchors

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -21,8 +21,9 @@ jobs:
         run: |
           sudo apt-get update -y
           sudo apt-get install -y clang-tidy
+
       - name: Build with clang-tidy
         run: |
           mkdir linuxbuild && cd linuxbuild
-          cmake -DOC_CLANG_TIDY_ENABLED=ON ..
+          cmake -DOC_IPV4_ENABLED=ON -DOC_CLANG_TIDY_ENABLED=ON -DBUILD_TESTING=OFF ..
           make all

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -544,6 +544,10 @@ if(BUILD_TESTING AND UNIX)
     if(OC_SECURITY_ENABLED)
         file(GLOB SECURITYTEST_SRC security/unittest/*.cpp)
         package_add_test(securitytest ${SECURITYTEST_SRC})
+
+        file(COPY ${PROJECT_SOURCE_DIR}/apps/pki_certs
+            DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
+        )
     endif()
 
 # Currently disabled because it hangs on TestCloudManager.cloud_manager_start_initialized_f

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,10 @@ if(OC_DNS_LOOKUP_IPV6_ENABLED)
     list(APPEND PRIVATE_COMPILE_DEFINITIONS "OC_DNS_LOOKUP_IPV6")
 endif()
 
+if(BUILD_TESTING)
+    list(APPEND PRIVATE_COMPILE_DEFINITIONS "OC_TEST")
+endif()
+
 ######## Gather source files ########
 file(GLOB COMMON_SRC
     ${PROJECT_SOURCE_DIR}/api/c-timestamp/timestamp_format.c
@@ -508,7 +512,7 @@ if(BUILD_TESTING AND UNIX)
         add_executable(${TESTNAME} ${ARGN})
         target_compile_options(${TESTNAME} PRIVATE ${TEST_COMPILE_OPTIONS})
         target_compile_features(${TESTNAME} PRIVATE cxx_nullptr)
-        target_compile_definitions(${TESTNAME} PRIVATE ${PUBLIC_COMPILE_DEFINITIONS} "OC_CLIENT" "OC_SERVER")
+        target_compile_definitions(${TESTNAME} PRIVATE ${PUBLIC_COMPILE_DEFINITIONS} "OC_CLIENT" "OC_SERVER" "OC_TEST")
         target_include_directories(${TESTNAME} SYSTEM PRIVATE ${PROJECT_SOURCE_DIR}/deps/gtest/include)
         target_include_directories(${TESTNAME} PRIVATE
             ${PROJECT_SOURCE_DIR}

--- a/security/oc_cred.c
+++ b/security/oc_cred.c
@@ -617,11 +617,11 @@ oc_sec_add_new_cred(size_t device, bool roles_resource, oc_tls_peer_t *client,
   if (cred->credtype == OC_CREDTYPE_CERT) {
     if (cred->credusage == OC_CREDUSAGE_MFG_CERT ||
         cred->credusage == OC_CREDUSAGE_IDENTITY_CERT) {
-      oc_tls_refresh_identity_certs();
+      oc_tls_add_new_identity_certs();
     }
     if (cred->credusage == OC_CREDUSAGE_MFG_TRUSTCA ||
         cred->credusage == OC_CREDUSAGE_TRUSTCA) {
-      oc_tls_refresh_trust_anchors();
+      oc_tls_add_new_trust_anchors();
     }
 #if defined(OC_PKI) && defined(OC_CLIENT)
     if (!roles_resource && credusage == OC_CREDUSAGE_ROLE_CERT &&

--- a/security/oc_cred.c
+++ b/security/oc_cred.c
@@ -192,9 +192,16 @@ oc_sec_remove_cred(oc_sec_cred_t *cred, size_t device)
   if (cred->credtype == OC_CREDTYPE_CERT) {
     if (cred->credusage != OC_CREDUSAGE_TRUSTCA &&
         cred->credusage != OC_CREDUSAGE_MFG_TRUSTCA) {
-      oc_tls_remove_identity_cert(cred);
+      if (!oc_tls_remove_identity_cert(cred)) {
+        OC_ERR(
+          "oc_cred: failed to remove identity certificate for credential(%d)",
+          cred->credid);
+      }
     } else {
-      oc_tls_remove_trust_anchor(cred);
+      if (!oc_tls_remove_trust_anchor(cred)) {
+        OC_ERR("oc_cred: failed to remove trust anchor for credential(%d)",
+               cred->credid);
+      }
     }
   }
 #endif /* OC_PKI */
@@ -617,11 +624,11 @@ oc_sec_add_new_cred(size_t device, bool roles_resource, oc_tls_peer_t *client,
   if (cred->credtype == OC_CREDTYPE_CERT) {
     if (cred->credusage == OC_CREDUSAGE_MFG_CERT ||
         cred->credusage == OC_CREDUSAGE_IDENTITY_CERT) {
-      oc_tls_add_new_identity_certs();
+      oc_tls_resolve_new_identity_certs();
     }
     if (cred->credusage == OC_CREDUSAGE_MFG_TRUSTCA ||
         cred->credusage == OC_CREDUSAGE_TRUSTCA) {
-      oc_tls_add_new_trust_anchors();
+      oc_tls_resolve_new_trust_anchors();
     }
 #if defined(OC_PKI) && defined(OC_CLIENT)
     if (!roles_resource && credusage == OC_CREDUSAGE_ROLE_CERT &&

--- a/security/oc_pki.c
+++ b/security/oc_pki.c
@@ -119,7 +119,7 @@ pki_add_intermediate_cert(size_t device, int credid, const unsigned char *cert,
 
   if (ret > 0) {
     OC_DBG("added intermediate CA cert to /oic/sec/cred");
-    oc_tls_refresh_identity_certs();
+    oc_tls_add_new_identity_certs();
     return credid;
   }
   OC_ERR("could not add intermediate CA cert to /oic/sec/cred");

--- a/security/oc_pki.c
+++ b/security/oc_pki.c
@@ -119,7 +119,7 @@ pki_add_intermediate_cert(size_t device, int credid, const unsigned char *cert,
 
   if (ret > 0) {
     OC_DBG("added intermediate CA cert to /oic/sec/cred");
-    oc_tls_add_new_identity_certs();
+    oc_tls_resolve_new_identity_certs();
     return credid;
   }
   OC_ERR("could not add intermediate CA cert to /oic/sec/cred");

--- a/security/oc_tls.c
+++ b/security/oc_tls.c
@@ -114,8 +114,10 @@ typedef struct oc_x509_cacrt_t
   mbedtls_x509_crt *cert;
 } oc_x509_cacrt_t;
 
-OC_MEMB(ca_certs_s, oc_x509_cacrt_t, OC_MAX_NUM_DEVICES);
-OC_LIST(ca_certs);
+OC_MEMB(g_ca_certs_s, oc_x509_cacrt_t, OC_MAX_NUM_DEVICES);
+OC_LIST(g_ca_certs);
+
+static mbedtls_x509_crt g_trust_anchors;
 
 typedef struct oc_x509_crt_t
 {
@@ -128,10 +130,9 @@ typedef struct oc_x509_crt_t
 } oc_x509_crt_t;
 
 #include "oc_certs.h"
-OC_MEMB(identity_certs_s, oc_x509_crt_t, 2 * OC_MAX_NUM_DEVICES);
-OC_LIST(identity_certs);
+OC_MEMB(g_identity_certs_s, oc_x509_crt_t, 2 * OC_MAX_NUM_DEVICES);
+OC_LIST(g_identity_certs);
 
-mbedtls_x509_crt trust_anchors;
 #endif /* OC_PKI */
 
 #ifndef OC_DYNAMIC_ALLOCATION
@@ -234,7 +235,7 @@ static const int cert_priority[5] = {
 mbedtls_x509_crt *
 oc_tls_get_trust_anchors(void)
 {
-  return &trust_anchors;
+  return &g_trust_anchors;
 }
 #endif /* OC_PKI */
 
@@ -413,7 +414,7 @@ oc_tls_is_pin_otm_supported(size_t device)
 bool
 oc_tls_is_cert_otm_supported(size_t device)
 {
-  oc_x509_crt_t *crt = (oc_x509_crt_t *)oc_list_head(identity_certs);
+  oc_x509_crt_t *crt = (oc_x509_crt_t *)oc_list_head(g_identity_certs);
   while (crt) {
     if (crt->device == device &&
         crt->cred->credusage == OC_CREDUSAGE_MFG_CERT) {
@@ -702,7 +703,7 @@ typedef bool (*check_if_known_cert_cb)(oc_sec_cred_t *cred);
 typedef void (*add_new_cert_cb)(oc_sec_cred_t *cred, size_t device);
 
 static void
-oc_tls_refresh_certs(oc_sec_credusage_t credusage,
+oc_tls_add_new_certs(oc_sec_credusage_t credusage,
                      check_if_known_cert_cb is_known_cert,
                      add_new_cert_cb add_new_cert)
 {
@@ -711,7 +712,7 @@ oc_tls_refresh_certs(oc_sec_credusage_t credusage,
     oc_sec_creds_t *creds = oc_sec_get_creds(device);
     oc_sec_cred_t *cred = (oc_sec_cred_t *)oc_list_head(creds->creds);
     for (; cred != NULL; cred = cred->next) {
-      /* Pick all "leaf" certficiates with matching credusage */
+      /* Pick all "leaf" certificates with matching credusage */
       if ((cred->credusage & credusage) != 0 && !cred->child) {
 
         if (is_known_cert(cred)) {
@@ -727,7 +728,7 @@ oc_tls_refresh_certs(oc_sec_credusage_t credusage,
 static bool
 is_known_identity_cert(oc_sec_cred_t *cred)
 {
-  oc_x509_crt_t *certs = (oc_x509_crt_t *)oc_list_head(identity_certs);
+  oc_x509_crt_t *certs = (oc_x509_crt_t *)oc_list_head(g_identity_certs);
 
   /* Look for a matching end-entity cert chain */
   for (; certs != NULL; certs = certs->next) {
@@ -825,7 +826,7 @@ next_cred_in_chain:
 static void
 add_new_identity_cert(oc_sec_cred_t *cred, size_t device)
 {
-  oc_x509_crt_t *cert = oc_memb_alloc(&identity_certs_s);
+  oc_x509_crt_t *cert = oc_memb_alloc(&g_identity_certs_s);
   if (!cert) {
     OC_WRN("could not allocate memory for identity cert");
     return;
@@ -859,6 +860,7 @@ add_new_identity_cert(oc_sec_cred_t *cred, size_t device)
         goto add_new_identity_cert_error;
       }
     }
+    OC_DBG("identity cert for credential(credid=%d) parsed", cred->credid);
     cred = cred->chain;
   }
 
@@ -872,7 +874,7 @@ add_new_identity_cert(oc_sec_cred_t *cred, size_t device)
   OC_DBG("adding new identity cert chain of size %d", chain_length);
 #endif /* OC_DEBUG */
 
-  oc_list_add(identity_certs, cert);
+  oc_list_add(g_identity_certs, cert);
 
   return;
 
@@ -880,54 +882,129 @@ add_new_identity_cert_error:
   OC_ERR("error adding identity cert");
   mbedtls_x509_crt_free(&cert->cert);
   mbedtls_pk_free(&cert->pk);
-  oc_memb_free(&identity_certs_s, cert);
+  oc_memb_free(&g_identity_certs_s, cert);
 }
 
 void
-oc_tls_refresh_identity_certs(void)
+oc_tls_add_new_identity_certs(void)
 {
-  OC_DBG("refreshing identity certs");
-  oc_tls_refresh_certs(OC_CREDUSAGE_MFG_CERT | OC_CREDUSAGE_IDENTITY_CERT,
+  OC_DBG("adding new identity certs");
+  oc_tls_add_new_certs(OC_CREDUSAGE_MFG_CERT | OC_CREDUSAGE_IDENTITY_CERT,
                        is_known_identity_cert, add_new_identity_cert);
 }
 
-void
-oc_tls_remove_identity_cert(oc_sec_cred_t *cred)
+static oc_x509_crt_t *
+oc_tls_find_identity_cert(const oc_sec_cred_t *cred)
 {
-  oc_x509_crt_t *cert = (oc_x509_crt_t *)oc_list_head(identity_certs);
+  oc_x509_crt_t *cert = (oc_x509_crt_t *)oc_list_head(g_identity_certs);
   while (cert != NULL && cert->cred != cred) {
     cert = cert->next;
   }
-  if (cert) {
-    oc_list_remove(identity_certs, cert);
-    mbedtls_x509_crt_free(&cert->cert);
-    mbedtls_pk_free(&cert->pk);
-    oc_memb_free(&identity_certs_s, cert);
+  return cert;
+}
+
+bool
+oc_tls_remove_identity_cert(oc_sec_cred_t *cred)
+{
+  oc_x509_crt_t *cert = oc_tls_find_identity_cert(cred);
+  if (!cert) {
+    return false;
   }
+  OC_DBG("identity cert for credential(credid=%d) removed", cred->credid);
+  oc_list_remove(g_identity_certs, cert);
+  mbedtls_x509_crt_free(&cert->cert);
+  mbedtls_pk_free(&cert->pk);
+  oc_memb_free(&g_identity_certs_s, cert);
+  return true;
+}
+
+static oc_sec_cred_t *
+oc_tls_find_cert_cred(oc_x509_crt_t *cert)
+{
+  if (cert == NULL) {
+    return NULL;
+  }
+  oc_sec_creds_t *creds = oc_sec_get_creds(cert->device);
+  for (oc_sec_cred_t *cred = (oc_sec_cred_t *)oc_list_head(creds->creds);
+       cred != NULL; cred = cred->next) {
+    if (cert->cred == cred) {
+      return cred;
+    }
+  }
+  return NULL;
+}
+
+static bool
+oc_tls_validate_identity_certs_consistency_for_device(size_t device)
+{
+  // check device credentials and list of identity certs equivalence
+  // - all credentials for identity certificates are contained in the list of
+  // identity certificates
+  oc_sec_creds_t *creds = oc_sec_get_creds(device);
+  for (oc_sec_cred_t *cred = (oc_sec_cred_t *)oc_list_head(creds->creds);
+       cred != NULL; cred = cred->next) {
+    /* Get leaf identity / mfg certificates */
+    if ((cred->credusage &
+         (OC_CREDUSAGE_MFG_CERT | OC_CREDUSAGE_IDENTITY_CERT)) != 0 &&
+        !cred->child) {
+      OC_DBG("search for identity cert for cred(%d)", cred->credid);
+      oc_x509_crt_t *cert = oc_tls_find_identity_cert(cred);
+      if (cert == NULL) {
+        OC_DBG("\tidentity not found", cert);
+        return false;
+      }
+      OC_DBG("\tidentity cert(%p) found", cert);
+    }
+  }
+
+  // - all identity certificates have a credential
+  oc_x509_crt_t *cert = (oc_x509_crt_t *)oc_list_head(g_identity_certs);
+  while (cert != NULL) {
+    OC_DBG("search for cred for identity cert (%p)", cert);
+    oc_sec_cred_t *cred = oc_tls_find_cert_cred(cert);
+    if (cred == NULL) {
+      OC_DBG("\tcred not found", cert);
+      return false;
+    }
+    OC_DBG("\tcred(%d) found", cred->credid);
+    cert = cert->next;
+  }
+
+  return true;
+}
+
+bool
+oc_tls_validate_identity_certs_consistency()
+{
+  for (size_t device = 0; device < oc_core_get_num_devices(); device++) {
+    if (!oc_tls_validate_identity_certs_consistency_for_device(device)) {
+      return false;
+    }
+  }
+  return true;
 }
 
 void
 oc_tls_remove_trust_anchor(oc_sec_cred_t *cred)
 {
-  oc_x509_cacrt_t *cert = (oc_x509_cacrt_t *)oc_list_head(ca_certs);
+  oc_x509_cacrt_t *cert = (oc_x509_cacrt_t *)oc_list_head(g_ca_certs);
   while (cert && cert->cred != cred) {
     cert = cert->next;
   }
   if (cert) {
-    oc_list_remove(ca_certs, cert);
-    oc_memb_free(&ca_certs_s, cert);
+    oc_list_remove(g_ca_certs, cert);
+    oc_memb_free(&g_ca_certs_s, cert);
   }
-  mbedtls_x509_crt_free(&trust_anchors);
-  mbedtls_x509_crt_init(&trust_anchors);
-  oc_tls_refresh_trust_anchors();
+  mbedtls_x509_crt_free(&g_trust_anchors);
+  mbedtls_x509_crt_init(&g_trust_anchors);
+  oc_tls_add_new_trust_anchors();
 }
 
 static int
 oc_tls_configure_end_entity_cert_chain(mbedtls_ssl_config *conf, size_t device,
                                        oc_sec_credusage_t credusage, int credid)
 {
-  oc_x509_crt_t *cert = (oc_x509_crt_t *)oc_list_head(identity_certs);
-
+  oc_x509_crt_t *cert = (oc_x509_crt_t *)oc_list_head(g_identity_certs);
   while (cert != NULL) {
     if (cert->device == device && cert->cred->credusage == credusage &&
         (credid == -1 || cert->cred->credid == credid)) {
@@ -964,7 +1041,7 @@ oc_tls_load_identity_cert_chain(mbedtls_ssl_config *conf, size_t device,
 static bool
 is_known_trust_anchor(oc_sec_cred_t *cred)
 {
-  oc_x509_cacrt_t *cert = (oc_x509_cacrt_t *)oc_list_head(ca_certs);
+  oc_x509_cacrt_t *cert = (oc_x509_cacrt_t *)oc_list_head(g_ca_certs);
 
   for (; cert != NULL; cert = cert->next) {
     if (cert->cred == cred) {
@@ -980,14 +1057,14 @@ add_new_trust_anchor(oc_sec_cred_t *cred, size_t device)
 {
   (void)device;
   int ret = mbedtls_x509_crt_parse(
-    &trust_anchors, (const unsigned char *)oc_string(cred->publicdata.data),
+    &g_trust_anchors, (const unsigned char *)oc_string(cred->publicdata.data),
     oc_string_len(cred->publicdata.data) + 1);
   if (ret != 0) {
     OC_WRN("could not parse an trustca/mfgtrustca root certificate %d", ret);
     return;
   }
 
-  oc_x509_cacrt_t *cert = oc_memb_alloc(&ca_certs_s);
+  oc_x509_cacrt_t *cert = oc_memb_alloc(&g_ca_certs_s);
   if (!cert) {
     OC_WRN("could not allocate memory for new trust anchor");
     return;
@@ -995,22 +1072,34 @@ add_new_trust_anchor(oc_sec_cred_t *cred, size_t device)
 
   cert->device = device;
   cert->cred = cred;
-  mbedtls_x509_crt *c = &trust_anchors;
+  mbedtls_x509_crt *c = &g_trust_anchors;
+#ifdef OC_DEBUG
+  int chain_length = 1;
+#endif /* OC_DEBUG */
   while (c->next) {
+#ifdef OC_DEBUG
+    ++chain_length;
+#endif /* OC_DEBUG */
     c = c->next;
   }
   cert->cert = c;
+#ifdef OC_DEBUG
+  char buf[256];
+  if (mbedtls_x509_serial_gets(buf, sizeof(buf) - 1, &c->serial) > 0) {
+    OC_DBG("trust anchor(serial: %s) added", buf);
+  }
+  OC_DBG("trust anchor chain is now of size %d", chain_length);
+#endif /* OC_DEBUG */
 
-  oc_list_add(ca_certs, cert);
-
+  oc_list_add(g_ca_certs, cert);
   OC_DBG("adding new trust anchor");
 }
 
 void
-oc_tls_refresh_trust_anchors(void)
+oc_tls_add_new_trust_anchors(void)
 {
-  OC_DBG("refreshing trust anchors");
-  oc_tls_refresh_certs(OC_CREDUSAGE_MFG_TRUSTCA | OC_CREDUSAGE_TRUSTCA,
+  OC_DBG("adding new trust anchors");
+  oc_tls_add_new_certs(OC_CREDUSAGE_MFG_TRUSTCA | OC_CREDUSAGE_TRUSTCA,
                        is_known_trust_anchor, add_new_trust_anchor);
 }
 
@@ -1047,7 +1136,7 @@ oc_tls_select_identity_cert_chain(int credid)
 static oc_x509_crt_t *
 get_identity_cert_for_session(const mbedtls_ssl_config *conf)
 {
-  oc_x509_crt_t *cert = (oc_x509_crt_t *)oc_list_head(identity_certs);
+  oc_x509_crt_t *cert = (oc_x509_crt_t *)oc_list_head(g_identity_certs);
   while (cert != NULL) {
     if (&cert->cert == conf->key_cert->cert) {
       return cert;
@@ -1063,7 +1152,7 @@ oc_tls_set_ciphersuites(mbedtls_ssl_config *conf, oc_endpoint_t *endpoint)
 {
   (void)endpoint;
 #ifdef OC_PKI
-  mbedtls_ssl_conf_ca_chain(conf, &trust_anchors, NULL);
+  mbedtls_ssl_conf_ca_chain(conf, &g_trust_anchors, NULL);
 #ifdef OC_CLIENT
   bool loaded_chain = false;
 #endif /* OC_CLIENT */
@@ -1183,7 +1272,7 @@ verify_certificate(void *opq, mbedtls_x509_crt *crt, int depth, uint32_t *flags)
       }
     } else {
       if (id_cert && id_cert->cred->credusage == OC_CREDUSAGE_IDENTITY_CERT) {
-        oc_x509_cacrt_t *ca_cert = (oc_x509_cacrt_t *)oc_list_head(ca_certs);
+        oc_x509_cacrt_t *ca_cert = (oc_x509_cacrt_t *)oc_list_head(g_ca_certs);
         while (ca_cert) {
           if (ca_cert->device == id_cert->device &&
               ca_cert->cred->credusage == OC_CREDUSAGE_TRUSTCA &&
@@ -1243,7 +1332,7 @@ verify_certificate(void *opq, mbedtls_x509_crt *crt, int depth, uint32_t *flags)
 
       OC_DBG(
         "looking for a matching trustca entry currently tracked by oc_tls");
-      oc_x509_cacrt_t *ca_cert = (oc_x509_cacrt_t *)oc_list_head(ca_certs);
+      oc_x509_cacrt_t *ca_cert = (oc_x509_cacrt_t *)oc_list_head(g_ca_certs);
       for (; ca_cert != NULL && ca_cert->device == id_cert->device &&
              ca_cert->cred->credusage == OC_CREDUSAGE_TRUSTCA;
            ca_cert = ca_cert->next) {
@@ -1480,19 +1569,19 @@ oc_tls_shutdown(void)
     p = oc_list_pop(tls_peers);
   }
 #ifdef OC_PKI
-  oc_x509_crt_t *cert = (oc_x509_crt_t *)oc_list_pop(identity_certs);
+  oc_x509_crt_t *cert = (oc_x509_crt_t *)oc_list_pop(g_identity_certs);
   while (cert != NULL) {
     mbedtls_x509_crt_free(&cert->cert);
     mbedtls_pk_free(&cert->pk);
-    oc_memb_free(&identity_certs_s, cert);
-    cert = (oc_x509_crt_t *)oc_list_pop(identity_certs);
+    oc_memb_free(&g_identity_certs_s, cert);
+    cert = (oc_x509_crt_t *)oc_list_pop(g_identity_certs);
   }
-  oc_x509_cacrt_t *ca = (oc_x509_cacrt_t *)oc_list_pop(ca_certs);
+  oc_x509_cacrt_t *ca = (oc_x509_cacrt_t *)oc_list_pop(g_ca_certs);
   while (ca) {
-    oc_memb_free(&ca_certs_s, ca);
-    ca = (oc_x509_cacrt_t *)oc_list_pop(ca_certs);
+    oc_memb_free(&g_ca_certs_s, ca);
+    ca = (oc_x509_cacrt_t *)oc_list_pop(g_ca_certs);
   }
-  mbedtls_x509_crt_free(&trust_anchors);
+  mbedtls_x509_crt_free(&g_trust_anchors);
 #endif /* OC_PKI */
   mbedtls_ctr_drbg_free(&ctr_drbg_ctx);
   mbedtls_ssl_cookie_free(&cookie_ctx);
@@ -1529,7 +1618,7 @@ oc_tls_init_context(void)
   }
 
 #ifdef OC_PKI
-  mbedtls_x509_crt_init(&trust_anchors);
+  mbedtls_x509_crt_init(&g_trust_anchors);
 #endif /* OC_PKI */
 
   return 0;

--- a/security/oc_tls.h
+++ b/security/oc_tls.h
@@ -155,14 +155,47 @@ void oc_tls_use_pin_obt_psk_identity(void);
 int oc_tls_pbkdf2(const unsigned char *pin, size_t pin_len, oc_uuid_t *uuid,
                   unsigned int c, uint8_t *key, uint32_t key_len);
 
-/* Internal interface for refreshing identity certficate chains */
-void oc_tls_refresh_identity_certs(void);
-void oc_tls_remove_identity_cert(oc_sec_cred_t *cred);
+/**
+ * @brief Internal interface for adding new identity certificate chains.
+ *
+ * Iterate over all credentials, check if a credential is associated with a leaf
+ * identity certificate. If the identity certificate doesn't exist in the global
+ * list of identity certificates then create a new identity certificate item and
+ * add it to the list.
+ */
+void oc_tls_add_new_identity_certs(void);
+
+/**
+ * @brief Remove certificate associated with the credential from the global list
+ * of leaf identity certificates and deallocate it.
+ *
+ * @param cred credential associated with the identity certificate to remove
+ * @return true identity certificate was found and removed
+ * @return false otherwise
+ */
+bool oc_tls_remove_identity_cert(oc_sec_cred_t *cred);
+
+/**
+ * @brief Check global lists of credentials and identity certificates that they
+ * contain the same items.
+ *
+ * @return true if the lists of identity certificates are consistent with each
+ * other
+ * @return false otherwise
+ */
+bool oc_tls_validate_identity_certs_consistency(void);
 
 /* Internal interface for refreshing trust anchor credentials */
-void oc_tls_refresh_trust_anchors(void);
+void oc_tls_add_new_trust_anchors(void);
 void oc_tls_remove_trust_anchor(oc_sec_cred_t *cred);
 
+/**
+ * @brief Get mbedtls container with trust anchors used globally by the
+ * application.
+ *
+ * @return mbedtls_x509_crt* X.509 certificate container with parsed trust
+ * anchors
+ */
 mbedtls_x509_crt *oc_tls_get_trust_anchors(void);
 
 #ifdef __cplusplus

--- a/security/oc_tls.h
+++ b/security/oc_tls.h
@@ -156,14 +156,15 @@ int oc_tls_pbkdf2(const unsigned char *pin, size_t pin_len, oc_uuid_t *uuid,
                   unsigned int c, uint8_t *key, uint32_t key_len);
 
 /**
- * @brief Internal interface for adding new identity certificate chains.
+ * @brief Internal interface for examining credentials for new identity
+ * certificate chains.
  *
  * Iterate over all credentials, check if a credential is associated with a leaf
  * identity certificate. If the identity certificate doesn't exist in the global
  * list of identity certificates then create a new identity certificate item and
  * add it to the list.
  */
-void oc_tls_add_new_identity_certs(void);
+void oc_tls_resolve_new_identity_certs(void);
 
 /**
  * @brief Remove certificate associated with the credential from the global list
@@ -176,18 +177,25 @@ void oc_tls_add_new_identity_certs(void);
 bool oc_tls_remove_identity_cert(oc_sec_cred_t *cred);
 
 /**
- * @brief Check global lists of credentials and identity certificates that they
- * contain the same items.
+ * @brief Internal interface for examining credentials for new trust anchors.
+ */
+void oc_tls_resolve_new_trust_anchors(void);
+
+/**
+ * @brief Remove certificate associated with the credential from the global
+ * lists of leaf trust anchors.
  *
- * @return true if the lists of identity certificates are consistent with each
- * other
+ * They are two lists that contain trust anchors: a simple linked list and a
+ * mbedtls chain. The trust anchor is removed from the linked list in a standard
+ * way. The mbedtls chain is thrown away fully and reloaded from the linked
+ * list.
+ *
+ * @param cred credential associated with the trust anchor to remove
+ * @return true trust anchor was found, removed the global linked list and the
+ * global mbedtls trust anchor chain was reloaded
  * @return false otherwise
  */
-bool oc_tls_validate_identity_certs_consistency(void);
-
-/* Internal interface for refreshing trust anchor credentials */
-void oc_tls_add_new_trust_anchors(void);
-void oc_tls_remove_trust_anchor(oc_sec_cred_t *cred);
+bool oc_tls_remove_trust_anchor(oc_sec_cred_t *cred);
 
 /**
  * @brief Get mbedtls container with trust anchors used globally by the
@@ -197,6 +205,28 @@ void oc_tls_remove_trust_anchor(oc_sec_cred_t *cred);
  * anchors
  */
 mbedtls_x509_crt *oc_tls_get_trust_anchors(void);
+
+#ifdef OC_TEST
+/**
+ * @brief Check global lists of credentials and identity certificates that they
+ * contain the same items.
+ *
+ * @return true if the lists of identity certificates are consistent with each
+ * other
+ * @return false otherwise
+ */
+bool oc_tls_validate_identity_certs_consistency(void);
+
+/**
+ * @brief Check global lists of credentials and trust anchors that they
+ * contain the same items.
+ *
+ * @return true if the lists of trust anchors are consistent with each
+ * other
+ * @return false otherwise
+ */
+bool oc_tls_validate_trust_anchors_consistency(void);
+#endif /* OC_TEST */
 
 #ifdef __cplusplus
 }

--- a/security/unittest/tls_cert_test.cpp
+++ b/security/unittest/tls_cert_test.cpp
@@ -18,7 +18,7 @@
  *
  ******************************************************************/
 
-#if defined(OC_SECURITY) && defined(OC_PKI)
+#if defined(OC_SECURITY) && defined(OC_PKI) && defined(OC_TEST)
 
 #include "gtest/gtest.h"
 
@@ -305,7 +305,7 @@ protected:
   TrustAnchor rootca2_;
 };
 
-TEST_F(TestTlsCertificates, AddAndRemoveIdentityCertificates)
+TEST_F(TestTlsCertificates, RemoveIdentityCertificates)
 {
   EXPECT_TRUE(oc_tls_validate_identity_certs_consistency());
   EXPECT_TRUE(oc_sec_remove_cred_by_credid(idcert1_.credid_, device_));
@@ -314,16 +314,13 @@ TEST_F(TestTlsCertificates, AddAndRemoveIdentityCertificates)
   EXPECT_TRUE(oc_tls_validate_identity_certs_consistency());
 }
 
-/*
-TEST_F(TestTlsCertificates, AddTrustedRoot)
+TEST_F(TestTlsCertificates, RemoveTrustAnchors)
 {
-  int rootca1_credid = oc_pki_add_mfg_trust_anchor(
-    0, reinterpret_cast<const unsigned char *>(rootca1.data_),
-    rootca1.dataLen_);
-  EXPECT_GE(rootca1_credid, 0);
-
-  // TODO: check ca_certs vs. trust_anchors size
+  EXPECT_TRUE(oc_tls_validate_trust_anchors_consistency());
+  EXPECT_TRUE(oc_sec_remove_cred_by_credid(rootca1_.credid_, device_));
+  EXPECT_TRUE(oc_tls_validate_trust_anchors_consistency());
+  EXPECT_TRUE(oc_sec_remove_cred_by_credid(rootca2_.credid_, device_));
+  EXPECT_TRUE(oc_tls_validate_trust_anchors_consistency());
 }
-*/
 
-#endif /* OC_SECURITY && OC_PKI */
+#endif /* OC_SECURITY && OC_PKI && OC_TEST */

--- a/security/unittest/tlstest.cpp
+++ b/security/unittest/tlstest.cpp
@@ -18,6 +18,8 @@
  *
  ******************************************************************/
 
+#if defined(OC_TCP) && defined(OC_SECURITY)
+
 #include "gtest/gtest.h"
 #include <cstdlib>
 
@@ -62,17 +64,14 @@ protected:
   }
 };
 
-#if defined(OC_TCP) && defined(OC_SECURITY)
 TEST_F(TestTlsConnection, InitTlsTest_P)
 {
-
   int errorCode = oc_tls_init_context();
   EXPECT_EQ(0, errorCode) << "Failed to init TLS Connection";
 }
 
 TEST_F(TestTlsConnection, InitTlsTestTwice_P)
 {
-
   int errorCode = oc_tls_init_context();
   ASSERT_EQ(0, errorCode) << "Failed to init TLS Connection";
   oc_tls_shutdown();
@@ -82,7 +81,6 @@ TEST_F(TestTlsConnection, InitTlsTestTwice_P)
 
 TEST_F(TestTlsConnection, TlsConnectionTest_N)
 {
-
   int errorCode = oc_tls_init_context();
   ASSERT_EQ(0, errorCode) << "Failed to init TLS Connection";
   oc_endpoint_t *endpoint = oc_new_endpoint();
@@ -91,4 +89,4 @@ TEST_F(TestTlsConnection, TlsConnectionTest_N)
   oc_free_endpoint(endpoint);
 }
 
-#endif
+#endif /* OC_TCP && OC_SECURITY */


### PR DESCRIPTION
Add test to verify consistency of internal lists containing
identity certificates.