### PR TITLE
Update tinycbor submodule to v0.6.0

### DIFF
--- a/deps/tinycbor.cmake
+++ b/deps/tinycbor.cmake
@@ -2,7 +2,9 @@ add_library(tinycbor-master OBJECT
     ${PROJECT_SOURCE_DIR}/deps/tinycbor/src/cborerrorstrings.c
     ${PROJECT_SOURCE_DIR}/deps/tinycbor/src/cborencoder.c
     ${PROJECT_SOURCE_DIR}/deps/tinycbor/src/cborencoder_close_container_checked.c
+    ${PROJECT_SOURCE_DIR}/deps/tinycbor/src/cborencoder_float.c
     ${PROJECT_SOURCE_DIR}/deps/tinycbor/src/cborparser.c
+    ${PROJECT_SOURCE_DIR}/deps/tinycbor/src/cborparser_float.c
     ${PROJECT_SOURCE_DIR}/deps/tinycbor/src/cborpretty.c
 )
 


### PR DESCRIPTION
TinyCBOR 0.6.0 adds compilation flags that may be needed for a future
update of the Zephyr port (#235).