### PR TITLE
Fix validation of swupdateaction to allow upgrade action

### DIFF
--- a/api/oc_swupdate.c
+++ b/api/oc_swupdate.c
@@ -560,7 +560,7 @@ post_swu(oc_request_t *request, oc_interface_mask_t interfaces, void *user_data)
     rep = rep->next;
   }
 
-  if (action >= OC_SWUPDATE_UPGRADE || !purl || !ut) {
+  if (action > OC_SWUPDATE_UPGRADE || !purl || !ut) {
     error_state = true;
   }
   if (action != OC_SWUPDATE_IDLE && action <= OC_SWUPDATE_UPGRADE && !purl) {


### PR DESCRIPTION
According to the specification the `swupdateaction` value `upgrade` should be accepted by the `oic.r.softwareupdate` resource for a POST request, but is declined due to a comparison bug.