### PR TITLE
Add missing oc_swupdate_result_t value

### DIFF
--- a/include/oc_swupdate.h
+++ b/include/oc_swupdate.h
@@ -31,14 +31,15 @@ extern "C" {
  *
  */
 typedef enum {
-  OC_SWUPDATE_RESULT_IDLE = 0,     ///< Idle
-  OC_SWUPDATE_RESULT_SUCCESS,      ///< software update successfull
-  OC_SWUPDATE_RESULT_LESS_RAM,     ///< not enough RAM
-  OC_SWUPDATE_RESULT_LESS_FLASH,   ///< not enough FLASH
-  OC_SWUPDATE_RESULT_CONN_FAIL,    ///< connection failure
-  OC_SWUPDATE_RESULT_SVV_FAIL,     ///< version failure
-  OC_SWUPDATE_RESULT_INVALID_URL,  ///< invalid URL
-  OC_SWUPDATE_RESULT_UPGRADE_FAIL, ///< upgrade failure
+  OC_SWUPDATE_RESULT_IDLE = 0,         ///< Idle
+  OC_SWUPDATE_RESULT_SUCCESS,          ///< software update successful
+  OC_SWUPDATE_RESULT_LESS_RAM,         ///< not enough RAM
+  OC_SWUPDATE_RESULT_LESS_FLASH,       ///< not enough FLASH
+  OC_SWUPDATE_RESULT_CONN_FAIL,        ///< connection failure
+  OC_SWUPDATE_RESULT_SVV_FAIL,         ///< version failure
+  OC_SWUPDATE_RESULT_INVALID_URL,      ///< invalid URL
+  OC_SWUPDATE_RESULT_UNSUPPORTED_PROT, ///< unsupported protocol for URL
+  OC_SWUPDATE_RESULT_UPGRADE_FAIL,     ///< upgrade failure
 } oc_swupdate_result_t;
 
 /**


### PR DESCRIPTION
Table 18 of the OCF Core Optional specification v2.2.5 for the `oic.r.softwareupdate` resource lists the codes of the "swupdateresult" property. It contains a code for "Unsupported protocol for download URL" (7), which is missing in the `enum oc_swupdate_result_t`.