### PR TITLE
Fix issues reported by clang-tidy

### DIFF
--- a/api/oc_client_api.c
+++ b/api/oc_client_api.c
@@ -338,8 +338,11 @@ bool
 oc_do_delete(const char *uri, oc_endpoint_t *endpoint, const char *query,
              oc_response_handler_t handler, oc_qos_t qos, void *user_data)
 {
-  oc_client_handler_t client_handler;
-  client_handler.response = handler;
+  oc_client_handler_t client_handler = {
+    .response = handler,
+    .discovery = NULL,
+    .discovery_all = NULL,
+  };
 
   oc_client_cb_t *cb = oc_ri_alloc_client_cb(uri, endpoint, OC_DELETE, query,
                                              client_handler, qos, user_data);
@@ -361,8 +364,11 @@ bool
 oc_do_get(const char *uri, oc_endpoint_t *endpoint, const char *query,
           oc_response_handler_t handler, oc_qos_t qos, void *user_data)
 {
-  oc_client_handler_t client_handler;
-  client_handler.response = handler;
+  oc_client_handler_t client_handler = {
+    .response = handler,
+    .discovery = NULL,
+    .discovery_all = NULL,
+  };
 
   oc_client_cb_t *cb = oc_ri_alloc_client_cb(uri, endpoint, OC_GET, query,
                                              client_handler, qos, user_data);
@@ -383,8 +389,11 @@ bool
 oc_init_put(const char *uri, oc_endpoint_t *endpoint, const char *query,
             oc_response_handler_t handler, oc_qos_t qos, void *user_data)
 {
-  oc_client_handler_t client_handler;
-  client_handler.response = handler;
+  oc_client_handler_t client_handler = {
+    .response = handler,
+    .discovery = NULL,
+    .discovery_all = NULL,
+  };
 
   oc_client_cb_t *cb = oc_ri_alloc_client_cb(uri, endpoint, OC_PUT, query,
                                              client_handler, qos, user_data);
@@ -398,8 +407,11 @@ bool
 oc_init_post(const char *uri, oc_endpoint_t *endpoint, const char *query,
              oc_response_handler_t handler, oc_qos_t qos, void *user_data)
 {
-  oc_client_handler_t client_handler;
-  client_handler.response = handler;
+  oc_client_handler_t client_handler = {
+    .response = handler,
+    .discovery = NULL,
+    .discovery_all = NULL,
+  };
 
   oc_client_cb_t *cb = oc_ri_alloc_client_cb(uri, endpoint, OC_POST, query,
                                              client_handler, qos, user_data);
@@ -426,8 +438,11 @@ bool
 oc_do_observe(const char *uri, oc_endpoint_t *endpoint, const char *query,
               oc_response_handler_t handler, oc_qos_t qos, void *user_data)
 {
-  oc_client_handler_t client_handler;
-  client_handler.response = handler;
+  oc_client_handler_t client_handler = {
+    .response = handler,
+    .discovery = NULL,
+    .discovery_all = NULL,
+  };
 
   oc_client_cb_t *cb = oc_ri_alloc_client_cb(uri, endpoint, OC_GET, query,
                                              client_handler, qos, user_data);
@@ -486,8 +501,11 @@ bool
 oc_send_ping(bool custody, oc_endpoint_t *endpoint, uint16_t timeout_seconds,
              oc_response_handler_t handler, void *user_data)
 {
-  oc_client_handler_t client_handler;
-  client_handler.response = handler;
+  oc_client_handler_t client_handler = {
+    .response = handler,
+    .discovery = NULL,
+    .discovery_all = NULL,
+  };
 
   oc_client_cb_t *cb = oc_ri_alloc_client_cb(
     "/ping", endpoint, 0, NULL, client_handler, LOW_QOS, user_data);
@@ -529,8 +547,11 @@ static oc_client_cb_t *
 oc_do_ipv4_multicast(const char *uri, const char *query,
                      oc_response_handler_t handler, void *user_data)
 {
-  oc_client_handler_t client_handler;
-  client_handler.response = handler;
+  oc_client_handler_t client_handler = {
+    .response = handler,
+    .discovery = NULL,
+    .discovery_all = NULL,
+  };
 
   oc_make_ipv4_endpoint(mcast4, IPV4 | DISCOVERY, 5683, 0xe0, 0x00, 0x01, 0xbb);
 
@@ -577,8 +598,11 @@ multi_scope_ipv6_multicast(oc_client_cb_t *cb4, uint8_t scope, const char *uri,
                         0, 0, 0, 0, 0, 0, 0, 0, 0x01, 0x58);
   mcast.addr.ipv6.scope = 0;
 
-  oc_client_handler_t client_handler;
-  client_handler.response = handler;
+  oc_client_handler_t client_handler = {
+    .response = handler,
+    .discovery = NULL,
+    .discovery_all = NULL,
+  };
 
   oc_client_cb_t *cb = oc_ri_alloc_client_cb(
     uri, &mcast, OC_GET, query, client_handler, LOW_QOS, user_data);
@@ -689,9 +713,11 @@ bool
 oc_do_site_local_ipv6_discovery_all(oc_discovery_all_handler_t handler,
                                     void *user_data)
 {
-  oc_client_handler_t handlers;
-  handlers.discovery_all = handler;
-  handlers.discovery = NULL;
+  oc_client_handler_t handlers = {
+    .response = NULL,
+    .discovery = NULL,
+    .discovery_all = handler,
+  };
   return multi_scope_ipv6_discovery(NULL, 0x05, NULL, handlers, user_data);
 }
 
@@ -699,9 +725,11 @@ bool
 oc_do_site_local_ipv6_discovery(const char *rt, oc_discovery_handler_t handler,
                                 void *user_data)
 {
-  oc_client_handler_t handlers;
-  handlers.discovery = handler;
-  handlers.discovery_all = NULL;
+  oc_client_handler_t handlers = {
+    .response = NULL,
+    .discovery = handler,
+    .discovery_all = NULL,
+  };
   oc_string_t uri_query;
   memset(&uri_query, 0, sizeof(oc_string_t));
   if (rt && strlen(rt) > 0) {
@@ -718,9 +746,11 @@ bool
 oc_do_realm_local_ipv6_discovery_all(oc_discovery_all_handler_t handler,
                                      void *user_data)
 {
-  oc_client_handler_t handlers;
-  handlers.discovery_all = handler;
-  handlers.discovery = NULL;
+  oc_client_handler_t handlers = {
+    .response = NULL,
+    .discovery = NULL,
+    .discovery_all = handler,
+  };
   return multi_scope_ipv6_discovery(NULL, 0x03, NULL, handlers, user_data);
 }
 
@@ -728,9 +758,11 @@ bool
 oc_do_realm_local_ipv6_discovery(const char *rt, oc_discovery_handler_t handler,
                                  void *user_data)
 {
-  oc_client_handler_t handlers;
-  handlers.discovery = handler;
-  handlers.discovery_all = NULL;
+  oc_client_handler_t handlers = {
+    .response = NULL,
+    .discovery = handler,
+    .discovery_all = NULL,
+  };
   oc_string_t uri_query;
   memset(&uri_query, 0, sizeof(oc_string_t));
   if (rt && strlen(rt) > 0) {
@@ -747,9 +779,11 @@ bool
 oc_do_ip_discovery(const char *rt, oc_discovery_handler_t handler,
                    void *user_data)
 {
-  oc_client_handler_t handlers;
-  handlers.discovery = handler;
-  handlers.discovery_all = NULL;
+  oc_client_handler_t handlers = {
+    .response = NULL,
+    .discovery = handler,
+    .discovery_all = NULL,
+  };
   oc_string_t uri_query;
   memset(&uri_query, 0, sizeof(oc_string_t));
   if (rt && strlen(rt) > 0) {
@@ -770,9 +804,11 @@ bool
 oc_do_ip_discovery_all(oc_discovery_all_handler_t handler, void *user_data)
 {
   oc_client_cb_t *cb4 = NULL;
-  oc_client_handler_t handlers;
-  handlers.discovery_all = handler;
-  handlers.discovery = NULL;
+  oc_client_handler_t handlers = {
+    .response = NULL,
+    .discovery = NULL,
+    .discovery_all = handler,
+  };
 #ifdef OC_IPV4
   cb4 = oc_do_ipv4_discovery(NULL, handlers, user_data);
 #endif
@@ -783,9 +819,11 @@ bool
 oc_do_ip_discovery_all_at_endpoint(oc_discovery_all_handler_t handler,
                                    oc_endpoint_t *endpoint, void *user_data)
 {
-  oc_client_handler_t handlers;
-  handlers.discovery_all = handler;
-  handlers.discovery = NULL;
+  oc_client_handler_t handlers = {
+    .response = NULL,
+    .discovery = NULL,
+    .discovery_all = handler,
+  };
   return dispatch_ip_discovery(NULL, NULL, handlers, endpoint, HIGH_QOS,
                                user_data);
 }
@@ -794,9 +832,11 @@ bool
 oc_do_ip_discovery_at_endpoint(const char *rt, oc_discovery_handler_t handler,
                                oc_endpoint_t *endpoint, void *user_data)
 {
-  oc_client_handler_t handlers;
-  handlers.discovery = handler;
-  handlers.discovery_all = NULL;
+  oc_client_handler_t handlers = {
+    .response = NULL,
+    .discovery = handler,
+    .discovery_all = NULL,
+  };
   oc_string_t uri_query;
   memset(&uri_query, 0, sizeof(oc_string_t));
   if (rt && strlen(rt) > 0) {

--- a/messaging/coap/coap.c
+++ b/messaging/coap/coap.c
@@ -517,7 +517,6 @@ coap_serialize_options(void *packet, uint8_t *option_array, bool inner,
       }
     }
 #endif /* OC_SPEC_VER_OIC */
-    current_number = OCF_OPTION_CONTENT_FORMAT_VER;
   }
 
   if (option) {

--- a/port/esp32/adapter/src/tcpadapter.c
+++ b/port/esp32/adapter/src/tcpadapter.c
@@ -489,7 +489,7 @@ connect_nonb(int sockfd, const struct sockaddr *r, int r_len, int nsec)
   tval.tv_sec = nsec;
   tval.tv_usec = 0;
 
-  if ((n = select(sockfd + 1, NULL, &wset, NULL, nsec ? &tval : NULL)) == 0) {
+  if (select(sockfd + 1, NULL, &wset, NULL, nsec ? &tval : NULL) == 0) {
     /* timeout */
     errno = ETIMEDOUT;
     return -1;

--- a/port/linux/tcpadapter.c
+++ b/port/linux/tcpadapter.c
@@ -515,7 +515,7 @@ connect_nonb(int sockfd, const struct sockaddr *r, int r_len, int nsec)
   tval.tv_sec = nsec;
   tval.tv_usec = 0;
 
-  if ((n = select(sockfd + 1, NULL, &wset, NULL, nsec ? &tval : NULL)) == 0) {
+  if (select(sockfd + 1, NULL, &wset, NULL, nsec ? &tval : NULL) == 0) {
     /* timeout */
     errno = ETIMEDOUT;
     return -1;
@@ -576,7 +576,7 @@ initiate_new_session_locked(ip_context_t *dev, oc_endpoint_t *endpoint,
     }
 
     socklen_t receiver_size = sizeof(*receiver);
-    int ret = 0;
+    int ret;
     if ((ret = connect_nonb(sock, (struct sockaddr *)receiver, receiver_size,
                             TCP_CONNECT_TIMEOUT)) == 0) {
       break;
@@ -585,6 +585,7 @@ initiate_new_session_locked(ip_context_t *dev, oc_endpoint_t *endpoint,
     close(sock);
     retry_cnt++;
     OC_DBG("connect fail with %d. retry(%d)", ret, retry_cnt);
+    (void)ret;
   }
 
   if (retry_cnt >= LIMIT_RETRY_CONNECT) {
@@ -621,8 +622,7 @@ oc_tcp_send_buffer(ip_context_t *dev, oc_message_t *message,
       OC_ERR("connection was closed");
       goto oc_tcp_send_buffer_done;
     }
-    if ((send_sock = initiate_new_session_locked(dev, &message->endpoint,
-                                                 receiver)) < 0) {
+    if (initiate_new_session_locked(dev, &message->endpoint, receiver) < 0) {
       OC_ERR("could not initiate new TCP session");
       goto oc_tcp_send_buffer_done;
     }

--- a/port/oc_assert.h
+++ b/port/oc_assert.h
@@ -25,18 +25,24 @@
 extern "C" {
 #endif
 
+#ifdef __GNUC__
+#define GCC_NO_RETURN __attribute__((__noreturn__))
+#else
+#define GCC_NO_RETURN
+#endif /* __GNUC__ */
+
 /**
  * @brief abort application
  *
  */
-void abort_impl(void);
+void abort_impl(void) GCC_NO_RETURN;
 
 /**
  * @brief exit the application
  *
  * @param status the exist status
  */
-void exit_impl(int status);
+void exit_impl(int status) GCC_NO_RETURN;
 
 /**
  * @brief abort with message

--- a/python/oc_python.c
+++ b/python/oc_python.c
@@ -2361,8 +2361,7 @@ doxm_discovery_cb(const char *anchor, const char *uri, oc_string_array_t types,
   (void)user_data;
   (void)types;
   (void)endpoint;
-  int uri_len = strlen(uri);
-  uri_len = (uri_len >= MAX_URI_LENGTH) ? MAX_URI_LENGTH - 1 : uri_len;
+  (void)uri;
   PRINT("DOXM CB\n");
   oc_endpoint_t *ep = endpoint;
   while (ep != NULL) {

--- a/security/oc_tls.c
+++ b/security/oc_tls.c
@@ -1838,6 +1838,7 @@ oc_tls_prf(const uint8_t *secret, size_t secret_len, uint8_t *output,
   mbedtls_md_context_t hmacA, hmacA_next;
   va_list msg_list;
   const uint8_t *msg;
+  va_start(msg_list, num_message_fragments);
 
   mbedtls_md_init(&hmacA);
   mbedtls_md_init(&hmacA_next);
@@ -1848,7 +1849,6 @@ oc_tls_prf(const uint8_t *secret, size_t secret_len, uint8_t *output,
              mbedtls_md_info_from_type(MBEDTLS_MD_SHA256), 1);
 
   MBEDTLS_MD(mbedtls_md_hmac_starts, &hmacA, secret, secret_len);
-  va_start(msg_list, num_message_fragments);
   for (i = 0; i < num_message_fragments; i++) {
     msg = va_arg(msg_list, const uint8_t *);
     msg_len = va_arg(msg_list, size_t);

--- a/util/oc_memb.c
+++ b/util/oc_memb.c
@@ -62,9 +62,9 @@ _oc_memb_alloc(
     return NULL;
   }
 
-  int i = m->num;
   void *ptr = NULL;
   if (m->num > 0) {
+    int i;
     for (i = 0; i < m->num; i++) {
       if (m->count[i] == 0) {
         /* If this block was unused, we increase the reference count to
@@ -115,13 +115,12 @@ _oc_memb_free(
   oc_mem_trace_add_pace(func, m->size, MEM_TRACE_FREE, ptr);
 #endif
 
-  int i = m->num;
   char *ptr2 = NULL;
   if (m->num > 0) {
     /* Walk through the list of blocks and try to find the block to
        which the pointer "ptr" points to. */
     ptr2 = (char *)m->mem;
-    for (i = 0; i < m->num; ++i) {
+    for (int i = 0; i < m->num; ++i) {
       if (ptr2 == (char *)ptr) {
         /* We've found to block to which "ptr" points so we decrease the
            reference count and return the new value of it. */


### PR DESCRIPTION
Addressed issues:
- clang-analyzer-deadcode.DeadStores
- clang-analyzer-valist.Uninitialized
- clang-analyzer-core.CallAndMessage