### PR TITLE
Fix ESP32 Github job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,9 @@ name: CI-building linux
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -98,7 +98,7 @@ jobs:
           # the actual build
           cd port/linux
           make DEBUG=1 SECURE=1 IPV4=1 TCP=1 PKI=1 DYNAMIC=1 CLOUD=1 JAVA=1 IDD=1
-  
+
   build_esp32:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
@@ -108,14 +108,18 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE,  so your job can access it
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          submodules: "true"
 
       # Runs a set of commands using the runners shell
       - name: build esp32
         run: |
           sudo apt install -y git wget flex bison gperf python3 python3-pip python3-setuptools python3-serial python3-click python3-cryptography python3-future python3-pyparsing python3-pyelftools cmake ninja-build ccache libffi-dev libssl-dev libusb-1.0-0
-          git submodule update --init
           cd ./port/esp32
-          git clone --recursive -b release/v5.0 https://github.com/espressif/esp-idf.git
+          # git clone --recursive -b release/v5.0 https://github.com/espressif/esp-idf.git
+          git clone -b release/v5.0 https://github.com/espressif/esp-idf.git
+          ( cd esp-idf && git checkout 335ca8a687d4f507b8ffe8a4ec3132ba4a4a4be3 )
+          ( cd esp-idf && git submodule update --init --recursive )
           ./esp-idf/install.sh
           . ./esp-idf/export.sh
           idf.py set-target esp32

--- a/port/esp32/README.md
+++ b/port/esp32/README.md
@@ -60,15 +60,25 @@ The last is to jump to the [common steps](#common-steps) below in the ubuntu bas
 
 ### Common steps
 
+<!--
+git clone --recursive -b release/v5.0 https://github.com/espressif/esp-idf.git
+release/v5.0 uses mbedTLS submodule with newer version than 3.2.1, our patches are applicable to
+version 3.1.0 so we must checkout a version with mbedTLS v3.1.0
+-->
+
 ```bash
 cd ./iotivity-lite/port/esp32
-git clone --recursive -b release/v5.0 https://github.com/espressif/esp-idf.git
+git clone -b release/v5.0 https://github.com/espressif/esp-idf.git
+# checkout latest commit with mbedTLS v3.1.0
+( cd esp-idf && git checkout 335ca8a687d4f507b8ffe8a4ec3132ba4a4a4be3 )
+( cd esp-idf && git submodule update --init --recursive )
 ./esp-idf/install.sh
 . ./esp-idf/export.sh
 idf.py set-target esp32
 idf.py menuconfig # this will bring up a GUI where you need to set up wifi
-( cd esp-idf/components/mbedtls/mbedtls && patch -p1 < ../../../../../../patches/01-ocf-x509san-anon-psk.patch)
-( cd esp-idf/components/mbedtls/mbedtls && patch -p1 < ../../../../patches/mbedtls/02-ocf-mbedtls-config.patch)
+# apply iotivity-lite patches for mbedTLS v3.1.0
+( cd esp-idf/components/mbedtls/mbedtls && patch -p1 < ../../../../../../patches/01-ocf-x509san-anon-psk.patch )
+( cd esp-idf/components/mbedtls/mbedtls && patch -p1 < ../../../../patches/mbedtls/02-ocf-mbedtls-config.patch )
 ( cd esp-idf/components/lwip/lwip && find ../../../../patches/lwip/ -type f -name '*.patch' -exec patch -p1 -i {} \; )
 idf.py build
 ESPBAUD=115200 idf.py flash monitor


### PR DESCRIPTION
To be able to apply iotivity-lite patches to mbedTLS in the ESP32 components we must checkout a commit in the repository where ESP32 uses mbedTLS v3.1.0