### PR TITLE
security/acl: add oc_sec_acl_clear API function

### DIFF
--- a/api/unittest/coreresourcetest.cpp
+++ b/api/unittest/coreresourcetest.cpp
@@ -28,22 +28,22 @@
 #include "oc_helpers.h"
 #include "port/oc_network_event_handler_internal.h"
 
-#define DEVICE_URI "/oic/d"
-#define DEVICE_TYPE "oic.d.light"
-#define MANUFACTURER_NAME "Samsung"
-#define DEVICE_NAME "Table Lamp"
-#define OCF_SPEC_VERSION "ocf.1.0.0"
-#define OCF_DATA_MODEL_VERSION "ocf.res.1.0.0"
+static const std::string kDeviceURI{ "/oic/d" };
+static const std::string kDeviceType{ "oic.d.light" };
+static const std::string kDeviceName{ "Table Lamp" };
+static const std::string kManufacturerName{ "Samsung" };
+static const std::string kOCFSpecVersion{ "ocf.1.0.0" };
+static const std::string kOCFDataModelVersion{ "ocf.res.1.0.0" };
 
 class TestCoreResource : public testing::Test {
 protected:
-  virtual void SetUp()
+  void SetUp() override
   {
     oc_core_init();
     oc_network_event_handler_mutex_init();
     oc_random_init();
   }
-  virtual void TearDown()
+  void TearDown() override
   {
     oc_random_destroy();
     oc_network_event_handler_mutex_destroy();
@@ -53,42 +53,37 @@ protected:
 
 TEST_F(TestCoreResource, InitPlatform_P)
 {
-  int oc_platform_info;
-
-  oc_platform_info = oc_init_platform(MANUFACTURER_NAME, NULL, NULL);
+  int oc_platform_info =
+    oc_init_platform(kManufacturerName.c_str(), nullptr, nullptr);
   EXPECT_EQ(0, oc_platform_info);
 }
 
 TEST_F(TestCoreResource, CoreInitPlatform_P)
 {
-  oc_platform_info_t *oc_platform_info;
-
-  oc_platform_info = oc_core_init_platform(MANUFACTURER_NAME, NULL, NULL);
-  EXPECT_EQ(strlen(MANUFACTURER_NAME),
+  const oc_platform_info_t *oc_platform_info =
+    oc_core_init_platform(kManufacturerName.c_str(), nullptr, nullptr);
+  EXPECT_EQ(kManufacturerName.length(),
             oc_string_len(oc_platform_info->mfg_name));
 }
 
 TEST_F(TestCoreResource, CoreDevice_P)
 {
-  int numcoredevice;
-  oc_device_info_t *addcoredevice;
-
-  addcoredevice = oc_core_add_new_device(DEVICE_URI, DEVICE_TYPE, DEVICE_NAME,
-                                         OCF_SPEC_VERSION,
-                                         OCF_DATA_MODEL_VERSION, NULL, NULL);
+  oc_device_info_t *addcoredevice = oc_core_add_new_device(
+    kDeviceURI.c_str(), kDeviceType.c_str(), kDeviceName.c_str(),
+    kOCFSpecVersion.c_str(), kOCFDataModelVersion.c_str(), nullptr, nullptr);
   ASSERT_NE(addcoredevice, nullptr);
-  numcoredevice = oc_core_get_num_devices();
+  size_t numcoredevice = oc_core_get_num_devices();
   EXPECT_EQ(1, numcoredevice);
   oc_connectivity_shutdown(0);
 }
 
 TEST_F(TestCoreResource, CoreGetResource_P)
 {
-  oc_core_init_platform(MANUFACTURER_NAME, NULL, NULL);
+  oc_core_init_platform(kManufacturerName.c_str(), nullptr, nullptr);
 
-  char uri[] = "/oic/p";
-  oc_resource_t *res = oc_core_get_resource_by_uri(uri, 0);
+  std::string uri = "/oic/p";
+  oc_resource_t *res = oc_core_get_resource_by_uri(uri.c_str(), 0);
 
   ASSERT_NE(nullptr, res);
-  EXPECT_EQ(strlen(uri), oc_string_len(res->uri));
+  EXPECT_EQ(uri.length(), oc_string_len(res->uri));
 }

--- a/api/unittest/ocapitest.cpp
+++ b/api/unittest/ocapitest.cpp
@@ -30,11 +30,11 @@
 #include <unistd.h>
 #include <vector>
 
-#define MAX_WAIT_TIME 10
-#define DEVICE_URI "/oic/d"
-#define MANUFACTURER_NAME "Samsung"
-#define OCF_SPEC_VERSION "ocf.1.0.0"
-#define OCF_DATA_MODEL_VERSION "ocf.res.1.0.0"
+static constexpr uint16_t kMaxWaitTime{ 10 };
+static const std::string kDeviceURI{ "/oic/d" };
+static const std::string kManufacturerName{ "Samsung" };
+static const std::string kOCFSpecVersion{ "ocf.1.0.0" };
+static const std::string kOCFDataModelVersion{ "ocf.res.1.0.0" };
 
 struct ApiDevice
 {
@@ -63,27 +63,27 @@ public:
 
   static int appInit(void)
   {
-    int result = oc_init_platform(MANUFACTURER_NAME, nullptr, nullptr);
+    int result = oc_init_platform(kManufacturerName.c_str(), nullptr, nullptr);
     size_t deviceId = 0;
     if (s_ObtResource.enabled) {
-      result |=
-        oc_add_device(DEVICE_URI, s_ObtResource.device_type.c_str(),
-                      s_ObtResource.device_name.c_str(), OCF_SPEC_VERSION,
-                      OCF_DATA_MODEL_VERSION, nullptr, nullptr);
+      result |= oc_add_device(
+        kDeviceURI.c_str(), s_ObtResource.device_type.c_str(),
+        s_ObtResource.device_name.c_str(), kOCFSpecVersion.c_str(),
+        kOCFDataModelVersion.c_str(), nullptr, nullptr);
       s_ObtResource.device_id = deviceId++;
     }
     if (s_LightResource.enabled) {
-      result |=
-        oc_add_device(DEVICE_URI, s_LightResource.device_type.c_str(),
-                      s_LightResource.device_name.c_str(), OCF_SPEC_VERSION,
-                      OCF_DATA_MODEL_VERSION, nullptr, nullptr);
+      result |= oc_add_device(
+        kDeviceURI.c_str(), s_LightResource.device_type.c_str(),
+        s_LightResource.device_name.c_str(), kOCFSpecVersion.c_str(),
+        kOCFDataModelVersion.c_str(), nullptr, nullptr);
       s_LightResource.device_id = deviceId++;
     }
     if (s_SwitchResource.enabled) {
-      result |=
-        oc_add_device(DEVICE_URI, s_SwitchResource.device_type.c_str(),
-                      s_SwitchResource.device_name.c_str(), OCF_SPEC_VERSION,
-                      OCF_DATA_MODEL_VERSION, nullptr, nullptr);
+      result |= oc_add_device(
+        kDeviceURI.c_str(), s_SwitchResource.device_type.c_str(),
+        s_SwitchResource.device_name.c_str(), kOCFSpecVersion.c_str(),
+        kOCFDataModelVersion.c_str(), nullptr, nullptr);
       s_SwitchResource.device_id = deviceId++;
     }
     return result;
@@ -344,7 +344,7 @@ TEST_F(TestServerClient, DiscoverResources)
   ResourceDiscovered rd{};
   EXPECT_TRUE(oc_do_ip_discovery(nullptr, &onResourceDiscovered, &rd))
     << "Cannot send discovery request";
-  ApiHelper::poolEvents(MAX_WAIT_TIME);
+  ApiHelper::poolEvents(kMaxWaitTime);
   EXPECT_TRUE(rd.isDone());
 }
 

--- a/include/oc_acl.h
+++ b/include/oc_acl.h
@@ -129,6 +129,16 @@ typedef struct oc_sec_ace_t
 } oc_sec_ace_t;
 
 /**
+ * @brief Access control entry (ACE) filtering function.
+ *
+ * @param ace ACE to check
+ * @param user_data user data passed from the caller
+ * @return true if ACE matches the filter
+ * @return false otherwise
+ */
+typedef bool (*oc_sec_ace_filter_t)(const oc_sec_ace_t *ace, void *user_data);
+
+/**
  * @brief Get access control list of a device
  *
  * @param device Index of the device
@@ -136,6 +146,17 @@ typedef struct oc_sec_ace_t
  */
 OC_API
 oc_sec_acl_t *oc_sec_get_acl(size_t device);
+
+/**
+ * @brief Remove access control entries matching filter from given device
+ *
+ * @param device Index of the device
+ * @param filter Filtering function (if NULL all existing ACEs match)
+ * @param user_data User data passed from the caller
+ */
+OC_API
+void oc_sec_acl_clear(size_t device, oc_sec_ace_filter_t filter,
+                      void *user_data);
 
 /**
  * @brief Remove access control entry from given device

--- a/include/oc_cred.h
+++ b/include/oc_cred.h
@@ -122,6 +122,17 @@ typedef struct oc_sec_creds_t
   oc_uuid_t rowneruuid;  ///< row owner uuid
 } oc_sec_creds_t;
 
+/**
+ * @brief Security credential filtering function.
+ *
+ * @param cred security credential to check
+ * @param user_data user data passed from the caller
+ * @return true if security credential matches the filter
+ * @return false otherwise
+ */
+typedef bool (*oc_sec_cred_filter_t)(const oc_sec_cred_t *cred,
+                                     void *user_data);
+
 #ifdef OC_PKI
 
 /**
@@ -253,6 +264,17 @@ int oc_sec_apply_cred(oc_rep_t *rep, oc_resource_t *resource,
  */
 OC_API
 oc_sec_creds_t *oc_sec_get_creds(size_t device);
+
+/**
+ * @brief remove credentials matching filter from given device
+ *
+ * @param device index of the device
+ * @param filter filtering function (if NULL all existing credentials match)
+ * @param user_data user data passed from the caller
+ */
+OC_API
+void oc_sec_cred_clear(size_t device, oc_sec_cred_filter_t filter,
+                       void *user_data);
 
 /**
  * @brief remove credential from given device

--- a/port/unittest/clocktest.cpp
+++ b/port/unittest/clocktest.cpp
@@ -27,10 +27,6 @@ extern "C" {
 }
 
 class TestClock : public testing::Test {
-protected:
-  virtual void SetUp() {}
-
-  virtual void TearDown() {}
 };
 
 TEST_F(TestClock, oc_clock_time)

--- a/port/unittest/storagetest.cpp
+++ b/port/unittest/storagetest.cpp
@@ -33,10 +33,6 @@ static uint8_t buf[100];
 #endif /* OC_SECURITY */
 
 class TestStorage : public testing::Test {
-protected:
-  virtual void SetUp() {}
-
-  virtual void TearDown() {}
 };
 
 #ifdef OC_SECURITY

--- a/security/oc_acl_internal.h
+++ b/security/oc_acl_internal.h
@@ -37,7 +37,6 @@ bool oc_sec_encode_acl(size_t device, oc_interface_mask_t iface_mask,
 bool oc_sec_decode_acl(oc_rep_t *rep, bool from_storage, size_t device,
                        oc_sec_on_apply_acl_cb_t on_apply_ace_cb,
                        void *on_apply_ace_data);
-void oc_sec_acl_init(void);
 void post_acl(oc_request_t *request, oc_interface_mask_t iface_mask,
               void *data);
 void get_acl(oc_request_t *request, oc_interface_mask_t iface_mask, void *data);
@@ -48,6 +47,24 @@ bool oc_sec_check_acl(oc_method_t method, oc_resource_t *resource,
 bool oc_sec_acl_add_created_resource_ace(const char *href,
                                          oc_endpoint_t *client, size_t device,
                                          bool collection);
+typedef struct
+{
+  oc_sec_ace_t *ace;
+  bool created;
+  bool created_resource;
+} oc_sec_ace_update_data_t;
+
+bool oc_sec_ace_update_res(oc_ace_subject_type_t type,
+                           oc_ace_subject_t *subject, int aceid,
+                           uint16_t permission, const char *tag,
+                           const char *href, oc_ace_wildcard_t wildcard,
+                           size_t device, oc_sec_ace_update_data_t *data);
+
+oc_sec_ace_t *oc_sec_acl_find_subject(oc_sec_ace_t *start,
+                                      oc_ace_subject_type_t type,
+                                      oc_ace_subject_t *subject, int aceid,
+                                      uint16_t permission, const char *tag,
+                                      bool match_tag, size_t device);
 
 #ifdef __cplusplus
 }

--- a/security/oc_cred_internal.h
+++ b/security/oc_cred_internal.h
@@ -29,7 +29,7 @@ extern "C" {
 
 struct oc_tls_peer_t;
 
-typedef struct oc_sec_add_new_cred_data_t
+typedef struct
 {
   bool created; ///< true if a new credential was created, false otherwise
   oc_sec_cred_t

--- a/security/unittest/acltest.cpp
+++ b/security/unittest/acltest.cpp
@@ -1,0 +1,165 @@
+/******************************************************************
+ *
+ * Copyright 2022 Daniel Adam, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"),
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************/
+
+#include "port/oc_network_event_handler_internal.h"
+#include "security/oc_acl_internal.h"
+#include "util/oc_list.h"
+#include "oc_acl.h"
+#include "oc_api.h"
+#include "oc_core_res.h"
+#include "oc_tls.h"
+#include "oc_uuid.h"
+#include "gtest/gtest.h"
+#include <string>
+
+#ifdef OC_SECURITY
+
+static const std::string kDeviceURI{ "/oic/d" };
+static const std::string kDeviceType{ "oic.d.light" };
+static const std::string kDeviceName{ "Table Lamp" };
+static const std::string kManufacturerName{ "Samsung" };
+static const std::string kOCFSpecVersion{ "ocf.1.0.0" };
+static const std::string kOCFDataModelVersion{ "ocf.res.1.0.0" };
+
+class TestAcl : public testing::Test {
+protected:
+  void SetUp() override
+  {
+    oc_ri_init();
+    oc_network_event_handler_mutex_init();
+    oc_core_init();
+    oc_init_platform(kManufacturerName.c_str(), nullptr, nullptr);
+    oc_add_device(kDeviceURI.c_str(), kDeviceType.c_str(), kDeviceName.c_str(),
+                  kOCFSpecVersion.c_str(), kOCFDataModelVersion.c_str(),
+                  nullptr, nullptr);
+    device_id_ = 0;
+    oc_sec_acl_init();
+  }
+
+  void TearDown() override
+  {
+    oc_sec_acl_free();
+    oc_ri_shutdown();
+    oc_tls_shutdown();
+    oc_connectivity_shutdown(0);
+    oc_network_event_handler_mutex_destroy();
+    oc_core_shutdown();
+  }
+
+public:
+  size_t device_id_;
+};
+
+static size_t
+oc_sec_ace_count(size_t device)
+{
+  size_t count = 0;
+  const auto *ace =
+    static_cast<oc_sec_ace_t *>(oc_list_head(oc_sec_get_acl(device)->subjects));
+  for (; ace != nullptr; ace = ace->next) {
+    ++count;
+  }
+  return count;
+}
+
+TEST_F(TestAcl, oc_sec_acl_add_bootstrap_acl)
+{
+  EXPECT_EQ(true, oc_sec_acl_add_bootstrap_acl(device_id_));
+  const oc_sec_acl_t *acl = oc_sec_get_acl(device_id_);
+  EXPECT_NE(nullptr, acl);
+  EXPECT_EQ(1, oc_sec_ace_count(device_id_));
+}
+
+TEST_F(TestAcl, oc_sec_acl_clear)
+{
+  oc_ace_subject_t anon_clear;
+  memset(&anon_clear, 0, sizeof(oc_ace_subject_t));
+  anon_clear.conn = OC_CONN_ANON_CLEAR;
+  EXPECT_EQ(true, oc_sec_ace_update_res(OC_SUBJECT_CONN, &anon_clear, -1,
+                                        OC_PERM_RETRIEVE, nullptr, "/test/a",
+                                        OC_ACE_NO_WC, device_id_, nullptr));
+
+  oc_uuid_t uuid = { { 0 } };
+  oc_gen_uuid(&uuid);
+  oc_ace_subject_t subject;
+  memset(&subject, 0, sizeof(oc_ace_subject_t));
+  memcpy(&subject.uuid, &uuid, sizeof(oc_uuid_t));
+  EXPECT_EQ(true, oc_sec_ace_update_res(OC_SUBJECT_UUID, &subject, -1,
+                                        OC_PERM_UPDATE, nullptr, "/test/b",
+                                        OC_ACE_NO_WC, device_id_, nullptr));
+
+  memset(&subject, 0, sizeof(oc_ace_subject_t));
+  std::string testRole{ "test.role" };
+  std::string testAuthority{ "test.authority" };
+  oc_new_string(&subject.role.role, testRole.c_str(), testRole.length());
+  oc_new_string(&subject.role.authority, testAuthority.c_str(),
+                testAuthority.length());
+  EXPECT_EQ(true, oc_sec_ace_update_res(OC_SUBJECT_ROLE, &subject, -1,
+                                        OC_PERM_NOTIFY, nullptr, "/test/c",
+                                        OC_ACE_NO_WC, device_id_, nullptr));
+  EXPECT_EQ(3, oc_sec_ace_count(device_id_));
+
+  oc_sec_acl_clear(
+    device_id_, [](const oc_sec_ace_t *, void *) { return false; }, nullptr);
+  EXPECT_EQ(3, oc_sec_ace_count(device_id_));
+
+  oc_sec_ace_t *ace =
+    oc_sec_acl_find_subject(nullptr, OC_SUBJECT_CONN, &anon_clear, /*aceid*/ -1,
+                            /*permission*/ 0, /*tag*/ nullptr,
+                            /*match_tag*/ false, device_id_);
+  EXPECT_NE(nullptr, ace);
+  oc_sec_acl_clear(
+    device_id_,
+    [](const oc_sec_ace_t *entry, void *) {
+      return entry->subject_type == OC_SUBJECT_CONN;
+    },
+    nullptr);
+  EXPECT_EQ(2, oc_sec_ace_count(device_id_));
+  ace =
+    oc_sec_acl_find_subject(nullptr, OC_SUBJECT_CONN, &anon_clear, /*aceid*/ -1,
+                            /*permission*/ 0, /*tag*/ nullptr,
+                            /*match_tag*/ false, device_id_);
+  EXPECT_EQ(nullptr, ace);
+
+  ace =
+    oc_sec_acl_find_subject(nullptr, OC_SUBJECT_ROLE, &subject,
+                            /*aceid*/ -1, /*permission*/ 0,
+                            /*tag*/ nullptr, /*match_tag*/ false, device_id_);
+  EXPECT_NE(nullptr, ace);
+  int aceid{ ace->aceid };
+  oc_sec_acl_clear(
+    device_id_,
+    [](const oc_sec_ace_t *entry, void *data) {
+      const auto *id = static_cast<int *>(data);
+      return entry->aceid == *id;
+    },
+    &aceid);
+  ace =
+    oc_sec_acl_find_subject(nullptr, OC_SUBJECT_ROLE, &subject,
+                            /*aceid*/ -1, /*permission*/ 0,
+                            /*tag*/ nullptr, /*match_tag*/ false, device_id_);
+  EXPECT_EQ(nullptr, ace);
+
+  oc_sec_acl_clear(device_id_, nullptr, nullptr);
+  EXPECT_EQ(0, oc_sec_ace_count(device_id_));
+
+  oc_free_string(&subject.role.authority);
+  oc_free_string(&subject.role.role);
+}
+
+#endif /* OC_SECURITY */

--- a/security/unittest/oscore_hkdf_test.cpp
+++ b/security/unittest/oscore_hkdf_test.cpp
@@ -25,13 +25,13 @@
 
 class TestOSCOREHKDF : public testing::Test {
 protected:
-  virtual void SetUp()
+  void SetUp() override
   {
     oc_random_init();
     oc_tls_init_context();
   }
 
-  virtual void TearDown()
+  void TearDown() override
   {
     oc_tls_shutdown();
     oc_random_destroy();

--- a/security/unittest/oscore_test.cpp
+++ b/security/unittest/oscore_test.cpp
@@ -18,18 +18,28 @@
 
 #include "messaging/coap/coap.h"
 #include "messaging/coap/oscore.h"
-#include "oc_helpers.h"
+#include "port/oc_network_event_handler_internal.h"
 #include "security/oc_oscore.h"
 #include "security/oc_oscore_context.h"
 #include "security/oc_oscore_crypto.h"
+#include "oc_helpers.h"
+
 #include "gtest/gtest.h"
 #include <cstdlib>
 
 class TestOSCORE : public testing::Test {
 protected:
-  virtual void SetUp() { oc_ri_init(); }
+  void SetUp() override
+  {
+    oc_network_event_handler_mutex_init();
+    oc_ri_init();
+  }
 
-  virtual void TearDown() { oc_ri_shutdown(); }
+  void TearDown() override
+  {
+    oc_ri_shutdown();
+    oc_network_event_handler_mutex_destroy();
+  }
 };
 
 /* Test cases from RFC 8613 */

--- a/security/unittest/tlstest.cpp
+++ b/security/unittest/tlstest.cpp
@@ -32,30 +32,27 @@
 #undef delete
 #include "port/oc_network_event_handler_internal.h"
 
-#define MAX_WAIT_TIME 10
-#define RESOURCE_URI "/LightResourceURI"
-#define DEVICE_URI "/oic/d"
-#define RESOURCE_TYPE "oic.r.light"
-#define DEVICE_TYPE "oic.d.light"
-#define RESOURCE_INTERFACE "oic.if.baseline"
-#define MANUFACTURER_NAME "Samsung"
-#define DEVICE_NAME "Table Lamp"
-#define OCF_SPEC_VERSION "ocf.1.0.0"
-#define OCF_DATA_MODEL_VERSION "ocf.res.1.0.0"
+static const std::string kDeviceURI{ "/oic/d" };
+static const std::string kDeviceType{ "oic.d.light" };
+static const std::string kDeviceName{ "Table Lamp" };
+static const std::string kManufacturerName{ "Samsung" };
+static const std::string kOCFSpecVersion{ "ocf.1.0.0" };
+static const std::string kOCFDataModelVersion{ "ocf.res.1.0.0" };
 
 class TestTlsConnection : public testing::Test {
 protected:
-  virtual void SetUp()
+  void SetUp() override
   {
     oc_ri_init();
     oc_network_event_handler_mutex_init();
     oc_core_init();
-    oc_init_platform(MANUFACTURER_NAME, NULL, NULL);
-    oc_add_device(DEVICE_URI, DEVICE_TYPE, DEVICE_NAME, OCF_SPEC_VERSION,
-                  OCF_DATA_MODEL_VERSION, NULL, NULL);
+    oc_init_platform(kManufacturerName.c_str(), nullptr, nullptr);
+    oc_add_device(kDeviceURI.c_str(), kDeviceType.c_str(), kDeviceName.c_str(),
+                  kOCFSpecVersion.c_str(), kOCFDataModelVersion.c_str(),
+                  nullptr, nullptr);
   }
 
-  virtual void TearDown()
+  void TearDown() override
   {
     oc_ri_shutdown();
     oc_tls_shutdown();

--- a/tests/itc/ri/src/RIGeneralIntegrationTest.cpp
+++ b/tests/itc/ri/src/RIGeneralIntegrationTest.cpp
@@ -23,10 +23,6 @@
 #include <gtest/gtest.h>
 
 class RIGeneralIntegrationTest : public ::testing::Test {
-public:
-  virtual void SetUp() {}
-
-  virtual void TearDown() {}
 };
 
 TEST(RIGeneralIntegrationTest, ri_nonsecure_initserver_P)


### PR DESCRIPTION
Add public function to clear Access Control Entries (ACE) matching a filter from given device.