### PR TITLE
cloud: start manager after configuration update

### DIFF
--- a/api/cloud/oc_cloud.c
+++ b/api/cloud/oc_cloud.c
@@ -41,7 +41,7 @@ cloud_manager_cb(oc_cloud_context_t *ctx)
   OC_DBG("cloud manager status changed %d", (int)ctx->store.status);
   cloud_rd_manager_status_changed(ctx);
 
-  if (ctx->callback) {
+  if (ctx->callback != NULL) {
     ctx->callback(ctx, ctx->store.status, ctx->user_data);
   }
 }
@@ -229,6 +229,11 @@ cloud_update_by_resource(oc_cloud_context_t *ctx,
   ctx->store.cps = OC_CPS_READYTOREGISTER;
   if (ctx->cloud_manager) {
     oc_cloud_manager_restart(ctx);
+    return;
+  }
+
+  if (oc_cloud_manager_start(ctx, ctx->callback, ctx->user_data) != 0) {
+    OC_ERR("cannot start cloud manager");
   }
 }
 
@@ -341,7 +346,7 @@ oc_cloud_manager_restart(oc_cloud_context_t *ctx)
 int
 oc_cloud_manager_start(oc_cloud_context_t *ctx, oc_cloud_cb_t cb, void *data)
 {
-  if (!ctx || !cb) {
+  if (ctx == NULL) {
     return -1;
   }
 

--- a/include/oc_cloud.h
+++ b/include/oc_cloud.h
@@ -125,7 +125,7 @@ oc_cloud_context_t *oc_cloud_get_context(size_t device);
  * @brief Start cloud registration process.
  *
  * @param ctx cloud context (cannot be NULL)
- * @param cb callback function invoked on status change (cannot be NULL)
+ * @param cb callback function invoked on status change
  * @param data user data provided to the status change function
  * @return int 0 on success
  * @return int -1 on error


### PR DESCRIPTION
If the cloud configuration resource is updated with non-empty data then manager should be always started or restarted.