### PR TITLE
tls: add oc_tls_peer_clear public function

### DIFF
--- a/.github/workflows/sonar-cloud-analysis.yml
+++ b/.github/workflows/sonar-cloud-analysis.yml
@@ -79,7 +79,7 @@ jobs:
           mkdir build && cd build
           # sonar-scanner currently cannot handle multi configuration configuration (ie. compilation of the same file with different defines),
           # so we enable as many features as possible so we get max. amount of code analysis
-          cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_VERBOSE_MAKEFILE=ON -DOC_CLOUD_ENABLED=ON -DOC_COLLECTIONS_IF_CREATE_ENABLED=ON -DOC_OSCORE_ENABLED=OFF -DOC_MNT_ENABLED=ON -DOC_WKCORE_ENABLED=ON -DOC_SOFTWARE_UPDATE_ENABLED=ON -DOC_PUSH_ENABLED=ON -DBUILD_TESTING=ON ..
+          cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_VERBOSE_MAKEFILE=ON -DOC_CLOUD_ENABLED=ON -DOC_COLLECTIONS_IF_CREATE_ENABLED=ON -DOC_MNT_ENABLED=ON -DOC_WKCORE_ENABLED=ON -DOC_SOFTWARE_UPDATE_ENABLED=ON -DOC_PUSH_ENABLED=ON -DBUILD_TESTING=ON ..
           cd ..
           # for files defined in multiple cmake targets, sonar-scanner seems to take the configuration from the first compilation of the file,
           # so we force client-server target to be compiled first so we get analysis of code with both OC_CLIENT and OC_SERVER enabled

--- a/api/cloud/oc_cloud_apis.c
+++ b/api/cloud/oc_cloud_apis.c
@@ -439,6 +439,7 @@ oc_cloud_deregister(oc_cloud_context_t *ctx, oc_cloud_cb_t cb, void *data)
       free_api_param(p);
       return -1;
     }
+    return 0;
   }
 
   return cloud_deregister(p, canUseAccessToken);

--- a/api/cloud/unittest/cloud_access_test.cpp
+++ b/api/cloud/unittest/cloud_access_test.cpp
@@ -40,7 +40,10 @@ public:
     return result;
   }
 
-  static void signalEventLoop(void) {}
+  static void signalEventLoop(void)
+  {
+    // no-op for tests
+  }
 
 protected:
   static void SetUpTestCase()

--- a/api/cloud/unittest/rd_client_test.cpp
+++ b/api/cloud/unittest/rd_client_test.cpp
@@ -38,7 +38,10 @@ public:
     return result;
   }
 
-  static void signalEventLoop(void) {}
+  static void signalEventLoop(void)
+  {
+    // no-op for tests
+  }
 
 protected:
   static void SetUpTestCase()

--- a/security/oc_tls.h
+++ b/security/oc_tls.h
@@ -63,6 +63,17 @@ typedef struct oc_tls_peer_t
 #endif
 } oc_tls_peer_t;
 
+/**
+ * @brief TLS peer filtering function.
+ *
+ * @param peer peer to check
+ * @param user_data user data passed from the caller
+ * @return true if the peer matches the filter
+ * @return false otherwise
+ */
+typedef bool (*oc_tls_peer_filter_t)(const oc_tls_peer_t *peer,
+                                     void *user_data);
+
 extern mbedtls_ctr_drbg_context g_oc_ctr_drbg_ctx;
 
 int oc_tls_init_context(void);
@@ -95,6 +106,15 @@ oc_tls_peer_t *oc_tls_add_peer(const oc_endpoint_t *endpoint, int role);
  * @param endpoint the endpoint
  */
 void oc_tls_remove_peer(const oc_endpoint_t *endpoint);
+
+/**
+ * @brief Remove TLS peers matching filter.
+ *
+ * @param filter Filtering function (if NULL all existing peers match)
+ * @param user_data User data passed from the caller
+ */
+OC_API
+void oc_tls_peer_clear(oc_tls_peer_filter_t filter, void *user_data);
 
 /**
  * @brief Get the peer for the endpoint.

--- a/security/oc_tls.h
+++ b/security/oc_tls.h
@@ -1,7 +1,7 @@
 /*
 // Copyright (c) 2016-2019 Intel Corporation
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
+// Licensed under the Apache License, Version 2.0 (the "License"),
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -61,7 +61,7 @@ typedef struct oc_tls_peer_t
 #endif /* OC_PKI */
 #ifdef OC_TCP
   oc_message_t *processed_recv_message;
-#endif
+#endif /* OC_TCP */
 } oc_tls_peer_t;
 
 /**

--- a/security/oc_tls.h
+++ b/security/oc_tls.h
@@ -48,7 +48,8 @@ typedef struct oc_tls_peer_t
   mbedtls_ssl_context ssl_ctx;
   mbedtls_ssl_config ssl_conf;
   oc_endpoint_t endpoint;
-  int role;
+  int role; // MBEDTLS_SSL_IS_SERVER = device acts as a server
+            // MBEDTLS_SSL_IS_CLIENT = device acts as a client
   oc_tls_retr_timer_t timer;
   uint8_t master_secret[48];
   uint8_t client_server_random[64];
@@ -114,7 +115,7 @@ void oc_tls_remove_peer(const oc_endpoint_t *endpoint);
  * @param user_data User data passed from the caller
  */
 OC_API
-void oc_tls_peer_clear(oc_tls_peer_filter_t filter, void *user_data);
+void oc_tls_close_peers(oc_tls_peer_filter_t filter, void *user_data);
 
 /**
  * @brief Get the peer for the endpoint.
@@ -122,6 +123,9 @@ void oc_tls_peer_clear(oc_tls_peer_filter_t filter, void *user_data);
  * @param endpoint the endpoint
  * @return peer for the endpoint if it exists
  * @return NULL if no peer exists for the endpoint
+ *
+ * @note if endpoint is NULL then the first peer will be returned regardless of
+ * the endpoint on the peer
  */
 oc_tls_peer_t *oc_tls_get_peer(const oc_endpoint_t *endpoint);
 

--- a/security/unittest/tls_peer_test.cpp
+++ b/security/unittest/tls_peer_test.cpp
@@ -1,0 +1,137 @@
+/******************************************************************
+ *
+ * Copyright 2018 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************/
+
+#if defined(OC_SECURITY)
+
+#include "oc_api.h"
+#include "messaging/coap/coap_signal.h"
+#include "security/oc_tls.h"
+#include "util/oc_features.h"
+#include <atomic>
+#include <gtest/gtest.h>
+#include <pthread.h>
+
+class TestTLSPeer : public testing::Test {
+protected:
+  void SetUp() override
+  {
+    s_handler.init = &appInit;
+    s_handler.signal_event_loop = &signalEventLoop;
+    int ret = oc_main_init(&s_handler);
+    ASSERT_EQ(0, ret);
+    ASSERT_EQ(0, oc_connectivity_init(0));
+  }
+
+  void TearDown() override
+  {
+    oc_connectivity_shutdown(0);
+    oc_main_shutdown();
+  }
+
+public:
+  static pthread_mutex_t s_mutex;
+  static pthread_cond_t s_cv;
+  static oc_handler_t s_handler;
+  static std::atomic<bool> s_terminate;
+
+  static int appInit(void)
+  {
+    int result = oc_init_platform("OCFCloud", nullptr, nullptr);
+    result |= oc_add_device("/oic/d", "oic.d.light", "Lamp", "ocf.1.0.0",
+                            "ocf.res.1.0.0", nullptr, nullptr);
+    return result;
+  }
+
+  static void signalEventLoop(void) { pthread_cond_signal(&s_cv); }
+
+  static oc_event_callback_retval_t quitEvent(void *)
+  {
+    s_terminate = true;
+    return OC_EVENT_DONE;
+  }
+
+  static void poolEvents(uint16_t seconds)
+  {
+    s_terminate = false;
+    oc_set_delayed_callback(nullptr, quitEvent, seconds);
+
+    while (!s_terminate) {
+      pthread_mutex_lock(&s_mutex);
+      oc_clock_time_t next_event = oc_main_poll();
+      if (next_event == 0) {
+        pthread_cond_wait(&s_cv, &s_mutex);
+      } else {
+        struct timespec ts;
+        ts.tv_sec = (next_event / OC_CLOCK_SECOND);
+        ts.tv_nsec = (next_event % OC_CLOCK_SECOND) * 1.e09 / OC_CLOCK_SECOND;
+        pthread_cond_timedwait(&s_cv, &s_mutex, &ts);
+      }
+      pthread_mutex_unlock(&s_mutex);
+    }
+  }
+
+  static void connectEndpoint(oc_endpoint_t *ep)
+  {
+    // #ifdef OC_HAS_FEATURE_TCP_ASYNC_CONNECT
+    int ret = oc_tcp_connect(ep, nullptr, nullptr);
+    ASSERT_LE(0, ret);
+    if (ret == OC_TCP_SOCKET_STATE_CONNECTING) {
+      poolEvents(10);
+    }
+    ASSERT_EQ(OC_TCP_SOCKET_STATE_CONNECTED, oc_tcp_connection_state(ep));
+    // #else
+    //     oc_message_t *msg = oc_allocate_message();
+    //     memcpy(&msg->endpoint, ep, sizeof(oc_endpoint_t));
+    //     coap_packet_t packet = {};
+    //     coap_tcp_init_message(&packet, CSM_7_01);
+    //     std::array<uint8_t, 8> payload{ "connect" };
+    //     packet.payload = payload.data();
+    //     packet.payload_len = payload.size();
+    //     msg->length = coap_serialize_message(&packet, msg->data);
+    //     oc_send_buffer(msg);
+    //     oc_message_unref(msg);
+    // #endif
+  }
+};
+
+pthread_mutex_t TestTLSPeer::s_mutex;
+pthread_cond_t TestTLSPeer::s_cv;
+oc_handler_t TestTLSPeer::s_handler;
+std::atomic<bool> TestTLSPeer::s_terminate{ 0 };
+
+TEST_F(TestTLSPeer, CountPeers)
+{
+  size_t ep_count = 0;
+  oc_endpoint_t *ep = oc_connectivity_get_endpoints(0);
+  while (ep != nullptr) {
+    if ((ep->flags & (TCP | SECURED)) == (TCP | SECURED)) {
+      ++ep_count;
+      connectEndpoint(ep);
+      break;
+    }
+    ep = ep->next;
+  }
+
+  if (ep_count == 0) {
+    return;
+  }
+
+  ASSERT_LT(0, oc_tls_num_peers(0));
+}
+
+#endif /* OC_SECURITY */

--- a/security/unittest/tls_peer_test.cpp
+++ b/security/unittest/tls_peer_test.cpp
@@ -2,7 +2,7 @@
  *
  * Copyright 2018 Samsung Electronics All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License"),
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -19,119 +19,240 @@
 #if defined(OC_SECURITY)
 
 #include "oc_api.h"
-#include "messaging/coap/coap_signal.h"
+#include "oc_config.h"
+#include "oc_core_res.h"
+#include "oc_uuid.h"
 #include "security/oc_tls.h"
-#include "util/oc_features.h"
-#include <atomic>
+#include "security/oc_pstat.h"
 #include <gtest/gtest.h>
-#include <pthread.h>
+#include <iostream>
+#include <iomanip>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+#include <WinSock2.h>
+#endif /* _WIN32 */
+
+struct Peer
+{
+  std::string address;
+  oc_uuid_t uuid;
+  int role;
+};
+
+static Peer
+createPeer(const std::string &addr, int role)
+{
+  static size_t peerCount = 0;
+  std::ostringstream ostr;
+  ostr << std::setfill('0') << std::setw(12) << peerCount;
+
+  std::string uuid = "00000000-0000-0000-0000-" + ostr.str();
+  ++peerCount;
+
+  Peer peer{};
+  peer.address = addr;
+  oc_str_to_uuid(uuid.c_str(), &peer.uuid);
+  peer.role = role;
+  return peer;
+}
 
 class TestTLSPeer : public testing::Test {
 protected:
+  static void SetUpTestCase()
+  {
+#ifdef _WIN32
+    WSADATA wsaData;
+    WSAStartup(MAKEWORD(2, 2), &wsaData);
+#endif /* _WIN32 */
+  }
+
+  static void TearDownTestCase()
+  {
+#ifdef _WIN32
+    WSACleanup();
+#endif /* _WIN32 */
+  }
+
   void SetUp() override
   {
     s_handler.init = &appInit;
     s_handler.signal_event_loop = &signalEventLoop;
-    int ret = oc_main_init(&s_handler);
-    ASSERT_EQ(0, ret);
-    ASSERT_EQ(0, oc_connectivity_init(0));
+    ASSERT_EQ(0, oc_main_init(&s_handler));
+    size_t deviceCount = oc_core_get_num_devices();
+    ASSERT_LT(0, deviceCount);
+    deviceId_ = deviceCount - 1;
+
+    oc_sec_pstat_t *pstat = oc_sec_get_pstat(deviceId_);
+    pstat->s = OC_DOS_RFNOP;
   }
 
-  void TearDown() override
-  {
-    oc_connectivity_shutdown(0);
-    oc_main_shutdown();
-  }
+  void TearDown() override { oc_main_shutdown(); }
 
 public:
-  static pthread_mutex_t s_mutex;
-  static pthread_cond_t s_cv;
+  size_t deviceId_{ static_cast<size_t>(-1) };
+
   static oc_handler_t s_handler;
-  static std::atomic<bool> s_terminate;
 
   static int appInit(void)
   {
-    int result = oc_init_platform("OCFCloud", nullptr, nullptr);
-    result |= oc_add_device("/oic/d", "oic.d.light", "Lamp", "ocf.1.0.0",
-                            "ocf.res.1.0.0", nullptr, nullptr);
-    return result;
-  }
-
-  static void signalEventLoop(void) { pthread_cond_signal(&s_cv); }
-
-  static oc_event_callback_retval_t quitEvent(void *)
-  {
-    s_terminate = true;
-    return OC_EVENT_DONE;
-  }
-
-  static void poolEvents(uint16_t seconds)
-  {
-    s_terminate = false;
-    oc_set_delayed_callback(nullptr, quitEvent, seconds);
-
-    while (!s_terminate) {
-      pthread_mutex_lock(&s_mutex);
-      oc_clock_time_t next_event = oc_main_poll();
-      if (next_event == 0) {
-        pthread_cond_wait(&s_cv, &s_mutex);
-      } else {
-        struct timespec ts;
-        ts.tv_sec = (next_event / OC_CLOCK_SECOND);
-        ts.tv_nsec = (next_event % OC_CLOCK_SECOND) * 1.e09 / OC_CLOCK_SECOND;
-        pthread_cond_timedwait(&s_cv, &s_mutex, &ts);
-      }
-      pthread_mutex_unlock(&s_mutex);
+    if (oc_init_platform("OCFCloud", nullptr, nullptr) != 0) {
+      return -1;
     }
+    if (oc_add_device("/oic/d", "oic.d.light", "Lamp", "ocf.1.0.0",
+                      "ocf.res.1.0.0", nullptr, nullptr) != 0) {
+      return -1;
+    }
+    return 0;
   }
 
-  static void connectEndpoint(oc_endpoint_t *ep)
+  static void signalEventLoop(void)
   {
-    // #ifdef OC_HAS_FEATURE_TCP_ASYNC_CONNECT
-    int ret = oc_tcp_connect(ep, nullptr, nullptr);
-    ASSERT_LE(0, ret);
-    if (ret == OC_TCP_SOCKET_STATE_CONNECTING) {
-      poolEvents(10);
+    // no-op for tests
+  }
+
+  static oc_endpoint_t getEndpoint(const std::string &ep)
+  {
+    oc_string_t ep_str;
+    oc_new_string(&ep_str, ep.c_str(), ep.length());
+    oc_endpoint_t endpoint;
+    EXPECT_EQ(0, oc_string_to_endpoint(&ep_str, &endpoint, nullptr));
+    oc_free_string(&ep_str);
+    return endpoint;
+  }
+
+  static std::vector<Peer> getClients()
+  {
+    std::vector<Peer> clients{ createPeer("coaps://[ff02::41]:1336",
+                                          MBEDTLS_SSL_IS_CLIENT) };
+#ifdef OC_IPV4
+    clients.emplace_back(
+      createPeer("coaps://1.3.3.6:41", MBEDTLS_SSL_IS_CLIENT));
+#endif /* OC_IPV4 */
+
+#ifdef OC_TCP
+    clients.emplace_back(
+      createPeer("coaps+tcp://[ff02::42]:1337", MBEDTLS_SSL_IS_CLIENT));
+#ifdef OC_IPV4
+    clients.emplace_back(
+      createPeer("coaps+tcp://1.3.3.7:42", MBEDTLS_SSL_IS_CLIENT));
+#endif /* OC_IPV4 */
+#endif /* OC_TCP */
+
+    return clients;
+  }
+
+  static std::vector<Peer> getServers()
+  {
+
+    std::vector<Peer> servers{ createPeer("coaps://[ff02::43]:1338",
+                                          MBEDTLS_SSL_IS_SERVER) };
+#ifdef OC_IPV4
+    servers.emplace_back(
+      createPeer("coaps://1.3.3.8:43", MBEDTLS_SSL_IS_SERVER));
+#endif /* OC_IPV4 */
+
+#ifdef OC_TCP
+    servers.emplace_back(
+      createPeer("coaps+tcp://[ff02::44]:1339", MBEDTLS_SSL_IS_SERVER));
+#ifdef OC_IPV4
+    servers.emplace_back(
+      createPeer("coaps+tcp://1.3.3.9:44", MBEDTLS_SSL_IS_SERVER));
+#endif /* OC_IPV4 */
+#endif /* OC_TCP */
+
+    return servers;
+  }
+
+  static void addPeers(const std::vector<Peer> &peers)
+  {
+    for (const auto &p : peers) {
+      oc_endpoint_t ep = getEndpoint(p.address);
+      oc_tls_peer_t *peer = oc_tls_add_peer(&ep, p.role);
+      ASSERT_NE(nullptr, peer);
+      peer->uuid = p.uuid;
     }
-    ASSERT_EQ(OC_TCP_SOCKET_STATE_CONNECTED, oc_tcp_connection_state(ep));
-    // #else
-    //     oc_message_t *msg = oc_allocate_message();
-    //     memcpy(&msg->endpoint, ep, sizeof(oc_endpoint_t));
-    //     coap_packet_t packet = {};
-    //     coap_tcp_init_message(&packet, CSM_7_01);
-    //     std::array<uint8_t, 8> payload{ "connect" };
-    //     packet.payload = payload.data();
-    //     packet.payload_len = payload.size();
-    //     msg->length = coap_serialize_message(&packet, msg->data);
-    //     oc_send_buffer(msg);
-    //     oc_message_unref(msg);
-    // #endif
   }
 };
 
-pthread_mutex_t TestTLSPeer::s_mutex;
-pthread_cond_t TestTLSPeer::s_cv;
-oc_handler_t TestTLSPeer::s_handler;
-std::atomic<bool> TestTLSPeer::s_terminate{ 0 };
+oc_handler_t TestTLSPeer::s_handler{};
 
 TEST_F(TestTLSPeer, CountPeers)
 {
-  size_t ep_count = 0;
-  oc_endpoint_t *ep = oc_connectivity_get_endpoints(0);
-  while (ep != nullptr) {
-    if ((ep->flags & (TCP | SECURED)) == (TCP | SECURED)) {
-      ++ep_count;
-      connectEndpoint(ep);
-      break;
-    }
-    ep = ep->next;
+  ASSERT_EQ(0, oc_tls_num_peers(deviceId_));
+
+  auto endpoints = getClients();
+#ifndef OC_DYNAMIC_ALLOCATION
+  if (endpoints.size() > OC_MAX_TLS_PEERS) {
+    endpoints.resize(OC_MAX_TLS_PEERS);
+  }
+#endif /* OC_DYNAMIC_ALLOCATION */
+
+  addPeers(endpoints);
+  ASSERT_EQ(endpoints.size(), oc_tls_num_peers(deviceId_));
+}
+
+TEST_F(TestTLSPeer, GetPeer)
+{
+  ASSERT_EQ(0, oc_tls_num_peers(deviceId_));
+  auto servers = getServers();
+#ifndef OC_DYNAMIC_ALLOCATION
+  if (servers.size() > OC_MAX_TLS_PEERS) {
+    servers.resize(OC_MAX_TLS_PEERS);
+  }
+#endif /* OC_DYNAMIC_ALLOCATION */
+
+  addPeers(servers);
+  ASSERT_EQ(servers.size(), oc_tls_num_peers(deviceId_));
+
+  auto clients = getClients();
+  for (const auto &c : clients) {
+    oc_endpoint_t ep = getEndpoint(c.address);
+    ASSERT_EQ(nullptr, oc_tls_get_peer(&ep));
+    ASSERT_EQ(nullptr, oc_tls_get_peer_uuid(&ep));
   }
 
-  if (ep_count == 0) {
-    return;
-  }
+  for (const auto &s : servers) {
+    oc_endpoint_t ep = getEndpoint(s.address);
+    const oc_tls_peer_t *peer = oc_tls_get_peer(&ep);
+    ASSERT_NE(nullptr, peer);
+    ASSERT_EQ(MBEDTLS_SSL_IS_SERVER, peer->role);
+    ASSERT_EQ(0, oc_endpoint_compare(&ep, &peer->endpoint));
 
-  ASSERT_LT(0, oc_tls_num_peers(0));
+    const oc_uuid_t *uuid = oc_tls_get_peer_uuid(&ep);
+    ASSERT_NE(nullptr, uuid);
+    ASSERT_TRUE(oc_uuid_is_equal(s.uuid, *uuid));
+  }
+}
+
+TEST_F(TestTLSPeer, ClearPeers)
+{
+  auto clients = getClients();
+  auto servers = getServers();
+
+#ifndef OC_DYNAMIC_ALLOCATION
+  size_t max_peers = OC_MAX_TLS_PEERS;
+  if (clients.size() > max_peers) {
+    clients.resize(max_peers);
+  }
+  max_peers -= clients.size();
+  if (servers.size() > max_peers) {
+    servers.resize(max_peers);
+  }
+#endif /* OC_DYNAMIC_ALLOCATION */
+
+  addPeers(clients);
+  addPeers(servers);
+  ASSERT_EQ(clients.size() + servers.size(), oc_tls_num_peers(deviceId_));
+
+  oc_tls_close_peers([](const oc_tls_peer_t *peer,
+                        void *) { return peer->role == MBEDTLS_SSL_IS_CLIENT; },
+                     nullptr);
+  ASSERT_EQ(servers.size(), oc_tls_num_peers(deviceId_));
+
+  oc_tls_close_peers(nullptr, nullptr);
+  ASSERT_EQ(0, oc_tls_num_peers(deviceId_));
 }
 
 #endif /* OC_SECURITY */

--- a/security/unittest/tlstest.cpp
+++ b/security/unittest/tlstest.cpp
@@ -2,8 +2,6 @@
  *
  * Copyright 2018 Samsung Electronics All Rights Reserved.
  *
- *
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at


### PR DESCRIPTION
Function removes all TLS peers that are matched by the filtering function.