### PR TITLE
Install mbedtls also when used as static library

### DIFF
--- a/deps/mbedtls.cmake
+++ b/deps/mbedtls.cmake
@@ -13,7 +13,12 @@ endif()
 option(ENABLE_PROGRAMS "Build mbed TLS programs." OFF)
 option(ENABLE_TESTING "Build mbed TLS tests." OFF)
 
-add_subdirectory(${PROJECT_SOURCE_DIR}/deps/mbedtls)
+set(OC_INSTALL_MBEDTLS ON CACHE BOOL "Include mbedtls in installation")
+if(OC_INSTALL_MBEDTLS)
+    add_subdirectory(${PROJECT_SOURCE_DIR}/deps/mbedtls)
+else()
+  add_subdirectory(${PROJECT_SOURCE_DIR}/deps/mbedtls EXCLUDE_FROM_ALL)
+endif()
 
 set(COMPILABLE_TYPES STATIC_LIBRARY MODULE_LIBRARY SHARED_LIBRARY OBJECT_LIBRARY EXECUTABLE)
 

--- a/deps/mbedtls.cmake
+++ b/deps/mbedtls.cmake
@@ -13,12 +13,7 @@ endif()
 option(ENABLE_PROGRAMS "Build mbed TLS programs." OFF)
 option(ENABLE_TESTING "Build mbed TLS tests." OFF)
 
-if(USE_SHARED_MBEDTLS_LIBRARY)
-    # when using mbedtls dynamic library make install needs to install .so files to /usr/lib and headers to /usr/include
-    add_subdirectory(${PROJECT_SOURCE_DIR}/deps/mbedtls)
-else()
-    add_subdirectory(${PROJECT_SOURCE_DIR}/deps/mbedtls EXCLUDE_FROM_ALL)
-endif()
+add_subdirectory(${PROJECT_SOURCE_DIR}/deps/mbedtls)
 
 set(COMPILABLE_TYPES STATIC_LIBRARY MODULE_LIBRARY SHARED_LIBRARY OBJECT_LIBRARY EXECUTABLE)
 


### PR DESCRIPTION
Since the iotivity-lite headers include mbedtls headers, the mbedtls library needs to be installed also when it is statically linked. The CMake property EXCLUDE_FROM_ALL prevented that.