### PR TITLE
cloud: Fix heap-use-after-free when deregisting from cloud

### DIFF
--- a/api/cloud/oc_cloud_context.c
+++ b/api/cloud/oc_cloud_context.c
@@ -21,6 +21,7 @@
 #ifdef OC_CLOUD
 
 #include "oc_cloud_context_internal.h"
+#include "oc_cloud_deregister_internal.h"
 #include "oc_cloud_internal.h"
 #include "oc_cloud_manager_internal.h"
 #include "oc_cloud_store_internal.h"
@@ -110,6 +111,7 @@ cloud_context_clear(oc_cloud_context_t *ctx)
   memset(ctx->cloud_ep, 0, sizeof(oc_endpoint_t));
   ctx->cloud_ep_state = OC_SESSION_DISCONNECTED;
   cloud_manager_stop(ctx);
+  cloud_deregister_stop(ctx);
   cloud_store_initialize(&ctx->store);
   ctx->last_error = 0;
   ctx->store.cps = 0;
@@ -124,18 +126,16 @@ cloud_context_size()
 }
 
 bool
-cloud_context_has_refresh_token(const oc_cloud_context_t *ctx)
+cloud_context_has_access_token(const oc_cloud_context_t *ctx)
 {
-  return oc_string(ctx->store.refresh_token) != NULL &&
-         oc_string_len(ctx->store.refresh_token) > 0;
+  return oc_string(ctx->store.access_token) != NULL &&
+         oc_string_len(ctx->store.access_token) > 0;
 }
 
 bool
 cloud_context_has_permanent_access_token(const oc_cloud_context_t *ctx)
 {
-  return oc_string(ctx->store.access_token) != NULL &&
-         oc_string_len(ctx->store.access_token) > 0 &&
-         ctx->store.expires_in < 0;
+  return cloud_context_has_access_token(ctx) && ctx->store.expires_in < 0;
 }
 
 void
@@ -143,6 +143,13 @@ cloud_context_clear_access_token(oc_cloud_context_t *ctx)
 {
   cloud_set_string(&ctx->store.access_token, NULL, 0);
   ctx->store.expires_in = 0;
+}
+
+bool
+cloud_context_has_refresh_token(const oc_cloud_context_t *ctx)
+{
+  return oc_string(ctx->store.refresh_token) != NULL &&
+         oc_string_len(ctx->store.refresh_token) > 0;
 }
 
 void

--- a/api/cloud/oc_cloud_context_internal.h
+++ b/api/cloud/oc_cloud_context_internal.h
@@ -61,11 +61,13 @@ void cloud_context_iterate(cloud_context_iterator_cb_t cb, void *user_data);
 void cloud_context_clear(oc_cloud_context_t *ctx);
 
 /**
- * @brief Check whether refresh token is set.
+ * @brief Check whether access token is set.
  *
  * @return true refresh token is set
+ * @return false otherwise
  */
-bool cloud_context_has_refresh_token(const oc_cloud_context_t *ctx);
+
+bool cloud_context_has_access_token(const oc_cloud_context_t *ctx);
 
 /**
  * @brief Checks whether the access token is set and whether it is permanent
@@ -73,11 +75,20 @@ bool cloud_context_has_refresh_token(const oc_cloud_context_t *ctx);
  * that the token is permanent).
  *
  * @return true access token is permanent
+ * @return false otherwise
  */
 bool cloud_context_has_permanent_access_token(const oc_cloud_context_t *ctx);
 
 /** @brief Clear access token from context */
 void cloud_context_clear_access_token(oc_cloud_context_t *ctx);
+
+/**
+ * @brief Check whether refresh token is set.
+ *
+ * @return true refresh token is set
+ * @return false otherwise
+ */
+bool cloud_context_has_refresh_token(const oc_cloud_context_t *ctx);
 
 #ifdef __cplusplus
 }

--- a/api/cloud/oc_cloud_deregister.c
+++ b/api/cloud/oc_cloud_deregister.c
@@ -57,11 +57,12 @@ cloud_deregister_on_reset_async_handler(oc_cloud_context_t *ctx,
   OC_DBG("[Cloud] cloud_deregister_on_reset_async_handler device=%zu",
          ctx->device);
   // this call might be invoked because of timeout (delayed call of
-  // oc_ri_remove_client_cb_with_notify_503 when the request is fired), however
-  // cloud_context_clear among other things closes the connected endpoint. This
-  // also invokes oc_ri_remove_client_cb_with_notify_503 for this call,
-  // causing memory issues. We schedule the context clear in a delayed callback,
-  // so this call removes itself from the queue of calls for the endpoint.
+  // oc_ri_remove_client_cb_with_notify_timeout_async when the request is
+  // fired), however cloud_context_clear among other things closes the connected
+  // endpoint. This closing for the endpoint connection also invokes
+  // oc_ri_remove_client_cb_with_notify_timeout_async for this call, causing
+  // memory issues. We schedule the context clear in a delayed callback, so this
+  // call removes itself from the queue of calls for the endpoint.
   cloud_reset_delayed_callback(ctx, cloud_deregister_context_clear_async, 0);
 }
 

--- a/api/cloud/oc_cloud_deregister.c
+++ b/api/cloud/oc_cloud_deregister.c
@@ -1,0 +1,360 @@
+/****************************************************************************
+ *
+ * Copyright (c) 2023 Daniel Adam, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"),
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#include "oc_config.h"
+
+#ifdef OC_CLOUD
+
+#include "oc_api.h"
+#include "oc_cloud_internal.h"
+#include "oc_cloud_access_internal.h"
+#include "oc_cloud_context_internal.h"
+#include "oc_cloud_deregister_internal.h"
+#include "oc_cloud_manager_internal.h"
+#include "oc_cloud_store_internal.h"
+
+#ifdef OC_SECURITY
+
+static void
+cloud_deregister_on_reset_handler(oc_cloud_context_t *ctx,
+                                  oc_cloud_status_t status, void *data)
+{
+  (void)status;
+  (void)data;
+  OC_DBG("[Cloud] cloud_deregister_on_reset_handler device=%zu", ctx->device);
+  cloud_context_clear(ctx);
+}
+
+static oc_event_callback_retval_t
+cloud_deregister_context_clear_async(void *data)
+{
+  oc_cloud_context_t *ctx = (oc_cloud_context_t *)data;
+  cloud_context_clear(ctx);
+  return OC_EVENT_DONE;
+}
+
+static void
+cloud_deregister_on_reset_async_handler(oc_cloud_context_t *ctx,
+                                        oc_cloud_status_t status, void *data)
+{
+  (void)status;
+  (void)data;
+  OC_DBG("[Cloud] cloud_deregister_on_reset_async_handler device=%zu",
+         ctx->device);
+  // this call might be invoked because of timeout (delayed call of
+  // oc_ri_remove_client_cb_with_notify_503 when the request is fired), however
+  // cloud_context_clear among other things closes the connected endpoint. This
+  // also invokes oc_ri_remove_client_cb_with_notify_503 for this call,
+  // causing memory issues. We schedule the context clear in a delayed callback,
+  // so this call removes itself from the queue of calls for the endpoint.
+  cloud_reset_delayed_callback(ctx, cloud_deregister_context_clear_async, 0);
+}
+
+static int
+cloud_deregister_on_reset_sync(oc_cloud_context_t *ctx, bool sync,
+                               uint16_t timeout)
+{
+  OC_DBG("[Cloud] cloud deregister on reset");
+  oc_cloud_cb_t handler = sync ? &cloud_deregister_on_reset_handler
+                               : &cloud_deregister_on_reset_async_handler;
+  int err = cloud_deregister(ctx, sync, timeout, handler, ctx);
+  if (err == 0 || err == CLOUD_DEREGISTER_ERROR_ALREADY_DEREGISTERING) {
+    return 0;
+  }
+  return -1;
+}
+
+static oc_event_callback_retval_t
+cloud_deregister_on_reset_async(void *data)
+{
+  cloud_api_param_t *p = (cloud_api_param_t *)data;
+  oc_cloud_context_t *ctx = p->ctx;
+  uint16_t timeout = p->timeout;
+  free_api_param(p);
+  if (cloud_deregister_on_reset_sync(ctx, /*sync*/ false, timeout) != 0) {
+    OC_ERR("[Cloud] failed to deregister from cloud");
+    cloud_context_clear(ctx);
+  }
+  return OC_EVENT_DONE;
+}
+
+bool
+cloud_deregister_on_reset(oc_cloud_context_t *ctx, bool sync, uint16_t timeout)
+{
+  cloud_manager_stop(ctx);
+  if (sync) {
+    return cloud_deregister_on_reset_sync(ctx, true, 0) == 0;
+  }
+
+  cloud_api_param_t *p = alloc_api_param();
+  if (p == NULL) {
+    OC_ERR("[Cloud] cannot allocate cloud parameters for reset");
+    return false;
+  }
+  p->ctx = ctx;
+  p->timeout = timeout;
+  cloud_reset_delayed_callback(p, cloud_deregister_on_reset_async, 0);
+  return true;
+}
+
+#endif /* OC_SECURITY */
+
+static void
+cloud_deregistered_internal(oc_client_response_t *data)
+{
+  cloud_api_param_t *p = (cloud_api_param_t *)data->user_data;
+  oc_cloud_context_t *ctx = p->ctx;
+  OC_DBG("Cloud deregister: deregistered for device=%zu", ctx->device);
+
+  if (data->code < OC_STATUS_BAD_REQUEST ||
+      cloud_is_connection_error_code(data->code)) {
+    ctx->store.status = OC_CLOUD_DEREGISTERED;
+  } else if (data->code >= OC_STATUS_BAD_REQUEST) {
+    cloud_set_last_error(ctx, CLOUD_ERROR_RESPONSE);
+    ctx->store.status |= OC_CLOUD_FAILURE;
+  }
+
+  ctx->store.cps = OC_CPS_UNINITIALIZED;
+
+  if (p->cb) {
+    p->cb(ctx, ctx->store.status, p->data);
+  }
+  free_api_param(p);
+
+  ctx->store.status &= ~(OC_CLOUD_FAILURE | OC_CLOUD_DEREGISTERED);
+
+  cloud_store_dump_async(&ctx->store);
+}
+
+static bool
+check_accesstoken_for_deregister(oc_cloud_context_t *ctx)
+{
+// This value is calculated by coap_oscore_serialize_message for deregister
+// message with empty query parameters. The value should remain the same
+// unless some global options are added to coap requests.
+// The deregister request won't be sent if the total size of its header is
+// greater than COAP_MAX_HEADER_SIZE, so we must ensure that the query
+// is not too large.
+// Some older cloud implementations require tokens in deregister requests.
+// To facilitate support for such implementations we append access token
+// to the request query if the resulting query size is within the limit.
+#define DEREGISTER_EMPTY_QUERY_HEADER_SIZE 38
+
+  oc_string_t query = cloud_access_deregister_query(
+    oc_string(ctx->store.uid), oc_string(ctx->store.access_token), ctx->device);
+  size_t query_size = oc_string_len(query);
+  oc_free_string(&query);
+
+  return DEREGISTER_EMPTY_QUERY_HEADER_SIZE + query_size <=
+         COAP_MAX_HEADER_SIZE;
+}
+
+static int
+cloud_deregister_by_request(cloud_api_param_t *p, uint16_t timeout,
+                            bool useAccessToken)
+{
+  assert(p != NULL);
+
+  oc_cloud_context_t *ctx = p->ctx;
+  OC_DBG("try deregister device %zu by DELETE request", ctx->device);
+  oc_cloud_access_conf_t conf = {
+    .device = ctx->device,
+    .selected_identity_cred_id = ctx->selected_identity_cred_id,
+    .handler = cloud_deregistered_internal,
+    .user_data = p,
+    .timeout = timeout,
+  };
+  if (oc_string(ctx->store.ci_server) == NULL ||
+      conv_cloud_endpoint(ctx) != 0) {
+    goto error;
+  }
+  conf.endpoint = ctx->cloud_ep;
+
+  if (cloud_access_deregister(
+        conf, oc_string(ctx->store.uid),
+        useAccessToken ? oc_string(ctx->store.access_token) : NULL)) {
+    return 0;
+  }
+
+error:
+  cloud_set_last_error(ctx, CLOUD_ERROR_CONNECT);
+  return -1;
+}
+
+static void
+cloud_deregister_try_logged_in(oc_cloud_context_t *ctx,
+                               oc_cloud_status_t status, void *data)
+{
+  OC_DBG("Cloud deregister: logged in for device=%zu", ctx->device);
+  cloud_api_param_t *p = (cloud_api_param_t *)data;
+
+  if ((status & OC_CLOUD_LOGGED_IN) == 0) {
+    OC_ERR("Failed to login to cloud for deregister");
+    free_api_param(p);
+    cloud_context_clear(ctx);
+    return;
+  }
+
+  if (cloud_deregister_by_request(p, p->timeout, false) != 0) {
+    OC_ERR("Failed to deregister from cloud");
+    free_api_param(p);
+    cloud_context_clear(ctx);
+    return;
+  }
+}
+
+static oc_event_callback_retval_t
+cloud_deregister_refreshed_token_async(void *data)
+{
+  cloud_api_param_t *p = (cloud_api_param_t *)data;
+  // short access token -> we can use it in query and deregister without login
+  if (check_accesstoken_for_deregister(p->ctx)) {
+    if (cloud_deregister_by_request(p, p->timeout, true) != 0) {
+      OC_ERR("Failed to deregister from cloud");
+      free_api_param(p);
+      cloud_context_clear(p->ctx);
+    }
+    return OC_EVENT_DONE;
+  }
+
+  // long access token -> we must login and then deregister without token
+  if (cloud_login(p->ctx, cloud_deregister_try_logged_in, p, p->timeout) != 0) {
+    OC_ERR("Failed to login to cloud for deregister");
+    free_api_param(p);
+    cloud_context_clear(p->ctx);
+    return OC_EVENT_DONE;
+  }
+  return OC_EVENT_DONE;
+}
+
+static void
+cloud_deregister_try_refreshed_token(oc_cloud_context_t *ctx,
+                                     oc_cloud_status_t status, void *data)
+{
+  OC_DBG("Cloud deregister: refreshed token for device=%zu", ctx->device);
+  cloud_api_param_t *p = (cloud_api_param_t *)data;
+  if ((status & OC_CLOUD_REFRESHED_TOKEN) == 0) {
+    OC_ERR("Failed to refresh access token for deregister");
+    free_api_param(p);
+    cloud_context_clear(ctx);
+    return;
+  }
+
+  // invoke in a delayed callback so, the cloud_api_param_t* structure allocated
+  // by cloud_deregister is deallocated before new one is allocated
+  oc_set_delayed_callback(p, cloud_deregister_refreshed_token_async, 0);
+}
+
+int
+cloud_deregister(oc_cloud_context_t *ctx, bool sync, uint16_t timeout,
+                 oc_cloud_cb_t cb, void *data)
+{
+  if ((ctx->store.status & OC_CLOUD_REGISTERED) == 0) {
+    OC_ERR("invalid cloud status(%d) for deregister", (int)ctx->store.status);
+    return -1;
+  }
+
+  if (cloud_is_deregistering(ctx)) {
+    OC_DBG("Device(%zu) is already deregistering, skipped", ctx->device);
+    return CLOUD_DEREGISTER_ERROR_ALREADY_DEREGISTERING;
+  }
+
+  cloud_api_param_t *p = alloc_api_param();
+  if (p == NULL) {
+    OC_ERR("cannot allocate cloud parameters");
+    return -1;
+  }
+  p->ctx = ctx;
+  p->cb = cb;
+  p->data = data;
+  p->timeout = timeout;
+
+  OC_DBG("Deregistering of device=%zu started", ctx->device);
+  cloud_set_cps(ctx, OC_CPS_DEREGISTERING);
+
+  bool canUseAccessToken = check_accesstoken_for_deregister(ctx);
+  bool isLoggedIn = (ctx->store.status & OC_CLOUD_LOGGED_IN) != 0;
+  // either we have a short access token or we are already logged in, so we can
+  // execute deregister
+  if (canUseAccessToken || isLoggedIn) {
+    if (cloud_deregister_by_request(p, p->timeout, canUseAccessToken) != 0) {
+      OC_ERR("Failed to deregister from cloud");
+      free_api_param(p);
+      return -1;
+    }
+    return 0;
+  }
+
+  if (sync) {
+    OC_ERR("Asynchronous deregister from cloud not allowed");
+    free_api_param(p);
+    return -1;
+  }
+
+  // otherwise we must log in, try first with an refresh token if we have it
+  bool hasRefreshToken = cloud_context_has_refresh_token(ctx) &&
+                         !cloud_context_has_permanent_access_token(ctx);
+  if (hasRefreshToken) {
+    if (cloud_refresh_token(ctx, cloud_deregister_try_refreshed_token, p,
+                            timeout) != 0) {
+      OC_ERR("Failed to refresh token for deregister");
+      free_api_param(p);
+      return -1;
+    }
+    return 0;
+  }
+
+  // otherwise try full log in
+  if (cloud_login(ctx, cloud_deregister_try_logged_in, p, timeout) != 0) {
+    OC_ERR("Failed to login to cloud for deregister");
+    free_api_param(p);
+    return -1;
+  }
+  return 0;
+}
+
+static bool
+cloud_match_context(const void *cb_data, const void *filter_data)
+{
+  const cloud_api_param_t *p = (const cloud_api_param_t *)cb_data;
+  const oc_cloud_context_t *ctx = (const oc_cloud_context_t *)filter_data;
+  return p->ctx == ctx;
+}
+
+static void
+cloud_free_api_param(void *cb_data)
+{
+  cloud_api_param_t *p = (cloud_api_param_t *)cb_data;
+  free_api_param(p);
+}
+
+void
+cloud_deregister_stop(oc_cloud_context_t *ctx)
+{
+  oc_remove_delayed_callback_by_filter(cloud_deregister_refreshed_token_async,
+                                       cloud_match_context, ctx, true,
+                                       cloud_free_api_param);
+#ifdef OC_SECURITY
+  oc_remove_delayed_callback(ctx, cloud_deregister_context_clear_async);
+  oc_remove_delayed_callback_by_filter(cloud_deregister_on_reset_async,
+                                       cloud_match_context, ctx, true,
+                                       cloud_free_api_param);
+#endif /* OC_SECURITY */
+}
+
+#endif /* OC_CLOUD */

--- a/api/cloud/oc_cloud_deregister_internal.h
+++ b/api/cloud/oc_cloud_deregister_internal.h
@@ -1,0 +1,84 @@
+/****************************************************************************
+ *
+ * Copyright (c) 2023 Daniel Adam, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"),
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifndef OC_CLOUD_DEREGISTER_INTERNAL_H
+#define OC_CLOUD_DEREGISTER_INTERNAL_H
+
+#include "oc_cloud.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Timeout for deregistering requests
+#define CLOUD_DEREGISTER_TIMEOUT 10
+
+/// Error when attempting to multiple deregistrations concurrently
+#define CLOUD_DEREGISTER_ERROR_ALREADY_DEREGISTERING -2
+
+/**
+ * @brief Execute cloud deregister
+ *
+ * @note If the device is not signed-in then access token is required in the
+ * deregistering request. However, the size of the request header is limited, if
+ * the access token is long then we will attempt to sign-in.
+ * The deregistration operation because asynchronous in this case, since we have
+ * to wait for responses from the server.
+ *
+ * @param ctx device context (cannot be NULL)
+ * @param sync force synchronous execution (function won't attempt to login and
+ * will just fail)
+ * @param timeout request timeout
+ * @param cb callback executed after successful deregister
+ * @param data user data provided to deregister callback
+ * @return 0 on success
+ * @return CLOUD_DEREGISTER_ERROR_ALREADY_DEREGISTERING if deregister is already
+ * being executed for given device
+ * @return -1 on other errors
+ */
+int cloud_deregister(oc_cloud_context_t *ctx, bool sync, uint16_t timeout,
+                     oc_cloud_cb_t cb, void *data);
+
+/**
+ * @brief Execute cloud deregister triggered by cloud_reset.
+ *
+ * @param ctx device context (cannot be NULL)
+ * @param sync force synchronous execution (function won't attempt to login and
+ * will just fail)
+ * @param timeout request timeout
+ * @return true on success
+ * @return false on failure
+ */
+bool cloud_deregister_on_reset(oc_cloud_context_t *ctx, bool sync,
+                               uint16_t timeout);
+
+/**
+ * @brief Clean-up all events by deregister.
+ *
+ * @param ctx device context (cannot be NULL);
+ */
+void cloud_deregister_stop(oc_cloud_context_t *ctx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OC_CLOUD_DEREGISTER_INTERNAL_H */

--- a/api/cloud/oc_cloud_rd.c
+++ b/api/cloud/oc_cloud_rd.c
@@ -2,7 +2,7 @@
  *
  * Copyright 2019 Jozef Kralik All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License"),
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -108,7 +108,7 @@ static void
 publish_resources_handler(oc_client_response_t *data)
 {
   oc_cloud_context_t *ctx = (oc_cloud_context_t *)data->user_data;
-  OC_DBG("[CRD] publish resources handler(%d)\n", data->code);
+  OC_DBG("[CRD] publish resources handler(%d)", data->code);
 
   if ((ctx->store.status & OC_CLOUD_LOGGED_IN) == 0) {
     return;
@@ -208,7 +208,7 @@ publish_published_resources(void *data)
 static void
 delete_resources_handler(oc_client_response_t *data)
 {
-  OC_DBG("[CRD] delete resources handler(%d)\n", data->code);
+  OC_DBG("[CRD] delete resources handler(%d)", data->code);
   (void)data;
 }
 

--- a/api/cloud/oc_cloud_resource.c
+++ b/api/cloud/oc_cloud_resource.c
@@ -2,7 +2,7 @@
  *
  * Copyright 2019 Jozef Kralik All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License"),
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -22,6 +22,7 @@
 
 #include "oc_api.h"
 #include "oc_cloud_internal.h"
+#include "oc_cloud_resource_internal.h"
 #include "oc_cloud_store_internal.h"
 #include "oc_core_res.h"
 

--- a/api/cloud/oc_cloud_resource_internal.h
+++ b/api/cloud/oc_cloud_resource_internal.h
@@ -1,0 +1,35 @@
+/****************************************************************************
+ *
+ * Copyright (c) 2023 Daniel Adam, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"),
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifndef OC_CLOUD_RESOURCE_INTERNAL_H
+#define OC_CLOUD_RESOURCE_INTERNAL_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Create CoAPCloudConf resource
+void oc_create_cloudconf_resource(size_t device);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OC_CLOUD_RESOURCE_INTERNAL_H */

--- a/api/cloud/oc_cloud_store.c
+++ b/api/cloud/oc_cloud_store.c
@@ -3,7 +3,7 @@
  * Copyright 2019 Jozef Kralik All Rights Reserved.
  * Copyright 2018 Samsung Electronics All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License"),
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -291,7 +291,7 @@ cloud_store_load_internal(const char *store_name, oc_cloud_store_t *store)
 #ifdef OC_DYNAMIC_ALLOCATION
   uint8_t *buf = malloc(OC_MAX_APP_DATA_SIZE);
   if (!buf) {
-    OC_ERR("[CLOUD_STORE] alloc failed!\n");
+    OC_ERR("[CLOUD_STORE] alloc failed!");
     return -1;
   }
 #else  /* OC_DYNAMIC_ALLOCATION */

--- a/api/cloud/rd_client.c
+++ b/api/cloud/rd_client.c
@@ -3,7 +3,7 @@
  * Copyright 2019 Jozef Kralik All Rights Reserved.
  * Copyright 2018 Samsung Electronics All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License"),
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -16,6 +16,9 @@
  * language governing permissions and limitations under the License.
  *
  ****************************************************************************/
+
+#include "oc_config.h"
+
 #ifdef OC_CLOUD
 
 #include "rd_client.h"
@@ -175,6 +178,5 @@ rd_delete(oc_endpoint_t *endpoint, oc_link_t *links, size_t device,
   return rd_delete_with_device_id(endpoint, links, uuid, handler, qos,
                                   user_data);
 }
-#else  /* OC_CLOUD*/
-typedef int dummy_declaration;
-#endif /* !OC_CLOUD */
+
+#endif /* OC_CLOUD */

--- a/api/cloud/rd_client.h
+++ b/api/cloud/rd_client.h
@@ -3,7 +3,7 @@
  * Copyright 2019 Jozef Kralik All Rights Reserved.
  * Copyright 2018 Samsung Electronics All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License"),
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/api/cloud/unittest/cloud_access_test.cpp
+++ b/api/cloud/unittest/cloud_access_test.cpp
@@ -3,7 +3,7 @@
  * Copyright 2019 Jozef Kralik All Rights Reserved.
  * Copyright 2018 Samsung Electronics All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License"),
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/api/cloud/unittest/cloud_manager_test.cpp
+++ b/api/cloud/unittest/cloud_manager_test.cpp
@@ -3,7 +3,7 @@
  * Copyright 2019 Jozef Kralik All Rights Reserved.
  * Copyright 2018 Samsung Electronics All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License"),
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/api/cloud/unittest/cloud_rd_test.cpp
+++ b/api/cloud/unittest/cloud_rd_test.cpp
@@ -2,7 +2,7 @@
  *
  * Copyright 2019 Jozef Kralik All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License"),
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/api/cloud/unittest/cloud_resource_test.cpp
+++ b/api/cloud/unittest/cloud_resource_test.cpp
@@ -2,7 +2,7 @@
  *
  * Copyright 2019 Jozef Kralik All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License"),
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/api/cloud/unittest/cloud_store_test.cpp
+++ b/api/cloud/unittest/cloud_store_test.cpp
@@ -3,7 +3,7 @@
  * Copyright 2019 Jozef Kralik All Rights Reserved.
  * Copyright 2018 Samsung Electronics All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License"),
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/api/cloud/unittest/cloud_test.cpp
+++ b/api/cloud/unittest/cloud_test.cpp
@@ -2,7 +2,7 @@
  *
  * Copyright 2019 Jozef Kralik All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License"),
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/api/cloud/unittest/rd_client_test.cpp
+++ b/api/cloud/unittest/rd_client_test.cpp
@@ -3,7 +3,7 @@
  * Copyright 2019 Jozef Kralik All Rights Reserved.
  * Copyright 2018 Samsung Electronics All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License"),
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/api/oc_client_api.c
+++ b/api/oc_client_api.c
@@ -394,8 +394,8 @@ oc_do_request_with_timeout(oc_method_t method, const char *uri,
     return false;
   }
   if (timeout_seconds > 0) {
-    oc_set_delayed_callback(cb, oc_ri_remove_client_cb_with_notify_503,
-                            timeout_seconds);
+    oc_set_delayed_callback(
+      cb, oc_ri_remove_client_cb_with_notify_timeout_async, timeout_seconds);
   }
   return true;
 }
@@ -477,8 +477,8 @@ oc_do_async_request_with_timeout(uint16_t timeout_seconds, oc_method_t method)
   }
 
   if (timeout_seconds > 0) {
-    oc_set_delayed_callback(cb, oc_ri_remove_client_cb_with_notify_503,
-                            timeout_seconds);
+    oc_set_delayed_callback(
+      cb, oc_ri_remove_client_cb_with_notify_timeout_async, timeout_seconds);
   }
   return true;
 }

--- a/api/oc_core_res.c
+++ b/api/oc_core_res.c
@@ -1,32 +1,39 @@
-/*
- // Copyright (c) 2016 Intel Corporation
- //
- // Licensed under the Apache License, Version 2.0 (the "License");
- // you may not use this file except in compliance with the License.
- // You may obtain a copy of the License at
- //
- //      http://www.apache.org/licenses/LICENSE-2.0
- //
- // Unless required by applicable law or agreed to in writing, software
- // distributed under the License is distributed on an "AS IS" BASIS,
- // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- // See the License for the specific language governing permissions and
- // limitations under the License.
- */
+/****************************************************************************
+ *
+ * Copyright (c) 2016 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"),
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
+#include "messaging/coap/oc_coap.h"
+#include "port/oc_assert.h"
+#include "util/oc_atomic.h"
 #include "util/oc_features.h"
 #include "oc_core_res.h"
-#include "api/cloud/oc_cloud_internal.h"
 #include "oc_api.h"
-#ifdef OC_MNT
-#include "api/oc_mnt.h"
-#endif /* OC_MNT */
-#include "messaging/coap/oc_coap.h"
 #include "oc_discovery.h"
 #include "oc_introspection_internal.h"
 #include "oc_rep.h"
 #include "oc_main.h"
-#include "util/oc_atomic.h"
+
+#ifdef OC_CLOUD
+#include "api/cloud/oc_cloud_resource_internal.h"
+#endif /* OC_CLOUD */
+
+#ifdef OC_MNT
+#include "api/oc_mnt.h"
+#endif /* OC_MNT */
 
 #ifdef OC_SECURITY
 #include "security/oc_doxm.h"
@@ -34,7 +41,6 @@
 #include "security/oc_tls.h"
 #endif /* OC_SECURITY */
 
-#include "port/oc_assert.h"
 #include <stdarg.h>
 #include <stdint.h>
 
@@ -265,7 +271,7 @@ oc_core_con_handler_post(oc_request_t *request, oc_interface_mask_t iface_mask,
 #if defined(OC_SERVER)
       oc_notify_observers_delayed(oc_core_get_resource_by_index(OCF_D, device),
                                   0);
-#endif /* OC_SERVER && OC_CLOUD */
+#endif /* OC_SERVER */
 
       changed = true;
       break;

--- a/api/oc_push.c
+++ b/api/oc_push.c
@@ -2298,7 +2298,7 @@ response_to_push_rsc(oc_client_response_t *data)
   OC_PUSH_DBG("\n   => return status code: [ %s ]",
               oc_status_to_str(data->code));
 
-  if (data->code == OC_STATUS_SERVICE_UNAVAILABLE) {
+  if (data->code == OC_REQUEST_TIMEOUT) {
     /*
      * TODO4ME <2022/4/17> if update request fails... retry to resolve endpoint
      * of target device ID...

--- a/api/oc_ri_internal.h
+++ b/api/oc_ri_internal.h
@@ -31,12 +31,13 @@
 oc_event_callback_retval_t oc_ri_remove_client_cb(void *cb);
 
 /**
- * @brief removes the client callback with triggering
- * OC_REQUEST_TIMEOUT to handler.
+ * @brief removes the client callback with triggering OC_REQUEST_TIMEOUT to
+ * handler.
  *
  * @param cb is oc_client_cb_t* type
  * @return returns OC_EVENT_DONE
  */
-oc_event_callback_retval_t oc_ri_remove_client_cb_with_notify_503(void *cb);
+oc_event_callback_retval_t oc_ri_remove_client_cb_with_notify_timeout_async(
+  void *cb);
 
 #endif /* OC_RI_INTERNAL_H */

--- a/api/oc_server_api.c
+++ b/api/oc_server_api.c
@@ -154,9 +154,11 @@ oc_has_delayed_callback(void *cb_data, oc_trigger_t callback,
 void
 oc_remove_delayed_callback_by_filter(oc_trigger_t cb,
                                      oc_ri_timed_event_filter_t filter,
-                                     const void *filter_data)
+                                     const void *filter_data, bool match_all,
+                                     oc_ri_timed_event_on_delete_t on_delete)
 {
-  oc_ri_remove_timed_event_callback_by_filter(cb, filter, filter_data);
+  oc_ri_remove_timed_event_callback_by_filter(cb, filter, filter_data,
+                                              match_all, on_delete);
 }
 
 void

--- a/api/oc_server_api.c
+++ b/api/oc_server_api.c
@@ -152,6 +152,14 @@ oc_has_delayed_callback(void *cb_data, oc_trigger_t callback,
 }
 
 void
+oc_remove_delayed_callback_by_filter(oc_trigger_t cb,
+                                     oc_ri_timed_event_filter_t filter,
+                                     const void *filter_data)
+{
+  oc_ri_remove_timed_event_callback_by_filter(cb, filter, filter_data);
+}
+
+void
 oc_remove_delayed_callback(void *cb_data, oc_trigger_t callback)
 {
   oc_ri_remove_timed_event_callback(cb_data, callback);

--- a/include/oc_api.h
+++ b/include/oc_api.h
@@ -1,18 +1,20 @@
-/*
-// Copyright (c) 2016-2019 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+/****************************************************************************
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"),
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /**
   @brief Main API of IoTivity-Lite for client and server.
@@ -29,9 +31,7 @@
 #ifndef OC_API_H
 #define OC_API_H
 
-#include "util/oc_features.h"
 #include "messaging/coap/oc_coap.h"
-#include "port/oc_storage.h"
 #include "oc_buffer_settings.h"
 #include "oc_cloud.h"
 #include "oc_config.h"
@@ -39,6 +39,8 @@
 #include "oc_rep.h"
 #include "oc_ri.h"
 #include "oc_signal_event_loop.h"
+#include "port/oc_storage.h"
+#include "util/oc_features.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -2365,6 +2367,7 @@ void oc_set_immutable_device_identifier(size_t device, oc_uuid_t *piid);
  * @param[in] callback the callback invoked after the set number of seconds
  * @param[in] seconds the number of seconds to wait till the callback is invoked
  */
+OC_API
 void oc_set_delayed_callback(void *cb_data, oc_trigger_t callback,
                              uint16_t seconds);
 
@@ -2377,6 +2380,7 @@ void oc_set_delayed_callback(void *cb_data, oc_trigger_t callback,
  * @param[in] miliseconds the number of miliseconds to wait till the callback is
  * invoked
  */
+OC_API
 void oc_set_delayed_callback_ms(void *cb_data, oc_trigger_t callback,
                                 uint16_t miliseconds);
 
@@ -2394,16 +2398,33 @@ void oc_set_delayed_callback_ms(void *cb_data, oc_trigger_t callback,
  * @return true matching delayed callback was found
  * @return false otherwise
  */
+OC_API
 bool oc_has_delayed_callback(void *cb_data, oc_trigger_t callback,
                              bool ignore_cb_data);
+
+/**
+ * @brief Cancel a scheduled delayed callback by matching it by the provided
+ * filtering function.
+ *
+ * @param[in] cb the delayed callback that is being removed
+ * @param[in] filter filtering function (cannot be NULL)
+ * @param[in] filter_data user data provided to the filtering function
+ *
+ * @see oc_ri_timed_event_filter_t
+ */
+OC_API
+void oc_remove_delayed_callback_by_filter(oc_trigger_t cb,
+                                          oc_ri_timed_event_filter_t filter,
+                                          const void *filter_data);
 
 /**
  * Cancel a scheduled delayed callback.
  *
  * @param[in] cb_data the user defined context pointer that was passed to the
- *                   oc_sed_delayed_callback() function
+ *                   oc_set_delayed_callback() function
  * @param[in] callback the delayed callback that is being removed
  */
+OC_API
 void oc_remove_delayed_callback(void *cb_data, oc_trigger_t callback);
 
 /** API for setting handlers for interrupts */

--- a/include/oc_api.h
+++ b/include/oc_api.h
@@ -2409,13 +2409,23 @@ bool oc_has_delayed_callback(void *cb_data, oc_trigger_t callback,
  * @param[in] cb the delayed callback that is being removed
  * @param[in] filter filtering function (cannot be NULL)
  * @param[in] filter_data user data provided to the filtering function
+ * @param[in] match_all iterate over all delayed callbacks (otherwise the
+ * iteration will stop after the first match)
+ * @param[in] on_delete function invoked with the context data of the delayed
+ * callback, before the callback is deallocated
+ *
+ * @note if the matched timed event is currently being processed then the \p
+ * on_delete callback will be invoked when the processing is finished. So it
+ * might occurr some time after the call to
+ * oc_ri_remove_timed_event_callback_by_filter has finished.
  *
  * @see oc_ri_timed_event_filter_t
+ * @see oc_ri_timed_event_on_delete_t
  */
 OC_API
-void oc_remove_delayed_callback_by_filter(oc_trigger_t cb,
-                                          oc_ri_timed_event_filter_t filter,
-                                          const void *filter_data);
+void oc_remove_delayed_callback_by_filter(
+  oc_trigger_t cb, oc_ri_timed_event_filter_t filter, const void *filter_data,
+  bool match_all, oc_ri_timed_event_on_delete_t on_delete);
 
 /**
  * Cancel a scheduled delayed callback.

--- a/include/oc_cloud.h
+++ b/include/oc_cloud.h
@@ -202,6 +202,12 @@ int oc_cloud_logout(oc_cloud_context_t *ctx, oc_cloud_cb_t cb, void *data);
  * @param data user data provided to the status change function
  * @return int 0 on success
  * @return int -1 on error
+ *
+ * @note oc_cloud_deregister shouldn't be called when oc_cloud_login or
+ * oc_cloud_refresh_token have been invoked and haven't yet received a response.
+ *
+ * @see oc_cloud_login
+ * @see oc_cloud_refresh_token
  */
 OC_API
 int oc_cloud_deregister(oc_cloud_context_t *ctx, oc_cloud_cb_t cb, void *data);

--- a/include/oc_ri.h
+++ b/include/oc_ri.h
@@ -1,18 +1,20 @@
-/*
-// Copyright (c) 2016-2019 Intel Corporation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-*/
+/****************************************************************************
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"),
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
 /**
   @file
 */
@@ -22,6 +24,7 @@
 #include "oc_config.h"
 #include "oc_endpoint.h"
 #include "oc_enums.h"
+#include "oc_export.h"
 #include "oc_rep.h"
 #include "oc_uuid.h"
 #include "util/oc_etimer.h"
@@ -382,12 +385,25 @@ void oc_ri_init(void);
 void oc_ri_shutdown(void);
 
 /**
+ * @brief Filtering function used to match scheduled timed events by context
+ * data.
+ *
+ * @param cb_data Data for the timed event callback
+ * @param filter_data User data passed from the caller to the filtering function
+ *
+ * @see oc_ri_remove_timed_event_callback_by_filter
+ */
+typedef bool (*oc_ri_timed_event_filter_t)(const void *cb_data,
+                                           const void *filter_data);
+
+/**
  * @brief add timed event callback
  *
  * @param cb_data the timed event callback info
  * @param event_callback the callback
  * @param ticks time in ticks
  */
+OC_API
 void oc_ri_add_timed_event_callback_ticks(void *cb_data,
                                           oc_trigger_t event_callback,
                                           oc_clock_time_t ticks);
@@ -421,16 +437,31 @@ void oc_ri_add_timed_event_callback_ticks(void *cb_data,
  * @return true matching timed event callback was found
  * @return false otherwise
  */
+OC_API
 bool oc_ri_has_timed_event_callback(const void *cb_data,
                                     oc_trigger_t event_callback,
                                     bool ignore_cb_data);
 
 /**
+ * @brief remove the timed event callback by filter
+ *
+ * @param cb timed event callback
+ * @param filter filtering function (cannot be NULL)
+ * @param filter_data user data provided to the filtering function
+ *
+ * @see oc_ri_timed_event_filter_t
+ */
+OC_API
+void oc_ri_remove_timed_event_callback_by_filter(
+  oc_trigger_t cb, oc_ri_timed_event_filter_t filter, const void *filter_data);
+
+/**
  * @brief remove the timed event callback
  *
- * @param cb_data the timed event callback info
- * @param event_callback the callback
+ * @param cb_data timed event callback info
+ * @param event_callback timed event callback
  */
+OC_API
 void oc_ri_remove_timed_event_callback(const void *cb_data,
                                        oc_trigger_t event_callback);
 

--- a/include/oc_ri.h
+++ b/include/oc_ri.h
@@ -397,6 +397,17 @@ typedef bool (*oc_ri_timed_event_filter_t)(const void *cb_data,
                                            const void *filter_data);
 
 /**
+ * @brief Function invoked with timed event context data before the timed event
+ * is deallocated.
+ *
+ * @note Expected use case is for a dynamically allocated context to be
+ * deallocated by this callback.
+ *
+ * @see oc_ri_remove_timed_event_callback_by_filter
+ */
+typedef void (*oc_ri_timed_event_on_delete_t)(void *cb_data);
+
+/**
  * @brief add timed event callback
  *
  * @param cb_data the timed event callback info
@@ -448,12 +459,22 @@ bool oc_ri_has_timed_event_callback(const void *cb_data,
  * @param cb timed event callback
  * @param filter filtering function (cannot be NULL)
  * @param filter_data user data provided to the filtering function
+ * @param match_all iterate over all timed events (otherwise the iteration will
+ * stop after the first match)
+ * @param on_delete function invoked with the context data of the timed event,
+ * before the event is deallocated
+ *
+ * @note if the matched timed event is currently being processed then the \p
+ * on_delete callback will be invoked when the processing is finished. So it
+ * might occurr some time after the call to
+ * oc_ri_remove_timed_event_callback_by_filter has finished.
  *
  * @see oc_ri_timed_event_filter_t
  */
 OC_API
 void oc_ri_remove_timed_event_callback_by_filter(
-  oc_trigger_t cb, oc_ri_timed_event_filter_t filter, const void *filter_data);
+  oc_trigger_t cb, oc_ri_timed_event_filter_t filter, const void *filter_data,
+  bool match_all, oc_ri_timed_event_on_delete_t on_delete);
 
 /**
  * @brief remove the timed event callback

--- a/port/esp32/main/CMakeLists.txt
+++ b/port/esp32/main/CMakeLists.txt
@@ -81,6 +81,7 @@ if (CONFIG_CLOUD)
   	${CMAKE_CURRENT_SOURCE_DIR}/../../../api/cloud/oc_cloud_access.c
   	${CMAKE_CURRENT_SOURCE_DIR}/../../../api/cloud/oc_cloud_apis.c
 	${CMAKE_CURRENT_SOURCE_DIR}/../../../api/cloud/oc_cloud_context.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../../api/cloud/oc_cloud_deregister.c
 	${CMAKE_CURRENT_SOURCE_DIR}/../../../api/cloud/oc_cloud_manager.c
 	${CMAKE_CURRENT_SOURCE_DIR}/../../../api/cloud/oc_cloud_rd.c
 	${CMAKE_CURRENT_SOURCE_DIR}/../../../api/cloud/oc_cloud_resource.c

--- a/security/oc_obt.c
+++ b/security/oc_obt.c
@@ -796,8 +796,7 @@ pstat_POST_dos1_to_dos2(oc_client_response_t *data)
 
   oc_switch_dos_ctx_t *d = (oc_switch_dos_ctx_t *)data->user_data;
 
-  if (data->code >= OC_STATUS_BAD_REQUEST &&
-      data->code != OC_STATUS_SERVICE_UNAVAILABLE) {
+  if (data->code >= OC_STATUS_BAD_REQUEST && data->code != OC_REQUEST_TIMEOUT) {
     free_switch_dos_ctx(d, -1);
     return;
   }

--- a/security/oc_pstat.c
+++ b/security/oc_pstat.c
@@ -163,13 +163,12 @@ oc_pstat_handle_state(oc_sec_pstat_t *ps, size_t device, bool from_storage,
     ps->tm = 2;
     ps->om = 3;
     ps->sm = 4;
-#ifdef OC_SERVER
-#ifdef OC_CLIENT
-#ifdef OC_CLOUD
-    cloud_reset(device);
-#endif /* OC_CLOUD */
-#endif /* OC_CLIENT */
-#endif /* OC_SERVER */
+#if defined(OC_SERVER) && defined(OC_CLIENT) && defined(OC_CLOUD)
+    cloud_reset(device, true, 0);
+    // TODO: we can allow async mode, but handling of OC_DOS_RESET that follows
+    // the reset call must be invoked asynchronously in a callback after
+    // cloud_reset finishes. Otherwise the cloud_reset won't execute correctly.
+#endif /* OC_SERVER && OC_CLIENT && OC_CLOUD */
     memset(ps->rowneruuid.id, 0, 16);
     oc_sec_doxm_default(device);
     oc_sec_cred_default(device);


### PR DESCRIPTION
Setting empty server forces deregistration from the original cloud server (if the device is connected to it). This is done by sending a deregister request to the cloud.
When the deregistration is triggered by a receiving a POST request form the server then creating a new request ovewrites the global shared buffer for requests. Because the original POST request is waiting for response and will try to use the buffer already used and freed by the deregistration request.

The solution is to execute deregistration only after the POST response has been sent.