### PR TITLE
Fix error when publishing docker images to Ghcr

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -53,6 +53,10 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2
+        # https://github.com/docker/build-push-action/issues/761
+        with:
+          driver-opts: |
+            image=moby/buildkit:v0.10.6
 
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9


### PR DESCRIPTION
When building several images, some of them fail with 'io: read/write on closed pipe' error and cause the whole job to fail.
The issue is in build-push-action:
https://github.com/docker/build-push-action/issues/761