### PR TITLE
api: use code OC_REQUEST_TIMEOUT for timeouts

### DIFF
--- a/api/cloud/oc_cloud_context.c
+++ b/api/cloud/oc_cloud_context.c
@@ -1,0 +1,160 @@
+/****************************************************************************
+ *
+ * Copyright (c) 2022 Daniel Adam, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"),
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#include "oc_config.h"
+
+#ifdef OC_CLOUD
+
+#include "oc_cloud_context_internal.h"
+#include "oc_cloud_internal.h"
+#include "oc_cloud_manager_internal.h"
+#include "oc_cloud_store_internal.h"
+#include "oc_core_res.h"
+#include "oc_endpoint.h"
+#include "oc_session_events.h"
+
+#ifdef OC_SECURITY
+#include "security/oc_pstat.h"
+#endif /* OC_SECURITY */
+
+#include <assert.h>
+
+OC_LIST(g_cloud_context_list);
+OC_MEMB(g_cloud_context_pool, oc_cloud_context_t, OC_MAX_NUM_DEVICES);
+
+oc_cloud_context_t *
+cloud_context_init(size_t device)
+{
+  oc_cloud_context_t *ctx =
+    (oc_cloud_context_t *)oc_memb_alloc(&g_cloud_context_pool);
+  if (ctx == NULL) {
+    OC_ERR("insufficient memory to create cloud context");
+    return NULL;
+  }
+  ctx->next = NULL;
+  ctx->device = device;
+  ctx->cloud_ep_state = OC_SESSION_DISCONNECTED;
+  ctx->cloud_ep = oc_new_endpoint();
+  ctx->selected_identity_cred_id = -1;
+  cloud_store_load(&ctx->store);
+  ctx->store.status &=
+    ~(OC_CLOUD_LOGGED_IN | OC_CLOUD_TOKEN_EXPIRY | OC_CLOUD_REFRESHED_TOKEN |
+      OC_CLOUD_LOGGED_OUT | OC_CLOUD_FAILURE | OC_CLOUD_DEREGISTERED);
+#ifdef OC_SECURITY
+  const oc_sec_pstat_t *ps = oc_sec_get_pstat(device);
+  if (ps->s == OC_DOS_RFOTM || ps->s == OC_DOS_RESET) {
+    // loaded configuration can have stored old cloud data
+    cloud_store_initialize(&ctx->store);
+  }
+#endif
+  ctx->time_to_live = RD_PUBLISH_TTL_UNLIMITED;
+  ctx->cloud_conf = oc_core_get_resource_by_index(OCF_COAPCLOUDCONF, device);
+  ctx->cloud_manager = false;
+  oc_list_add(g_cloud_context_list, ctx);
+
+  return ctx;
+}
+
+void
+cloud_context_deinit(oc_cloud_context_t *ctx)
+{
+  cloud_rd_deinit(ctx);
+  cloud_store_deinitialize(&ctx->store);
+  cloud_close_endpoint(ctx->cloud_ep);
+  oc_free_endpoint(ctx->cloud_ep);
+  oc_list_remove(g_cloud_context_list, ctx);
+  oc_memb_free(&g_cloud_context_pool, ctx);
+}
+
+oc_cloud_context_t *
+oc_cloud_get_context(size_t device)
+{
+  oc_cloud_context_t *ctx = oc_list_head(g_cloud_context_list);
+  while (ctx != NULL && ctx->device != device) {
+    ctx = ctx->next;
+  }
+  return ctx;
+}
+
+void
+cloud_context_iterate(cloud_context_iterator_cb_t cb, void *user_data)
+{
+  for (oc_cloud_context_t *ctx = oc_list_head(g_cloud_context_list);
+       ctx != NULL; ctx = ctx->next) {
+    cb(ctx, user_data);
+  }
+}
+
+void
+cloud_context_clear(oc_cloud_context_t *ctx)
+{
+  assert(ctx != NULL);
+
+  cloud_rd_reset_context(ctx);
+  cloud_close_endpoint(ctx->cloud_ep);
+  memset(ctx->cloud_ep, 0, sizeof(oc_endpoint_t));
+  ctx->cloud_ep_state = OC_SESSION_DISCONNECTED;
+  cloud_manager_stop(ctx);
+  cloud_store_initialize(&ctx->store);
+  ctx->last_error = 0;
+  ctx->store.cps = 0;
+  ctx->selected_identity_cred_id = -1;
+  cloud_store_dump_async(&ctx->store);
+}
+
+size_t
+cloud_context_size()
+{
+  return oc_list_length(g_cloud_context_list);
+}
+
+bool
+cloud_context_has_refresh_token(const oc_cloud_context_t *ctx)
+{
+  return oc_string(ctx->store.refresh_token) != NULL &&
+         oc_string_len(ctx->store.refresh_token) > 0;
+}
+
+bool
+cloud_context_has_permanent_access_token(const oc_cloud_context_t *ctx)
+{
+  return oc_string(ctx->store.access_token) != NULL &&
+         oc_string_len(ctx->store.access_token) > 0 &&
+         ctx->store.expires_in < 0;
+}
+
+void
+cloud_context_clear_access_token(oc_cloud_context_t *ctx)
+{
+  cloud_set_string(&ctx->store.access_token, NULL, 0);
+  ctx->store.expires_in = 0;
+}
+
+void
+oc_cloud_set_identity_cert_chain(oc_cloud_context_t *ctx, int cred_id)
+{
+  ctx->selected_identity_cred_id = cred_id;
+}
+
+int
+oc_cloud_get_identity_cert_chain(const oc_cloud_context_t *ctx)
+{
+  return ctx->selected_identity_cred_id;
+}
+
+#endif /* OC_CLOUD */

--- a/api/cloud/oc_cloud_context_internal.h
+++ b/api/cloud/oc_cloud_context_internal.h
@@ -1,0 +1,86 @@
+/****************************************************************************
+ *
+ * Copyright (c) 2022 Daniel Adam, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"),
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifndef OC_CLOUD_CONTEXT_INTERNAL_H
+#define OC_CLOUD_CONTEXT_INTERNAL_H
+
+#include "oc_cloud.h"
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Allocate and initialize cloud context for device
+ *
+ * @param device device index
+ * @return allocated context on success
+ * @return NULL on failure
+ */
+oc_cloud_context_t *cloud_context_init(size_t device);
+
+/**
+ * @brief Deinitialize and deallocate cloud context
+ *
+ * @param ctx context to deinitialize (cannot be NULL)
+ */
+void cloud_context_deinit(oc_cloud_context_t *ctx);
+
+/// @brief Count number of allocated contexts
+size_t cloud_context_size();
+
+/**
+ * @brief A function pointer for handling a single cloud context iteration;
+ *
+ * @param ctx cloud context (cannot be NULL)
+ * @param user_data user data
+ */
+typedef void (*cloud_context_iterator_cb_t)(oc_cloud_context_t *ctx,
+                                            void *user_data);
+
+/// Iterate over allocated cloud contexts;
+void cloud_context_iterate(cloud_context_iterator_cb_t cb, void *user_data);
+
+/// @brief Clear cloud context values
+void cloud_context_clear(oc_cloud_context_t *ctx);
+
+/**
+ * @brief Check whether refresh token is set.
+ *
+ * @return true refresh token is set
+ */
+bool cloud_context_has_refresh_token(const oc_cloud_context_t *ctx);
+
+/**
+ * @brief Checks whether the access token is set and whether it is permanent
+ * (ie. the expires in time of the access token has special value which means
+ * that the token is permanent).
+ *
+ * @return true access token is permanent
+ */
+bool cloud_context_has_permanent_access_token(const oc_cloud_context_t *ctx);
+
+/** @brief Clear access token from context */
+void cloud_context_clear_access_token(oc_cloud_context_t *ctx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OC_CLOUD_CONTEXT_INTERNAL_H */

--- a/api/cloud/oc_cloud_internal.h
+++ b/api/cloud/oc_cloud_internal.h
@@ -40,14 +40,14 @@ extern "C" {
 
 typedef struct cloud_conf_update_t
 {
-  char *access_token; /**< Access Token resolved with an auth code. */
+  const char *access_token; /**< Access Token resolved with an auth code. */
   size_t access_token_len;
-  char *auth_provider; /**< Auth Provider ID*/
+  const char *auth_provider; /**< Auth Provider ID*/
   size_t auth_provider_len;
-  char *ci_server; /**< Cloud Interface Server URL which an Enrollee is going to
-                      registered. */
+  const char *ci_server; /**< Cloud Interface Server URL which an Enrollee is
+                      going to registered. */
   size_t ci_server_len;
-  char *sid; /**< OCF Cloud Identity as defined in OCF CNC 2.0 Spec. */
+  const char *sid; /**< OCF Cloud Identity as defined in OCF CNC 2.0 Spec. */
   size_t sid_len;
 } cloud_conf_update_t;
 
@@ -65,25 +65,33 @@ int conv_cloud_endpoint(oc_cloud_context_t *ctx);
 int oc_cloud_init(void);
 void oc_cloud_shutdown(void);
 
+bool cloud_is_connection_error_code(oc_status_t code);
+bool cloud_is_timeout_error_code(oc_status_t code);
+
 void oc_cloud_register_handler(oc_client_response_t *data);
 void oc_cloud_login_handler(oc_client_response_t *data);
 void oc_cloud_refresh_token_handler(oc_client_response_t *data);
-void oc_cloud_clear_context(oc_cloud_context_t *ctx);
-int oc_cloud_reset_context(size_t device);
 
 void cloud_close_endpoint(oc_endpoint_t *cloud_ep);
 
-void cloud_store_dump_async(const oc_cloud_store_t *store);
-int cloud_store_load(oc_cloud_store_t *store);
-long cloud_store_dump(const oc_cloud_store_t *store);
-void cloud_store_initialize(oc_cloud_store_t *store);
-void cloud_store_deinitialize(oc_cloud_store_t *store);
 void cloud_manager_cb(oc_cloud_context_t *ctx);
 void cloud_set_string(oc_string_t *dst, const char *data, size_t len);
 void cloud_set_last_error(oc_cloud_context_t *ctx, oc_cloud_error_t error);
 void cloud_set_cps(oc_cloud_context_t *ctx, oc_cps_t cps);
 void cloud_set_cps_and_last_error(oc_cloud_context_t *ctx, oc_cps_t cps,
                                   oc_cloud_error_t error);
+
+int cloud_reset(size_t device);
+
+/**
+ * @brief Set cloud configuration.
+ *
+ * @param ctx cloud context (cannot be NULL)
+ * @param data configuration update (cannot be NULL)
+ */
+void cloud_set_cloudconf(oc_cloud_context_t *ctx,
+                         const cloud_conf_update_t *data);
+
 void cloud_update_by_resource(oc_cloud_context_t *ctx,
                               const cloud_conf_update_t *data);
 /**
@@ -123,29 +131,7 @@ void cloud_rd_deinit(oc_cloud_context_t *ctx);
  */
 void cloud_rd_reset_context(oc_cloud_context_t *ctx);
 
-void cloud_manager_start(oc_cloud_context_t *ctx);
-void cloud_manager_stop(oc_cloud_context_t *ctx);
-
 void oc_create_cloudconf_resource(size_t device);
-
-/**
- * @brief Check whether refresh token is set.
- *
- * @return true refresh token is set
- */
-bool cloud_has_refresh_token(const oc_cloud_context_t *ctx);
-
-/**
- * @brief Checks whether the access token is set and whether it is permanent
- * (ie. the expires in time of the access token has special value which means
- * that the token is permanent).
- *
- * @return true access token is permanent
- */
-bool cloud_has_permanent_access_token(const oc_cloud_context_t *ctx);
-
-/** @brief Clear access token from context */
-void cloud_clear_access_token(oc_cloud_context_t *ctx);
 
 /**
  * @brief Send a ping over the cloud connected connection

--- a/api/cloud/oc_cloud_manager_internal.h
+++ b/api/cloud/oc_cloud_manager_internal.h
@@ -100,6 +100,20 @@ bool cloud_manager_handle_redirect_response(oc_cloud_context_t *ctx,
 bool cloud_manager_handle_refresh_token_response(oc_cloud_context_t *ctx,
                                                  const oc_rep_t *payload);
 
+/**
+ * @brief Start executing cloud provisioning steps
+ *
+ * @param ctx cloud context (cannot be NULL)
+ */
+void cloud_manager_start(oc_cloud_context_t *ctx);
+
+/**
+ * @brief Stop executing cloud provisioning steps
+ *
+ * @param ctx cloud context (cannot be NULL)
+ */
+void cloud_manager_stop(oc_cloud_context_t *ctx);
+
 #ifdef __cplusplus
 }
 #endif

--- a/api/cloud/oc_cloud_store.c
+++ b/api/cloud/oc_cloud_store.c
@@ -16,12 +16,18 @@
  * limitations under the License.
  *
  ******************************************************************/
+
+#include "oc_config.h"
+
 #ifdef OC_CLOUD
 
+#include "api/oc_rep_internal.h"
 #include "oc_api.h"
 #include "oc_cloud_internal.h"
-#include "oc_config.h"
+#include "oc_cloud_store_internal.h"
 #include "oc_rep.h"
+
+#include <stdint.h>
 #ifdef OC_DYNAMIC_ALLOCATION
 #include <stdlib.h>
 #endif /* OC_DYNAMIC_ALLOCATION */
@@ -44,6 +50,7 @@ check oc_config.h and make sure OC_STORAGE is defined if OC_CLOUD is defined.
 
 #define CLOUD_STR(s) #s
 #define CLOUD_XSTR(s) CLOUD_STR(s)
+#define CLOUD_XSTRLEN(s) (sizeof(CLOUD_STR(s)) - 1)
 
 #define CLOUD_TAG_MAX (32)
 
@@ -176,74 +183,98 @@ cloud_store_dump_async(const oc_cloud_store_t *store)
   _oc_signal_event_loop();
 }
 
-static int
-cloud_store_decode(oc_rep_t *rep, oc_cloud_store_t *store)
+static bool
+cloud_store_parse_string_property(const oc_rep_t *rep, oc_cloud_store_t *store)
 {
-  oc_rep_t *t = rep;
-  size_t len = 0;
+  assert(rep->type == OC_REP_STRING);
+  if (oc_rep_is_property(rep, CLOUD_XSTR(CLOUD_CI_SERVER),
+                         CLOUD_XSTRLEN(CLOUD_CI_SERVER))) {
+    cloud_set_string(&store->ci_server, oc_string(rep->value.string),
+                     oc_string_len(rep->value.string));
+    return true;
+  }
+  if (oc_rep_is_property(rep, CLOUD_XSTR(CLOUD_SID),
+                         CLOUD_XSTRLEN(CLOUD_SID))) {
+    cloud_set_string(&store->sid, oc_string(rep->value.string),
+                     oc_string_len(rep->value.string));
+    return true;
+  }
+  if (oc_rep_is_property(rep, CLOUD_XSTR(CLOUD_AUTH_PROVIDER),
+                         CLOUD_XSTRLEN(CLOUD_AUTH_PROVIDER))) {
+    cloud_set_string(&store->auth_provider, oc_string(rep->value.string),
+                     oc_string_len(rep->value.string));
+    return true;
+  }
+  if (oc_rep_is_property(rep, CLOUD_XSTR(CLOUD_UID),
+                         CLOUD_XSTRLEN(CLOUD_UID))) {
+    cloud_set_string(&store->uid, oc_string(rep->value.string),
+                     oc_string_len(rep->value.string));
+    return true;
+  }
+  if (oc_rep_is_property(rep, CLOUD_XSTR(CLOUD_ACCESS_TOKEN),
+                         CLOUD_XSTRLEN(CLOUD_ACCESS_TOKEN))) {
+    cloud_set_string(&store->access_token, oc_string(rep->value.string),
+                     oc_string_len(rep->value.string));
+    return true;
+  }
+  if (oc_rep_is_property(rep, CLOUD_XSTR(CLOUD_REFRESH_TOKEN),
+                         CLOUD_XSTRLEN(CLOUD_REFRESH_TOKEN))) {
+    cloud_set_string(&store->refresh_token, oc_string(rep->value.string),
+                     oc_string_len(rep->value.string));
+    return true;
+  }
 
-  while (t != NULL) {
-    len = oc_string_len(t->name);
-    switch (t->type) {
+  OC_ERR("[CLOUD_STORE] Unknown string property %s", oc_string(rep->name));
+  return false;
+}
+
+static bool
+cloud_store_parse_int_property(const oc_rep_t *rep, oc_cloud_store_t *store)
+{
+  assert(rep->type == OC_REP_INT);
+
+  if (oc_rep_is_property(rep, CLOUD_XSTR(CLOUD_STATUS),
+                         CLOUD_XSTRLEN(CLOUD_STATUS))) {
+    assert(rep->value.integer <= UINT8_MAX);
+    store->status = (uint8_t)rep->value.integer;
+    return true;
+  }
+  if (oc_rep_is_property(rep, CLOUD_XSTR(CLOUD_CPS),
+                         CLOUD_XSTRLEN(CLOUD_CPS))) {
+    assert(rep->value.integer <= UINT8_MAX);
+    store->cps = (uint8_t)rep->value.integer;
+    return true;
+  }
+  if (oc_rep_is_property(rep, CLOUD_XSTR(CLOUD_EXPIRES_IN),
+                         CLOUD_XSTRLEN(CLOUD_EXPIRES_IN))) {
+    store->expires_in = rep->value.integer;
+    return true;
+  }
+
+  OC_ERR("[CLOUD_STORE] Unknown integer property %s", oc_string(rep->name));
+  return false;
+}
+
+static int
+cloud_store_decode(const oc_rep_t *rep, oc_cloud_store_t *store)
+{
+  while (rep != NULL) {
+    switch (rep->type) {
     case OC_REP_STRING:
-      if (len == strlen(CLOUD_XSTR(CLOUD_CI_SERVER)) &&
-          memcmp(oc_string(t->name), CLOUD_XSTR(CLOUD_CI_SERVER),
-                 strlen(CLOUD_XSTR(CLOUD_CI_SERVER))) == 0) {
-        cloud_set_string(&store->ci_server, oc_string(t->value.string),
-                         oc_string_len(t->value.string));
-      } else if (len == strlen(CLOUD_XSTR(CLOUD_SID)) &&
-                 memcmp(oc_string(t->name), CLOUD_XSTR(CLOUD_SID),
-                        strlen(CLOUD_XSTR(CLOUD_SID))) == 0) {
-        cloud_set_string(&store->sid, oc_string(t->value.string),
-                         oc_string_len(t->value.string));
-      } else if (len == strlen(CLOUD_XSTR(CLOUD_AUTH_PROVIDER)) &&
-                 memcmp(oc_string(t->name), CLOUD_XSTR(CLOUD_AUTH_PROVIDER),
-                        strlen(CLOUD_XSTR(CLOUD_AUTH_PROVIDER))) == 0) {
-        cloud_set_string(&store->auth_provider, oc_string(t->value.string),
-                         oc_string_len(t->value.string));
-      } else if (len == strlen(CLOUD_XSTR(CLOUD_UID)) &&
-                 memcmp(oc_string(t->name), CLOUD_XSTR(CLOUD_UID),
-                        strlen(CLOUD_XSTR(CLOUD_UID))) == 0) {
-        cloud_set_string(&store->uid, oc_string(t->value.string),
-                         oc_string_len(t->value.string));
-      } else if (len == strlen(CLOUD_XSTR(CLOUD_ACCESS_TOKEN)) &&
-                 memcmp(oc_string(t->name), CLOUD_XSTR(CLOUD_ACCESS_TOKEN),
-                        strlen(CLOUD_XSTR(CLOUD_ACCESS_TOKEN))) == 0) {
-        cloud_set_string(&store->access_token, oc_string(t->value.string),
-                         oc_string_len(t->value.string));
-      } else if (len == strlen(CLOUD_XSTR(CLOUD_REFRESH_TOKEN)) &&
-                 memcmp(oc_string(t->name), CLOUD_XSTR(CLOUD_REFRESH_TOKEN),
-                        strlen(CLOUD_XSTR(CLOUD_REFRESH_TOKEN))) == 0) {
-        cloud_set_string(&store->refresh_token, oc_string(t->value.string),
-                         oc_string_len(t->value.string));
-      } else {
-        OC_ERR("[CLOUD_STORE] Unknown property %s", oc_string(t->name));
+      if (!cloud_store_parse_string_property(rep, store)) {
         return -1;
       }
       break;
     case OC_REP_INT:
-      if (len == strlen(CLOUD_XSTR(CLOUD_STATUS)) &&
-          memcmp(oc_string(t->name), CLOUD_XSTR(CLOUD_STATUS),
-                 strlen(CLOUD_XSTR(CLOUD_STATUS))) == 0) {
-        store->status = (uint8_t)t->value.integer;
-      } else if (len == strlen(CLOUD_XSTR(CLOUD_CPS)) &&
-                 memcmp(oc_string(t->name), CLOUD_XSTR(CLOUD_CPS),
-                        strlen(CLOUD_XSTR(CLOUD_CPS))) == 0) {
-        store->cps = (uint8_t)t->value.integer;
-      } else if (len == strlen(CLOUD_XSTR(CLOUD_EXPIRES_IN)) &&
-                 memcmp(oc_string(t->name), CLOUD_XSTR(CLOUD_EXPIRES_IN),
-                        strlen(CLOUD_XSTR(CLOUD_EXPIRES_IN))) == 0) {
-        store->expires_in = t->value.integer;
-      } else {
-        OC_ERR("[CLOUD_STORE] Unknown property %s", oc_string(t->name));
+      if (!cloud_store_parse_int_property(rep, store)) {
         return -1;
       }
       break;
     default:
-      OC_ERR("[CLOUD_STORE] Unknown property %s", oc_string(t->name));
+      OC_ERR("[CLOUD_STORE] Unknown property %s", oc_string(rep->name));
       return -1;
     }
-    t = t->next;
+    rep = rep->next;
   }
   return 0;
 }
@@ -256,7 +287,6 @@ cloud_store_load_internal(const char *store_name, oc_cloud_store_t *store)
   }
 
   int ret = 0;
-  oc_rep_t *rep;
 
 #ifdef OC_DYNAMIC_ALLOCATION
   uint8_t *buf = malloc(OC_MAX_APP_DATA_SIZE);
@@ -267,22 +297,14 @@ cloud_store_load_internal(const char *store_name, oc_cloud_store_t *store)
 #else  /* OC_DYNAMIC_ALLOCATION */
   uint8_t buf[OC_MAX_APP_DATA_SIZE];
 #endif /* !OC_DYNAMIC_ALLOCATION */
-  long size = 0;
-  size = oc_storage_read(store_name, buf, OC_MAX_APP_DATA_SIZE);
+  long size = oc_storage_read(store_name, buf, OC_MAX_APP_DATA_SIZE);
   if (size > 0) {
-#ifndef OC_DYNAMIC_ALLOCATION
-    char rep_objects_alloc[OC_MAX_NUM_REP_OBJECTS];
-    oc_rep_t rep_objects_pool[OC_MAX_NUM_REP_OBJECTS];
-    memset(rep_objects_alloc, 0, OC_MAX_NUM_REP_OBJECTS * sizeof(char));
-    memset(rep_objects_pool, 0, OC_MAX_NUM_REP_OBJECTS * sizeof(oc_rep_t));
-    struct oc_memb rep_objects = { sizeof(oc_rep_t), OC_MAX_NUM_REP_OBJECTS,
-                                   rep_objects_alloc, (void *)rep_objects_pool,
-                                   0 };
-#else  /* !OC_DYNAMIC_ALLOCATION */
-    struct oc_memb rep_objects = { sizeof(oc_rep_t), 0, 0, 0, 0 };
-#endif /* OC_DYNAMIC_ALLOCATION */
+    OC_MEMB_LOCAL(rep_objects, oc_rep_t, OC_MAX_NUM_REP_OBJECTS);
     oc_rep_set_pool(&rep_objects);
-    oc_parse_rep(buf, (int)size, &rep);
+    oc_rep_t *rep;
+    if (oc_parse_rep(buf, (int)size, &rep) != 0) {
+      OC_ERR("failed to parse cloud store buffer");
+    }
     ret = cloud_store_decode(rep, store);
     oc_rep_set_pool(&rep_objects); // Reset representation pool
     oc_free_rep(rep);
@@ -319,6 +341,5 @@ cloud_store_deinitialize(oc_cloud_store_t *store)
   store->status = 0;
   store->expires_in = 0;
 }
-#else  /* OC_CLOUD*/
-typedef int dummy_declaration;
-#endif /* !OC_CLOUD */
+
+#endif /* OC_CLOUD */

--- a/api/cloud/oc_cloud_store_internal.h
+++ b/api/cloud/oc_cloud_store_internal.h
@@ -1,0 +1,76 @@
+/****************************************************************************
+ *
+ * Copyright (c) 2019 Intel Corporation
+ * Copyright 2019 Jozef Kralik All Rights Reserved.
+ * Copyright 2018 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"),
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifndef OC_CLOUD_STORE_INTERNAL_H
+#define OC_CLOUD_STORE_INTERNAL_H
+
+#include "oc_cloud.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Load store data from storage
+ *
+ * @param[out] store store to save data to (cannot be NULL)
+ * @return 0 on success
+ * @return <0 on failure
+ */
+int cloud_store_load(oc_cloud_store_t *store);
+
+/**
+ * @brief Save store data to storage
+ *
+ * @param store store with data to save (cannot be NULL)
+ * @return >=0 amount of bytes written to storage
+ * @return <0 on failure
+ */
+long cloud_store_dump(const oc_cloud_store_t *store);
+
+/**
+ * @brief Schedule delayed saving of store data to storage
+ *
+ * @param store with data to save (cannot be NULL)
+ *
+ * @warning You must ensure that the store pointer is still valid in the delayed
+ * execution
+ */
+void cloud_store_dump_async(const oc_cloud_store_t *store);
+
+/**
+ * @brief Set store data to default values
+ *
+ * @param store store
+ */
+void cloud_store_initialize(oc_cloud_store_t *store);
+
+/**
+ * @brief Deallocate allocated data
+ *
+ * @param store store
+ */
+void cloud_store_deinitialize(oc_cloud_store_t *store);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OC_CLOUD_INTERNAL_H */

--- a/api/cloud/unittest/cloud_manager_test.cpp
+++ b/api/cloud/unittest/cloud_manager_test.cpp
@@ -22,6 +22,7 @@
 #include "oc_api.h"
 #include "oc_cloud_internal.h"
 #include "oc_cloud_manager_internal.h"
+#include "oc_cloud_store_internal.h"
 #include "oc_rep.h"
 
 #include <gtest/gtest.h>

--- a/api/cloud/unittest/cloud_store_test.cpp
+++ b/api/cloud/unittest/cloud_store_test.cpp
@@ -17,12 +17,13 @@
  *
  ******************************************************************/
 
-#include <gtest/gtest.h>
-#include <pthread.h>
-
 #include "oc_api.h"
 #include "oc_cloud_internal.h"
+#include "oc_cloud_store_internal.h"
 #include "oc_collection.h"
+
+#include <gtest/gtest.h>
+#include <pthread.h>
 
 #define ACCESS_TOKEN ("access_token")
 #define AUTH_PROVIDER ("auth_provider")

--- a/api/cloud/unittest/cloud_test.cpp
+++ b/api/cloud/unittest/cloud_test.cpp
@@ -141,13 +141,13 @@ TEST_F(TestCloud, cloud_update_by_resource)
   ctx->store.status = OC_CLOUD_FAILURE;
 
   cloud_conf_update_t data;
-  data.access_token = (char *)"access_token";
+  data.access_token = "access_token";
   data.access_token_len = strlen(data.access_token);
-  data.auth_provider = (char *)"auth_provider";
+  data.auth_provider = "auth_provider";
   data.auth_provider_len = strlen(data.auth_provider);
-  data.ci_server = (char *)"ci_server";
+  data.ci_server = "ci_server";
   data.ci_server_len = strlen("ci_server");
-  data.sid = (char *)"sid";
+  data.sid = "sid";
   data.sid_len = strlen(data.sid);
 
   cloud_update_by_resource(ctx, &data);
@@ -156,5 +156,24 @@ TEST_F(TestCloud, cloud_update_by_resource)
   EXPECT_STREQ(data.auth_provider, oc_string(ctx->store.auth_provider));
   EXPECT_STREQ(data.ci_server, oc_string(ctx->store.ci_server));
   EXPECT_STREQ(data.sid, oc_string(ctx->store.sid));
+  EXPECT_EQ(OC_CLOUD_INITIALIZED, ctx->store.status);
+}
+
+TEST_F(TestCloud, oc_cloud_provision_conf_resource)
+{
+  oc_cloud_context_t *ctx = oc_cloud_get_context(0);
+  ASSERT_NE(nullptr, ctx);
+
+  const char *access_token = "access_token";
+  const char *auth_provider = "auth_provider";
+  const char *ci_server = "ci_server";
+  const char *sid = "sid";
+  ASSERT_EQ(0, oc_cloud_provision_conf_resource(ctx, ci_server, access_token,
+                                                sid, auth_provider));
+
+  EXPECT_STREQ(access_token, oc_string(ctx->store.access_token));
+  EXPECT_STREQ(auth_provider, oc_string(ctx->store.auth_provider));
+  EXPECT_STREQ(ci_server, oc_string(ctx->store.ci_server));
+  EXPECT_STREQ(sid, oc_string(ctx->store.sid));
   EXPECT_EQ(OC_CLOUD_INITIALIZED, ctx->store.status);
 }

--- a/api/oc_rep.c
+++ b/api/oc_rep.c
@@ -18,6 +18,7 @@
 
 #include "oc_api.h"
 #include "oc_rep.h"
+#include "oc_rep_internal.h"
 #include "oc_rep_encode_internal.h"
 #include "oc_config.h"
 #include "port/oc_assert.h"
@@ -812,4 +813,14 @@ bool
 oc_rep_get_object_array(const oc_rep_t *rep, const char *key, oc_rep_t **value)
 {
   return oc_rep_get_value(rep, OC_REP_OBJECT_ARRAY, key, (void **)value, NULL);
+}
+
+bool
+oc_rep_is_property(const oc_rep_t *rep, const char *propname,
+                   size_t propname_len)
+{
+  assert(rep != NULL);
+  assert(propname != NULL);
+  return oc_string_len(rep->name) == propname_len &&
+         memcmp(oc_string((rep)->name), propname, propname_len) == 0;
 }

--- a/api/oc_rep_internal.h
+++ b/api/oc_rep_internal.h
@@ -1,0 +1,46 @@
+/****************************************************************************
+ *
+ * Copyright (c) 2023 Daniel Adam
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"),
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifndef OC_REP_INTERNAL_H
+#define OC_REP_INTERNAL_H
+
+#include "oc_rep.h"
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Check whether name of property matches parameters
+ *
+ * @param rep object to check (cannot be NULL)
+ * @param propname property name (cannot be NULL)
+ * @param propname_len length of property name
+ * @return true if property name matches
+ * @return false otherwise
+ */
+bool oc_rep_is_property(const oc_rep_t *rep, const char *propname,
+                        size_t propname_len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OC_REP_INTERNAL_H */

--- a/api/oc_ri.c
+++ b/api/oc_ri.c
@@ -1571,7 +1571,7 @@ notify_client_cb_503(oc_client_cb_t *cb)
   client_response.endpoint = &cb->endpoint;
   client_response.observe_option = -1;
   client_response.user_data = cb->user_data;
-  client_response.code = OC_STATUS_SERVICE_UNAVAILABLE;
+  client_response.code = OC_REQUEST_TIMEOUT;
 
   oc_response_handler_t handler = (oc_response_handler_t)cb->handler.response;
   handler(&client_response);

--- a/api/oc_ri_internal.h
+++ b/api/oc_ri_internal.h
@@ -19,7 +19,7 @@
 #ifndef OC_RI_INTERNAL_H
 #define OC_RI_INTERNAL_H
 
-#include "oc_api.h"
+#include "oc_ri.h"
 
 /**
  * @brief removes the client callback. This is silent remove client without
@@ -32,7 +32,7 @@ oc_event_callback_retval_t oc_ri_remove_client_cb(void *cb);
 
 /**
  * @brief removes the client callback with triggering
- * OC_STATUS_SERVICE_UNAVAILABLE to handler.
+ * OC_REQUEST_TIMEOUT to handler.
  *
  * @param cb is oc_client_cb_t* type
  * @return returns OC_EVENT_DONE

--- a/api/unittest/ocapitest.cpp
+++ b/api/unittest/ocapitest.cpp
@@ -537,7 +537,7 @@ TEST_F(TestServerClient, GetWithTimeout)
   EXPECT_EQ(expected, code);
 
   ApiHelper::s_TestResource.onGet.response = -1; // disable sending of response
-  expected = OC_STATUS_SERVICE_UNAVAILABLE;
+  expected = OC_REQUEST_TIMEOUT;
   EXPECT_TRUE(
     oc_do_get_with_timeout(ApiHelper::s_TestResource.resource_uri.c_str(),
                            &ApiHelper::s_TestResource.endpoint, nullptr,
@@ -566,7 +566,7 @@ TEST_F(TestServerClient, DeleteWithTimeout)
 
   ApiHelper::s_TestResource.onDelete.response =
     -1; // disable sending of response
-  expected = OC_STATUS_SERVICE_UNAVAILABLE;
+  expected = OC_REQUEST_TIMEOUT;
   EXPECT_TRUE(
     oc_do_delete_with_timeout(ApiHelper::s_TestResource.resource_uri.c_str(),
                               &ApiHelper::s_TestResource.endpoint, nullptr,
@@ -594,7 +594,7 @@ TEST_F(TestServerClient, PostWithTimeout)
   EXPECT_EQ(expected, code);
 
   ApiHelper::s_TestResource.onPost.response = -1; // disable sending of
-  expected = OC_STATUS_SERVICE_UNAVAILABLE;
+  expected = OC_REQUEST_TIMEOUT;
   EXPECT_TRUE(oc_init_post(ApiHelper::s_TestResource.resource_uri.c_str(),
                            &ApiHelper::s_TestResource.endpoint, nullptr,
                            PostDevice, HIGH_QOS, &code));
@@ -622,7 +622,7 @@ TEST_F(TestServerClient, PutWithTimeout)
   EXPECT_EQ(expected, code);
 
   ApiHelper::s_TestResource.onPut.response = -1; // disable sending of
-  expected = OC_STATUS_SERVICE_UNAVAILABLE;
+  expected = OC_REQUEST_TIMEOUT;
   EXPECT_TRUE(oc_init_put(ApiHelper::s_TestResource.resource_uri.c_str(),
                           &ApiHelper::s_TestResource.endpoint, nullptr,
                           PutDevice, HIGH_QOS, &code));

--- a/include/oc_api.h
+++ b/include/oc_api.h
@@ -1928,7 +1928,7 @@ bool oc_do_get(const char *uri, oc_endpoint_t *endpoint, const char *query,
  * @return True if the client successfully dispatched the CoAP GET request
  *
  * @note If a response is not received before @p timeout_seconds expires then
- * the response handler is invoked with OC_STATUS_SERVICE_UNAVAILABLE code
+ * the response handler is invoked with OC_REQUEST_TIMEOUT code
  */
 OC_API
 bool oc_do_get_with_timeout(const char *uri, oc_endpoint_t *endpoint,
@@ -1972,7 +1972,7 @@ bool oc_do_delete(const char *uri, oc_endpoint_t *endpoint, const char *query,
  * @return True if the client successfully dispatched the CoAP DELETE
  *
  * @note If a response is not received before @p timeout_seconds expires then
- * the response handler is invoked with OC_STATUS_SERVICE_UNAVAILABLE code
+ * the response handler is invoked with OC_REQUEST_TIMEOUT code
  */
 OC_API
 bool oc_do_delete_with_timeout(const char *uri, oc_endpoint_t *endpoint,
@@ -2052,7 +2052,7 @@ bool oc_do_put(void);
  * @return True if the client successfully dispatched the CoAP PUT request
  *
  * @note If a response is not received before @p timeout_seconds expires then
- * the response handler is invoked with OC_STATUS_SERVICE_UNAVAILABLE code
+ * the response handler is invoked with OC_REQUEST_TIMEOUT code
  *
  * @see oc_init_put
  */
@@ -2131,7 +2131,7 @@ bool oc_do_post(void);
  * @return True if the client successfully dispatched the CoAP POST request
  *
  * @note If a response is not received before @p timeout_seconds expires then
- * the response handler is invoked with OC_STATUS_SERVICE_UNAVAILABLE code
+ * the response handler is invoked with OC_REQUEST_TIMEOUT code
  *
  * @see oc_init_post
  */

--- a/include/oc_cloud.h
+++ b/include/oc_cloud.h
@@ -266,6 +266,20 @@ int oc_cloud_discover_resources(oc_cloud_context_t *ctx,
                                 oc_discovery_all_handler_t handler,
                                 void *user_data);
 
+/**
+ * @brief Configure cloud properties.
+ *
+ * @param ctx Cloud context to update (cannot be be NULL)
+ * @param server Cloud server URL
+ * @param access_token Access token from an Authorisation Provider
+ * @param server_id Cloud server ID
+ * @param auth_provider Name of the Authorization Provider which provided the
+ * access token
+ * @return 0 on success
+ * @return -1 on failure
+ *
+ * @note Cloud manager will be restarted if is was started previously
+ */
 OC_API
 int oc_cloud_provision_conf_resource(oc_cloud_context_t *ctx,
                                      const char *server,

--- a/include/oc_ri.h
+++ b/include/oc_ri.h
@@ -89,8 +89,11 @@ typedef enum {
   OC_STATUS_GATEWAY_TIMEOUT,          ///< Gateway Timeout
   OC_STATUS_PROXYING_NOT_SUPPORTED,   ///< Proxying not supported
   __NUM_OC_STATUS_CODES__,
-  OC_IGNORE,      ///< Ignore: do not respond to request
-  OC_PING_TIMEOUT ///< Ping Time out
+  OC_IGNORE,          ///< Ignore: do not respond to request
+  OC_PING_TIMEOUT,    ///< Ping Time out
+  OC_REQUEST_TIMEOUT, ///< Timeout for requests created by
+                      ///< oc_do_get_with_timeout, oc_do_delete_with_timeout,
+                      ///< oc_do_put_with_timeout or oc_do_post_with_timeout
 } oc_status_t;
 
 /**

--- a/port/esp32/main/CMakeLists.txt
+++ b/port/esp32/main/CMakeLists.txt
@@ -80,6 +80,7 @@ if (CONFIG_CLOUD)
   list(APPEND sources
   	${CMAKE_CURRENT_SOURCE_DIR}/../../../api/cloud/oc_cloud_access.c
   	${CMAKE_CURRENT_SOURCE_DIR}/../../../api/cloud/oc_cloud_apis.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../../api/cloud/oc_cloud_context.c
 	${CMAKE_CURRENT_SOURCE_DIR}/../../../api/cloud/oc_cloud_manager.c
 	${CMAKE_CURRENT_SOURCE_DIR}/../../../api/cloud/oc_cloud_rd.c
 	${CMAKE_CURRENT_SOURCE_DIR}/../../../api/cloud/oc_cloud_resource.c

--- a/security/oc_pstat.c
+++ b/security/oc_pstat.c
@@ -15,8 +15,8 @@
 */
 
 #ifdef OC_SECURITY
+
 #include "oc_pstat.h"
-#include "api/cloud/oc_cloud_internal.h"
 #include "api/oc_buffer_internal.h"
 #include "api/oc_main.h"
 #include "messaging/coap/observe.h"
@@ -31,6 +31,11 @@
 #include "oc_sp.h"
 #include "oc_store.h"
 #include "oc_tls.h"
+
+#ifdef OC_CLOUD
+#include "api/cloud/oc_cloud_internal.h"
+#endif /* OC_CLOUD */
+
 #ifdef OC_COLLECTIONS_IF_CREATE
 #include "api/oc_resource_factory.h"
 #endif /* OC_COLLECTIONS_IF_CREATE */
@@ -161,7 +166,7 @@ oc_pstat_handle_state(oc_sec_pstat_t *ps, size_t device, bool from_storage,
 #ifdef OC_SERVER
 #ifdef OC_CLIENT
 #ifdef OC_CLOUD
-    oc_cloud_reset_context(device);
+    cloud_reset(device);
 #endif /* OC_CLOUD */
 #endif /* OC_CLIENT */
 #endif /* OC_SERVER */


### PR DESCRIPTION
Instead of OC_STATUS_SERVICE_UNAVAILABLE use OC_REQUEST_TIMEOUT when oc_do_get_with_timeout, oc_do_post_with_timeout, ... end in a timeout. There are other scenarios that end OC_STATUS_SERVICE_UNAVAILABLE and it was not possible to determine that a timeout occurred. With a new status code OC_REQUEST_TIMEOUT it is always determinable.