### PR TITLE
Fix global coap status value

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -920,11 +920,13 @@ install(FILES ${PORT_INCLUDE_DIR}/oc_config.h
 install(DIRECTORY util
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/iotivity-lite COMPONENT dev
     FILES_MATCHING PATTERN "*.h"
+    PATTERN "*_internal.h" EXCLUDE
 )
 install(DIRECTORY messaging/coap/
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/iotivity-lite/messaging/coap COMPONENT dev
     FILES_MATCHING PATTERN "*.h"
     PATTERN "unittest" EXCLUDE
+    PATTERN "*_internal.h" EXCLUDE
 )
 
 # ####### Code formatting ########

--- a/api/oc_ri.c
+++ b/api/oc_ri.c
@@ -17,6 +17,7 @@
  ***************************************************************************/
 
 #include "api/oc_helpers_internal.h"
+#include "messaging/coap/coap_internal.h"
 #include "messaging/coap/constants.h"
 #include "messaging/coap/engine.h"
 #include "messaging/coap/oc_coap.h"
@@ -1123,7 +1124,7 @@ oc_ri_invoke_coap_entity_handler(void *request, void *response, uint8_t *buffer,
     if (request_obj.origin && (request_obj.origin->flags & MULTICAST) &&
         !oc_ri_filter_request_by_device_id(endpoint->device, uri_query,
                                            uri_query_len)) {
-      coap_status_code = CLEAR_TRANSACTION;
+      coap_set_global_status_code(CLEAR_TRANSACTION);
       coap_set_status_code(response, OC_IGNORE);
       return false;
     }
@@ -1553,7 +1554,7 @@ oc_ri_invoke_coap_entity_handler(void *request, void *response, uint8_t *buffer,
        * below a response code of IGNORE, which results in the messaging
        * layer freeing the CoAP transaction associated with the request.
        */
-      coap_status_code = CLEAR_TRANSACTION;
+      coap_set_global_status_code(CLEAR_TRANSACTION);
     } else {
 #ifdef OC_SERVER
       /* If the recently handled request was a PUT/POST, it conceivably

--- a/messaging/coap/coap.c
+++ b/messaging/coap/coap.c
@@ -65,12 +65,67 @@
 #include "security/oc_tls.h"
 #endif /* OC_SECURITY */
 
+/* option format serialization */
+#define COAP_SERIALIZE_INT_OPTION(number, field, text)                         \
+  if (IS_OPTION(coap_pkt, number)) {                                           \
+    option_length += coap_serialize_int_option(number, current_number, option, \
+                                               coap_pkt->field);               \
+    if (option) {                                                              \
+      OC_DBG(text " [%u]", (unsigned int)coap_pkt->field);                     \
+      option = option_array + option_length;                                   \
+    }                                                                          \
+    current_number = number;                                                   \
+  }
+#define COAP_SERIALIZE_BYTE_OPTION(number, field, text)                        \
+  if (IS_OPTION(coap_pkt, number)) {                                           \
+    option_length += coap_serialize_array_option(number, current_number,       \
+                                                 option, coap_pkt->field,      \
+                                                 coap_pkt->field##_len, '\0'); \
+    if (option) {                                                              \
+      OC_DBG(text " %u [0x%02X%02X%02X%02X%02X%02X%02X%02X]",                  \
+             (unsigned int)coap_pkt->field##_len, coap_pkt->field[0],          \
+             coap_pkt->field[1], coap_pkt->field[2], coap_pkt->field[3],       \
+             coap_pkt->field[4], coap_pkt->field[5], coap_pkt->field[6],       \
+             coap_pkt->field[7]); /* FIXME always prints 8 bytes */            \
+      option = option_array + option_length;                                   \
+    }                                                                          \
+    current_number = number;                                                   \
+  }
+#define COAP_SERIALIZE_STRING_OPTION(number, field, splitter, text)            \
+  if (IS_OPTION(coap_pkt, number)) {                                           \
+    option_length += coap_serialize_array_option(                              \
+      number, current_number, option, (uint8_t *)coap_pkt->field,              \
+      coap_pkt->field##_len, splitter);                                        \
+    if (option) {                                                              \
+      OC_DBG(text " [%.*s]", (int)coap_pkt->field##_len, coap_pkt->field);     \
+      option = option_array + option_length;                                   \
+    }                                                                          \
+    current_number = number;                                                   \
+  }
+#define COAP_SERIALIZE_BLOCK_OPTION(number, field, text)                       \
+  if (IS_OPTION(coap_pkt, number)) {                                           \
+    uint32_t block = coap_pkt->field##_num << 4;                               \
+    if (coap_pkt->field##_more) {                                              \
+      block |= 0x8;                                                            \
+    }                                                                          \
+    block |= 0xF & coap_log_2(coap_pkt->field##_size / 16);                    \
+    option_length +=                                                           \
+      coap_serialize_int_option(number, current_number, option, block);        \
+    if (option) {                                                              \
+      OC_DBG(text " [%lu%s (%u B/blk)]", (unsigned long)coap_pkt->field##_num, \
+             coap_pkt->field##_more ? "+" : "", coap_pkt->field##_size);       \
+      OC_DBG(text " encoded: 0x%lX", (unsigned long)block);                    \
+      option = option_array + option_length;                                   \
+    }                                                                          \
+    current_number = number;                                                   \
+  }
+
 /*---------------------------------------------------------------------------*/
 /*- Variables ---------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 static uint16_t current_mid = 0;
 
-coap_status_t coap_status_code = COAP_NO_ERROR;
+static coap_status_t g_coap_status_code = COAP_NO_ERROR;
 /*---------------------------------------------------------------------------*/
 /*- Local helper functions --------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -1886,4 +1941,15 @@ coap_set_payload(void *packet, const void *payload, size_t length)
 
   return coap_pkt->payload_len;
 }
-/*---------------------------------------------------------------------------*/
+
+coap_status_t
+coap_global_status_code()
+{
+  return g_coap_status_code;
+}
+
+void
+coap_set_global_status_code(coap_status_t code)
+{
+  g_coap_status_code = code;
+}

--- a/messaging/coap/coap.h
+++ b/messaging/coap/coap.h
@@ -171,65 +171,6 @@ typedef struct
   uint8_t *payload;
 } coap_packet_t;
 
-/* option format serialization */
-#define COAP_SERIALIZE_INT_OPTION(number, field, text)                         \
-  if (IS_OPTION(coap_pkt, number)) {                                           \
-    option_length += coap_serialize_int_option(number, current_number, option, \
-                                               coap_pkt->field);               \
-    if (option) {                                                              \
-      OC_DBG(text " [%u]", (unsigned int)coap_pkt->field);                     \
-      option = option_array + option_length;                                   \
-    }                                                                          \
-    current_number = number;                                                   \
-  }
-#define COAP_SERIALIZE_BYTE_OPTION(number, field, text)                        \
-  if (IS_OPTION(coap_pkt, number)) {                                           \
-    option_length += coap_serialize_array_option(number, current_number,       \
-                                                 option, coap_pkt->field,      \
-                                                 coap_pkt->field##_len, '\0'); \
-    if (option) {                                                              \
-      OC_DBG(text " %u [0x%02X%02X%02X%02X%02X%02X%02X%02X]",                  \
-             (unsigned int)coap_pkt->field##_len, coap_pkt->field[0],          \
-             coap_pkt->field[1], coap_pkt->field[2], coap_pkt->field[3],       \
-             coap_pkt->field[4], coap_pkt->field[5], coap_pkt->field[6],       \
-             coap_pkt->field[7]); /* FIXME always prints 8 bytes */            \
-      option = option_array + option_length;                                   \
-    }                                                                          \
-    current_number = number;                                                   \
-  }
-#define COAP_SERIALIZE_STRING_OPTION(number, field, splitter, text)            \
-  if (IS_OPTION(coap_pkt, number)) {                                           \
-    option_length += coap_serialize_array_option(                              \
-      number, current_number, option, (uint8_t *)coap_pkt->field,              \
-      coap_pkt->field##_len, splitter);                                        \
-    if (option) {                                                              \
-      OC_DBG(text " [%.*s]", (int)coap_pkt->field##_len, coap_pkt->field);     \
-      option = option_array + option_length;                                   \
-    }                                                                          \
-    current_number = number;                                                   \
-  }
-#define COAP_SERIALIZE_BLOCK_OPTION(number, field, text)                       \
-  if (IS_OPTION(coap_pkt, number)) {                                           \
-    uint32_t block = coap_pkt->field##_num << 4;                               \
-    if (coap_pkt->field##_more) {                                              \
-      block |= 0x8;                                                            \
-    }                                                                          \
-    block |= 0xF & coap_log_2(coap_pkt->field##_size / 16);                    \
-    option_length +=                                                           \
-      coap_serialize_int_option(number, current_number, option, block);        \
-    if (option) {                                                              \
-      OC_DBG(text " [%lu%s (%u B/blk)]", (unsigned long)coap_pkt->field##_num, \
-             coap_pkt->field##_more ? "+" : "", coap_pkt->field##_size);       \
-      OC_DBG(text " encoded: 0x%lX", (unsigned long)block);                    \
-      option = option_array + option_length;                                   \
-    }                                                                          \
-    current_number = number;                                                   \
-  }
-
-/* to store error code and human-readable payload */
-extern coap_status_t coap_status_code;
-extern char *coap_error_message;
-
 void coap_init_connection(void);
 uint16_t coap_get_mid(void);
 

--- a/messaging/coap/coap_internal.h
+++ b/messaging/coap/coap_internal.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ *
+ * Copyright (c) 2023 Daniel Adam, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"),
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifndef COAP_INTERNAL_H
+#define COAP_INTERNAL_H
+
+#include "constants.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// @brief Get global COAP status code
+coap_status_t coap_global_status_code();
+
+/// @brief Set global COAP status code
+void coap_set_global_status_code(coap_status_t code);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* COAP_INTERNAL_H */

--- a/messaging/coap/separate.c
+++ b/messaging/coap/separate.c
@@ -53,6 +53,7 @@
 
 #include "oc_buffer.h"
 #include "separate.h"
+#include "messaging/coap/coap_internal.h"
 #include "transactions.h"
 #include "util/oc_memb.h"
 #include <stdio.h>
@@ -88,7 +89,7 @@ coap_separate_accept(const coap_packet_t *request,
                      const oc_endpoint_t *endpoint, int observe)
 #endif /* !OC_BLOCK_WISE */
 {
-  coap_status_code = CLEAR_TRANSACTION;
+  coap_set_global_status_code(CLEAR_TRANSACTION);
 
   if (separate_response->active == 0) {
     OC_LIST_STRUCT_INIT(separate_response, requests);

--- a/port/unittest/connectivitytest.cpp
+++ b/port/unittest/connectivitytest.cpp
@@ -90,6 +90,7 @@ protected:
     int ret = oc_main_init(&s_handler);
     ASSERT_EQ(0, ret);
     ASSERT_EQ(0, oc_connectivity_init(g_device));
+    poolEvents(1); // give some time for everything to start-up
   }
 
   void TearDown() override

--- a/util/oc_process.c
+++ b/util/oc_process.c
@@ -42,8 +42,8 @@
 #include <string.h>
 #endif /* OC_DYNAMIC_ALLOCATION */
 #ifdef OC_SECURITY
-#include "api/oc_events.h"       // oc_event_to_oc_process_event
-#include "messaging/coap/coap.h" // coap_status_code
+#include "api/oc_events.h" // oc_event_to_oc_process_event
+#include "messaging/coap/coap_internal.h"
 
 #endif /* OC_SECURITY */
 
@@ -350,7 +350,7 @@ oc_process_nevents(void)
 bool
 oc_process_is_closing_all_tls_sessions()
 {
-  if (coap_status_code == CLOSE_ALL_TLS_SESSIONS) {
+  if (coap_global_status_code() == CLOSE_ALL_TLS_SESSIONS) {
     return true;
   }
 


### PR DESCRIPTION
- remove the global variable from public header
- provide internal setter and getters
- fix issue when the status remained in CLOSE_ALL_TLS_SESSIONS state in some scenarios