### PR TITLE
Fixed the condition around the OC_HAS_FEATURE_TCP_ASYNC_CONNECT flag preventing handling of TCP

### DIFF
--- a/util/oc_features.h
+++ b/util/oc_features.h
@@ -20,11 +20,11 @@
 #define OC_FEATURES_H
 
 #include "oc_config.h"
-#if defined(__linux__) && !defined(__ANDROID_API__) && defined(OC_CLIENT) &&   \
-  defined(OC_TCP)
+#if defined(__linux__) && !defined(__ANDROID_API__) && defined(OC_TCP) &&      \
+  (defined(OC_CLIENT) || defined(OC_SERVER))
 /* Support asynchronous TCP connect */
 #define OC_HAS_FEATURE_TCP_ASYNC_CONNECT
-#endif /* __linux__ && OC_CLIENT && OC_TCP */
+#endif /* __linux__ && !__ANDROID_API__ && OC_TCP && (OC_CLIENT || OC_SERVER) */
 
 #if defined(OC_PUSH) && defined(OC_SERVER) && defined(OC_CLIENT) &&            \
   defined(OC_DYNAMIC_ALLOCATION) && defined(OC_COLLECTIONS_IF_CREATE)


### PR DESCRIPTION
Relates to: #385

The flag was only active when OC_CLIENT was passed which breaks simpleserver which only has OC_SERVER passed to it.

I've updated the condition to include OC_SERVER which covers the case for simpleserver and some others I expect.