### PR TITLE
PKI/TPM: allow to set pk functions for TPM use

### DIFF
--- a/.github/workflows/plgd-hub-tests.yml
+++ b/.github/workflows/plgd-hub-tests.yml
@@ -44,6 +44,10 @@ jobs:
           - name: cloud-server-tsan
             build_args: "-DOC_TSAN_ENABLED=ON"
 
+          - name: cloud-server-simulate-tpm-asan
+            build_args: "-DOC_ASAN_ENABLED=ON"
+            args: "--simulate-tpm"
+            
           - name: cloud-server-time-2000-01-01
             build_args: ""
             docker_args: '-e FAKETIME="@2000-01-01 11:12:13"'

--- a/include/oc_pki.h
+++ b/include/oc_pki.h
@@ -32,12 +32,14 @@
 extern "C" {
 #endif
 
-#include <stddef.h>
-
+#include "oc_export.h"
 #include "oc_sp.h"
 #include <mbedtls/build_info.h>
 #include <mbedtls/mbedtls_config.h>
 #include <mbedtls/x509_crt.h>
+
+#include <stddef.h>
+#include <stdbool.h>
 
 /**
  * Add a PKI identity certificate.
@@ -55,6 +57,7 @@ extern "C" {
  *    chain
  *  - `-1` on failure
  */
+OC_API
 int oc_pki_add_identity_cert(size_t device, const unsigned char *cert,
                              size_t cert_size, const unsigned char *key,
                              size_t key_size);
@@ -75,6 +78,7 @@ int oc_pki_add_identity_cert(size_t device, const unsigned char *cert,
  *    chain
  *  - `-1` on failure
  */
+OC_API
 int oc_pki_add_mfg_cert(size_t device, const unsigned char *cert,
                         size_t cert_size, const unsigned char *key,
                         size_t key_size);
@@ -94,6 +98,7 @@ int oc_pki_add_mfg_cert(size_t device, const unsigned char *cert,
  *     chain
  *   - `-1` on failure
  */
+OC_API
 int oc_pki_add_mfg_intermediate_cert(size_t device, int credid,
                                      const unsigned char *cert,
                                      size_t cert_size);
@@ -110,6 +115,7 @@ int oc_pki_add_mfg_intermediate_cert(size_t device, int credid,
  *    chain
  *  - `-1` on failure
  */
+OC_API
 int oc_pki_add_mfg_trust_anchor(size_t device, const unsigned char *cert,
                                 size_t cert_size);
 
@@ -125,6 +131,7 @@ int oc_pki_add_mfg_trust_anchor(size_t device, const unsigned char *cert,
  *    chain
  *  - `-1` on failure
  */
+OC_API
 int oc_pki_add_trust_anchor(size_t device, const unsigned char *cert,
                             size_t cert_size);
 
@@ -162,13 +169,156 @@ typedef int (*oc_pki_verify_certificate_cb_t)(struct oc_tls_peer_t *peer,
  * ocf verifies the certificate chain.
  * @param[in] cb the callback function
  */
+OC_API
 void oc_pki_set_verify_certificate_cb(oc_pki_verify_certificate_cb_t cb);
 
 /**
  * Get the verification callback for the certificate chain.
  * @return the callback function
  */
+OC_API
 oc_pki_verify_certificate_cb_t oc_pki_get_verify_certificate_cb(void);
+
+/**
+ * @brief           This function loads a private key for use with identity or
+ * manufacturer certificates stored in the credential resource of a device. The
+ * private key can be provided in either PEM or DER format, or by reference to a
+ * previously stored private key in TPM. The function parses the provided
+ * private key and returns a loaded private key object, which can then be used
+ * in cryptographic operations.
+ *
+ * @param device    The device index the key belongs to.
+ * @param pk       The PK context to fill. It must have been initialized
+ *                  but not set up.
+ * @param key       Input buffer to parse.
+ *                  The buffer must contain the input exactly, with no
+ *                  extra trailing material. For PEM, the buffer must
+ *                  contain a null-terminated string. It could be PEM, DER or
+ *                  the reference key (eg in TPM).
+ * @param keylen    Size of \b key in bytes.
+ *                  For PEM data, this includes the terminating null byte,
+ *                  so \p keylen must be equal to `strlen(key) + 1`.
+ * @param pwd       Optional password for decryption.
+ *                  Pass \c NULL if expecting a non-encrypted key.
+ *                  Pass a string of \p pwdlen bytes if expecting an encrypted
+ *                  key; a non-encrypted key will also be accepted.
+ *                  The empty password is not supported.
+ * @param pwdlen    Size of the password in bytes.
+ *                  Ignored if \p pwd is \c NULL.
+ * @param f_rng     RNG function, must not be \c NULL. Used for blinding.
+ * @param p_rng     RNG parameter
+ *
+ * @note            On entry, ctx must be empty, either freshly initialised
+ *                  with mbedtls_pk_init() or reset with mbedtls_pk_free(). If
+ * you need a specific key type, check the result with mbedtls_pk_can_do().
+ *
+ * @note            The key is also checked for correctness.
+ *
+ * @return          0 if successful, or a specific PK or PEM error code
+ * @see
+ * https://arm-software.github.io/CMSIS-mbedTLS/latest/pk_8h.html#aad02107b63f2a47020e6e1ef328e4393
+ */
+typedef int (*mbedtls_pk_parse_key_cb_t)(
+  size_t device, mbedtls_pk_context *pk, const unsigned char *key,
+  size_t keylen, const unsigned char *pwd, size_t pwdlen,
+  int (*f_rng)(void *, unsigned char *, size_t), void *p_rng);
+
+/**
+ * @brief            This function writes a private key to the credential
+ * resource for storage. The private key can be provided as an object and will
+ * be written in either PKCS#1 or SEC1 DER structure, depending on the specified
+ * format. Alternatively, a reference to a private key stored in TPM can be
+ * provided, and the function will write the reference to the credential
+ * resource. Once the private key is written, it can be used with identity or
+ * manufacturer certificates for cryptographic operations. Note: data is written
+ * at the end of the buffer! Use the return value to determine where you should
+ * start using the buffer
+ *
+ * @param device    The device index the key belongs to.
+ * @param ctx       PK context which must contain a valid private key.
+ * @param buf       buffer to write to
+ * @param size      size of the buffer
+ *
+ * @return          length of data written if successful, or a specific
+ *                  error code
+ * @see
+ * https://arm-software.github.io/CMSIS-mbedTLS/latest/pk_8h.html#a2cf4ebaa430cc90954c9556ace2d4dc0
+ */
+typedef int (*mbedtls_pk_write_key_der_cb_t)(size_t device,
+                                             const mbedtls_pk_context *ctx,
+                                             unsigned char *buf, size_t size);
+
+/**
+ * @brief           This function generates the ECP key for the identity
+ * certificate of the device. If the device has a TPM, the function will
+ * generate a private key within the TPM and store it there. The generated key
+ * is returned as an object that can be used to create an identity certificate.
+ *
+ * @param device    The device index the key belongs to.
+ * @param grp_id    The ECP group identifier.
+ * @param pk       The destination key. The key is initialized by
+ * MBEDTLS_PK_ECKEY.
+ * @param f_rng     The RNG function to use. This must not be \c NULL.
+ * @param p_rng     The RNG context to be passed to \p f_rng. This may
+ *                  be \c NULL if \p f_rng doesn't need a context argument.
+ *
+ * \return          \c 0 on success.
+ * \return          An \c MBEDTLS_ERR_ECP_XXX or \c MBEDTLS_MPI_XXX error code
+ *                  on failure.
+ * @see
+ * https://arm-software.github.io/CMSIS-mbedTLS/latest/ecp_8h.html#a0c9a407214f019493ba5d7bc27fa57dc
+ */
+typedef int (*mbedtls_pk_ecp_gen_key_cb_t)(
+  size_t device, mbedtls_ecp_group_id grp_id, mbedtls_pk_context *pk,
+  int (*f_rng)(void *, unsigned char *, size_t), void *p_rng);
+
+/**
+ * @brief          This function frees the private key of the device generated
+ * by mbedtls_pk_ecp_gen_key_cb_t. It is called when factory reset is performed
+ * or during generating csr when the key-pair is not valid.
+ *
+ * @param device   The device index the key belongs to.
+ * @param key      The private key to free.
+ * @param keylen   The length of the private key.
+ *
+ * @return         true, the key is invalid and needs to be regenerated
+ * @return         false, the key is still valid
+ *
+ * @note default implementation returns false, so the key is same as before.
+ *
+ * @see oc_mbedtls_pk_ecp_gen_key
+ */
+typedef bool (*pk_free_key_cb_t)(size_t device, const unsigned char *key,
+                                 size_t keylen);
+
+typedef struct oc_pki_pk_functions_s
+{
+  mbedtls_pk_parse_key_cb_t mbedtls_pk_parse_key;
+  mbedtls_pk_write_key_der_cb_t mbedtls_pk_write_key_der;
+  mbedtls_pk_ecp_gen_key_cb_t mbedtls_pk_ecp_gen_key;
+  pk_free_key_cb_t pk_free_key;
+} oc_pki_pk_functions_t;
+
+/**
+ * Set the PK functions for the identity certificate or the manufacturer
+ * certificate.
+ * @param[in] pk_functions the PK functions, if NULL, the default mbedtls
+ * functions will be used.
+ * @return true if the PK functions have been set.
+ * @return false when any of the functions is NULL.
+ */
+OC_API
+bool oc_pki_set_pk_functions(const oc_pki_pk_functions_t *pk_functions);
+
+/**
+ * Get the PK functions for the identity certificate or the manufacturer
+ * certificate.
+ * @param[out] pk_functions the PK functions
+ * @return true if the PK functions have been configured through the
+ * oc_pki_set_pk_functions function.
+ */
+OC_API
+bool oc_pki_get_pk_functions(oc_pki_pk_functions_t *pk_functions);
 
 #ifdef __cplusplus
 }

--- a/port/oc_log_internal.h
+++ b/port/oc_log_internal.h
@@ -323,7 +323,7 @@
 #else /* OC_NO_LOG_BYTES || !OC_DEBUG */
 #define OC_LOGbytes(bytes, length)                                             \
   do {                                                                         \
-    if (length == 0) {                                                         \
+    if ((length) == 0) {                                                       \
       break;                                                                   \
     }                                                                          \
     oc_logger_t *logger = oc_log_get_logger();                                 \
@@ -333,7 +333,7 @@
     oc_string_t _oc_log_bytes_buf;                                             \
     memset(&_oc_log_bytes_buf, 0, sizeof(_oc_log_bytes_buf));                  \
     oc_alloc_string(&_oc_log_bytes_buf,                                        \
-                    length * 3 + 1 < 2048 ? length * 3 + 1 : 2048);            \
+                    (length)*3 + 1 < 2048 ? (length)*3 + 1 : 2048);            \
     size_t _oc_log_bytes_buf_size = oc_string_len(_oc_log_bytes_buf);          \
     if (_oc_log_bytes_buf_size == 0) {                                         \
       break;                                                                   \

--- a/security/oc_certs.c
+++ b/security/oc_certs.c
@@ -29,6 +29,7 @@
 #include "security/oc_certs_internal.h"
 #include "security/oc_certs_validate_internal.h"
 #include "security/oc_entropy_internal.h"
+#include "security/oc_pki_internal.h"
 #include "security/oc_tls_internal.h"
 #include "util/oc_macros.h"
 
@@ -207,10 +208,10 @@ oc_certs_parse_serial_number(const unsigned char *cert, size_t cert_size,
 }
 
 int
-oc_certs_extract_private_key(const mbedtls_x509_crt *cert,
+oc_certs_extract_private_key(size_t device, const mbedtls_x509_crt *cert,
                              unsigned char *buffer, size_t buffer_size)
 {
-  int ret = mbedtls_pk_write_key_der(&cert->pk, buffer, buffer_size);
+  int ret = oc_mbedtls_pk_write_key_der(device, &cert->pk, buffer, buffer_size);
   if (ret < 0) {
     OC_ERR("could not extract private key from cert %d", ret);
     return ret;
@@ -224,8 +225,9 @@ oc_certs_extract_private_key(const mbedtls_x509_crt *cert,
 }
 
 int
-oc_certs_parse_private_key(const unsigned char *cert, size_t cert_size,
-                           unsigned char *buffer, size_t buffer_size)
+oc_certs_parse_private_key(size_t device, const unsigned char *cert,
+                           size_t cert_size, unsigned char *buffer,
+                           size_t buffer_size)
 {
   mbedtls_x509_crt crt;
   mbedtls_x509_crt_init(&crt);
@@ -236,7 +238,7 @@ oc_certs_parse_private_key(const unsigned char *cert, size_t cert_size,
     return -1;
   }
 
-  ret = oc_certs_extract_private_key(&crt, buffer, buffer_size);
+  ret = oc_certs_extract_private_key(device, &crt, buffer, buffer_size);
   mbedtls_x509_crt_free(&crt);
   return ret;
 }
@@ -245,7 +247,7 @@ int
 oc_certs_extract_public_key(const mbedtls_x509_crt *cert, unsigned char *buffer,
                             size_t buffer_size)
 {
-  int ret = mbedtls_pk_write_pubkey_der(&cert->pk, buffer, buffer_size);
+  int ret = oc_mbedtls_pk_write_pubkey_der(&cert->pk, buffer, buffer_size);
   if (ret < 0) {
     OC_ERR("could not extract public key from cert %d", ret);
     return ret;

--- a/security/oc_certs_internal.h
+++ b/security/oc_certs_internal.h
@@ -73,13 +73,14 @@ int oc_certs_parse_serial_number(const unsigned char *cert, size_t cert_size,
  * @return <0 on error
  * @return >=0 on success, length of data written
  */
-int oc_certs_extract_private_key(const mbedtls_x509_crt *cert,
+int oc_certs_extract_private_key(size_t device, const mbedtls_x509_crt *cert,
                                  unsigned char *buffer, size_t buffer_size);
 
 /// @brief Parse PEM string into a x509 certificate and extract public key
 /// @see oc_certs_extract_private_key
-int oc_certs_parse_private_key(const unsigned char *cert, size_t cert_size,
-                               unsigned char *buffer, size_t buffer_size);
+int oc_certs_parse_private_key(size_t device, const unsigned char *cert,
+                               size_t cert_size, unsigned char *buffer,
+                               size_t buffer_size);
 
 /**
  * @brief Extract public key from a x509 certificate.

--- a/security/oc_csr.c
+++ b/security/oc_csr.c
@@ -30,6 +30,7 @@
 #include "security/oc_csr_internal.h"
 #include "security/oc_entropy_internal.h"
 #include "security/oc_keypair_internal.h"
+#include "security/oc_pki_internal.h"
 #include "security/oc_tls_internal.h"
 
 #include <assert.h>
@@ -37,15 +38,51 @@
 #include <mbedtls/entropy.h>
 #include <mbedtls/x509_csr.h>
 
+static bool
+load_pk_context(size_t device, mbedtls_pk_context *pk)
+{
+  const oc_ecdsa_keypair_t *kp = oc_sec_ecdsa_get_keypair(device);
+  if (kp == NULL) {
+    OC_ERR("could not find public/private key pair on device %zd", device);
+    return -1;
+  }
+  int ret =
+    mbedtls_pk_parse_public_key(pk, kp->public_key, kp->public_key_size);
+  if (ret != 0) {
+    OC_ERR("could not parse public key for device %zd", device);
+    return false;
+  }
+
+  ret = oc_mbedtls_pk_parse_key(
+    device, pk, kp->private_key, kp->private_key_size, 0, 0,
+    mbedtls_ctr_drbg_random, oc_tls_ctr_drbg_context());
+  if (ret != 0) {
+    OC_ERR("could not parse private key for device %zd %d", device, ret);
+    return false;
+  }
+  return true;
+}
+
 int
 oc_sec_csr_generate(size_t device, mbedtls_md_type_t md, unsigned char *csr,
                     size_t csr_size)
 {
   assert(csr != NULL);
-  const oc_ecdsa_keypair_t *kp = oc_sec_ecdsa_get_keypair(device);
-  if (kp == NULL) {
-    OC_ERR("could not find public/private key pair on device %zd", device);
-    return -1;
+
+  mbedtls_pk_context pk;
+  mbedtls_pk_init(&pk);
+  if (!load_pk_context(device, &pk)) {
+    mbedtls_pk_free(&pk);
+    mbedtls_pk_init(&pk);
+    OC_DBG(
+      "could not load keypair for device %zd - try to regenerating the new one",
+      device);
+    oc_sec_ecdsa_reset_keypair(device);
+    if (!load_pk_context(device, &pk)) {
+      mbedtls_pk_free(&pk);
+      OC_ERR("could not load pk for device %zd", device);
+      return -1;
+    }
   }
 
   const oc_uuid_t *uuid = oc_core_get_device_id(device);
@@ -66,29 +103,14 @@ oc_sec_csr_generate(size_t device, mbedtls_md_type_t md, unsigned char *csr,
   mbedtls_entropy_init(&entropy);
   oc_entropy_add_source(&entropy);
 
-  mbedtls_pk_context pk;
-  mbedtls_pk_init(&pk);
-
-  int ret =
-    mbedtls_pk_parse_public_key(&pk, kp->public_key, kp->public_key_size);
-  if (ret != 0) {
-    OC_ERR("could not parse public key for device %zd", device);
-    goto generate_csr_error;
-  }
-
-  ret =
-    mbedtls_pk_parse_key(&pk, kp->private_key, kp->private_key_size, 0, 0,
-                         mbedtls_ctr_drbg_random, oc_tls_ctr_drbg_context());
-  if (ret != 0) {
-    OC_ERR("could not parse private key for device %zd %d", device, ret);
-    goto generate_csr_error;
-  }
+  mbedtls_x509write_csr request;
+  memset(&request, 0, sizeof(mbedtls_x509write_csr));
 
 #define PERSONALIZATION_DATA "IoTivity-Lite-CSR-Generation"
 
-  ret = mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy,
-                              (const unsigned char *)PERSONALIZATION_DATA,
-                              sizeof(PERSONALIZATION_DATA));
+  int ret = mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy,
+                                  (const unsigned char *)PERSONALIZATION_DATA,
+                                  sizeof(PERSONALIZATION_DATA));
 
 #undef PERSONALIZATION_DATA
 
@@ -97,8 +119,6 @@ oc_sec_csr_generate(size_t device, mbedtls_md_type_t md, unsigned char *csr,
     goto generate_csr_error;
   }
 
-  mbedtls_x509write_csr request;
-  memset(&request, 0, sizeof(mbedtls_x509write_csr));
   mbedtls_x509write_csr_init(&request);
   mbedtls_x509write_csr_set_md_alg(&request, md);
   mbedtls_x509write_csr_set_key(&request, &pk);
@@ -213,7 +233,7 @@ oc_sec_csr_extract_public_key(const mbedtls_x509_csr *csr, uint8_t *buffer,
                               size_t buffer_size)
 {
   assert(csr != NULL);
-  int ret = mbedtls_pk_write_pubkey_der(&csr->pk, buffer, buffer_size);
+  int ret = oc_mbedtls_pk_write_pubkey_der(&csr->pk, buffer, buffer_size);
   if (ret < 0) {
     OC_ERR("unable to read public key from CSR %d", ret);
     return -1;

--- a/security/oc_keypair.c
+++ b/security/oc_keypair.c
@@ -269,8 +269,8 @@ generate_ecdsa_keypair_error:
 }
 
 bool
-oc_sec_ecdsa_generate_keypair_for_device(mbedtls_ecp_group_id grpid,
-                                         size_t device)
+oc_sec_ecdsa_update_or_generate_keypair_for_device(mbedtls_ecp_group_id grpid,
+                                                   size_t device)
 {
   oc_ecdsa_keypair_t *kp = oc_sec_ecdsa_get_keypair(device);
   bool exists = kp != NULL;
@@ -296,7 +296,7 @@ oc_sec_ecdsa_generate_keypair_for_device(mbedtls_ecp_group_id grpid,
   return true;
 }
 
-void
+int
 oc_sec_ecdsa_reset_keypair(size_t device)
 {
   oc_ecdsa_keypair_t *kp = oc_sec_ecdsa_get_keypair(device);
@@ -305,16 +305,18 @@ oc_sec_ecdsa_reset_keypair(size_t device)
       OC_DBG("oc_pk_free_key the associated private key for device %zd is "
              "still valid",
              device);
-      return;
+      return 0;
     }
     oc_list_remove(g_oc_keypairs, kp);
     oc_memb_free(&g_oc_keypairs_s, kp);
   }
-  if (!oc_sec_ecdsa_generate_keypair_for_device(oc_sec_certs_ecp_group_id(),
-                                                device)) {
+  if (!oc_sec_ecdsa_update_or_generate_keypair_for_device(
+        oc_sec_certs_ecp_group_id(), device)) {
     OC_ERR("error generating ECDSA keypair for device %zd", device);
+    return -1;
   }
   oc_sec_dump_ecdsa_keypair(device);
+  return 0;
 }
 
 #endif /* OC_SECURITY && OC_PKI */

--- a/security/oc_keypair_internal.h
+++ b/security/oc_keypair_internal.h
@@ -86,8 +86,9 @@ bool oc_sec_ecdsa_encode_keypair(const oc_ecdsa_keypair_t *kp);
 bool oc_sec_ecdsa_decode_keypair(const oc_rep_t *rep, oc_ecdsa_keypair_t *kp);
 
 /**
- * @brief Generate a public and private key pair, store it in a global list of
- * key-pairs and associate it with the given device.
+ * @brief Update an already existing public and private key pair associated with
+ * a given device or generate a new one if it doesn't yet exist and tore it in a
+ * global list of key-pairs and associate it with the given device.
  *
  * @note Each device can be associated with only a single key-pair. If this
  * function is called multiple times with a single device then each successful
@@ -98,8 +99,8 @@ bool oc_sec_ecdsa_decode_keypair(const oc_rep_t *rep, oc_ecdsa_keypair_t *kp);
  * @return true on success
  * @return false on failure
  */
-bool oc_sec_ecdsa_generate_keypair_for_device(mbedtls_ecp_group_id grpid,
-                                              size_t device);
+bool oc_sec_ecdsa_update_or_generate_keypair_for_device(
+  mbedtls_ecp_group_id grpid, size_t device);
 
 /**
  * @brief Decode public and private key, store it in a global list of key-pairs
@@ -136,7 +137,7 @@ oc_ecdsa_keypair_t *oc_sec_ecdsa_get_keypair(size_t device);
 void oc_sec_ecdsa_free_keypairs(void);
 
 /** Free the key-pair associated with the given device and generate new one */
-void oc_sec_ecdsa_reset_keypair(size_t device);
+int oc_sec_ecdsa_reset_keypair(size_t device);
 
 #ifdef __cplusplus
 }

--- a/security/oc_keypair_internal.h
+++ b/security/oc_keypair_internal.h
@@ -47,6 +47,7 @@ typedef struct oc_ecdsa_keypair_t
 /**
  * @brief Generate an ECP key-pair.
  *
+ * @param device device index
  * @param grpid MbedTLS elliptic curve identifier
  * @param[out] public_key buffer to store generated public key
  * @param public_key_buf_size size of the public key buffer
@@ -57,7 +58,7 @@ typedef struct oc_ecdsa_keypair_t
  * @return 0 on success
  * @return -1 on failure
  */
-int oc_sec_ecdsa_generate_keypair(mbedtls_ecp_group_id grpid,
+int oc_sec_ecdsa_generate_keypair(size_t device, mbedtls_ecp_group_id grpid,
                                   uint8_t *public_key,
                                   size_t public_key_buf_size,
                                   size_t *public_key_size, uint8_t *private_key,
@@ -133,6 +134,9 @@ oc_ecdsa_keypair_t *oc_sec_ecdsa_get_keypair(size_t device);
 
 /** Free all key-pairs in the global list */
 void oc_sec_ecdsa_free_keypairs(void);
+
+/** Free the key-pair associated with the given device and generate new one */
+void oc_sec_ecdsa_reset_keypair(size_t device);
 
 #ifdef __cplusplus
 }

--- a/security/oc_obt.c
+++ b/security/oc_obt.c
@@ -3677,7 +3677,7 @@ oc_obt_generate_root_cred(void)
 {
   uint8_t public_key[OC_ECDSA_PUBKEY_SIZE];
   size_t public_key_size = 0;
-  if (oc_sec_ecdsa_generate_keypair(oc_sec_certs_ecp_group_id(), public_key,
+  if (oc_sec_ecdsa_generate_keypair(0, oc_sec_certs_ecp_group_id(), public_key,
                                     OC_ECDSA_PUBKEY_SIZE, &public_key_size,
                                     g_private_key, sizeof(g_private_key),
                                     &g_private_key_size) < 0) {

--- a/security/oc_obt_certs.c
+++ b/security/oc_obt_certs.c
@@ -31,6 +31,7 @@
 #include "security/oc_entropy_internal.h"
 #include "security/oc_keypair_internal.h"
 #include "security/oc_obt_internal.h"
+#include "security/oc_pki_internal.h"
 
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/entropy.h>
@@ -109,8 +110,8 @@ oc_obt_generate_self_signed_root_cert_pem(
     goto exit;
   }
 
-  ret = mbedtls_pk_parse_key(
-    &pk, cert_data.private_key, cert_data.private_key_size,
+  ret = oc_mbedtls_pk_parse_key(
+    0, &pk, cert_data.private_key, cert_data.private_key_size,
     /*pwd*/ NULL, /*pwd_len*/ 0, mbedtls_ctr_drbg_random, &ctr_drbg);
   if (ret < 0) {
     OC_ERR("error parsing root cert's private key %d", ret);
@@ -249,9 +250,10 @@ oc_obt_generate_identity_cert_pem(
     goto exit;
   }
 
-  ret = mbedtls_pk_parse_key(&issuer_priv_key, cert_data.issuer_private_key,
-                             cert_data.issuer_private_key_size, /*pwd*/ NULL,
-                             /*pwdlen*/ 0, mbedtls_ctr_drbg_random, &ctr_drbg);
+  ret =
+    oc_mbedtls_pk_parse_key(0, &issuer_priv_key, cert_data.issuer_private_key,
+                            cert_data.issuer_private_key_size, /*pwd*/ NULL,
+                            /*pwdlen*/ 0, mbedtls_ctr_drbg_random, &ctr_drbg);
   if (ret < 0) {
     OC_ERR("error parsing issuer's private key %d", ret);
     goto exit;
@@ -510,9 +512,10 @@ oc_obt_generate_role_cert_pem(oc_obt_generate_role_cert_data_t cert_data,
     goto exit;
   }
 
-  ret = mbedtls_pk_parse_key(&issuer_priv_key, cert_data.issuer_private_key,
-                             cert_data.issuer_private_key_size, 0, 0,
-                             mbedtls_ctr_drbg_random, &ctr_drbg);
+  ret =
+    oc_mbedtls_pk_parse_key(0, &issuer_priv_key, cert_data.issuer_private_key,
+                            cert_data.issuer_private_key_size, 0, 0,
+                            mbedtls_ctr_drbg_random, &ctr_drbg);
   if (ret < 0) {
     OC_ERR("error parsing issuer's private key %d", ret);
     goto exit;

--- a/security/oc_pstat.c
+++ b/security/oc_pstat.c
@@ -29,6 +29,7 @@
 #include "oc_core_res.h"
 #include "oc_cred_internal.h"
 #include "oc_doxm_internal.h"
+#include "oc_keypair_internal.h"
 #include "oc_roles_internal.h"
 #include "oc_sdi_internal.h"
 #include "oc_sp_internal.h"
@@ -284,6 +285,8 @@ oc_pstat_handle_state(oc_sec_pstat_t *ps, size_t device, bool from_storage,
     }
 #ifdef OC_PKI
     oc_sec_free_roles_for_device(device);
+    // regenerate the key-pair for the identity device certificate.
+    oc_sec_ecdsa_reset_keypair(device);
 #endif /* OC_PKI */
     oc_sec_sp_default(device);
 #ifdef OC_SERVER

--- a/security/oc_store.c
+++ b/security/oc_store.c
@@ -207,8 +207,8 @@ oc_sec_load_ecdsa_keypair(size_t device)
   oc_storage_free_buffer(sb);
 
   if (ret <= 0) {
-    if (!oc_sec_ecdsa_generate_keypair_for_device(oc_sec_certs_ecp_group_id(),
-                                                  device)) {
+    if (!oc_sec_ecdsa_update_or_generate_keypair_for_device(
+          oc_sec_certs_ecp_group_id(), device)) {
       OC_ERR("error generating ECDSA keypair for device %zd", device);
     }
     oc_sec_dump_ecdsa_keypair(device);

--- a/security/unittest/csrtest.cpp
+++ b/security/unittest/csrtest.cpp
@@ -26,6 +26,7 @@
 #include "security/oc_keypair_internal.h"
 #include "security/oc_obt_internal.h"
 #include "tests/gtest/Device.h"
+#include "tests/gtest/KeyPair.h"
 
 #include <algorithm>
 #include <array>
@@ -165,146 +166,17 @@ TEST_F(TestCSRWithDevice, Validate256)
   mbedtls_x509_csr_free(&csr);
 }
 
-class TestCSRWithDeviceTPM : public TestCSRWithDevice {
-public:
-  void SetUp() override
-  {
-    static oc_pki_pk_functions_t pk_functions;
-    pk_functions.mbedtls_pk_ecp_gen_key =
-      TestCSRWithDeviceTPM::simulate_tpm_mbedtls_pk_ecp_gen_key;
-    pk_functions.mbedtls_pk_parse_key =
-      TestCSRWithDeviceTPM::simulate_tpm_mbedtls_pk_parse_key;
-    pk_functions.mbedtls_pk_write_key_der =
-      TestCSRWithDeviceTPM::simulate_tpm_mbedtls_pk_write_key_der;
-    memset(&public_key[0], 0, public_key.size());
-    public_key_size = 0;
-    oc_pki_set_pk_functions(&pk_functions);
-    TestCSRWithDevice::SetUp();
-  }
-
-  void TearDown() override
-  {
-    TestCSRWithDevice::TearDown();
-    oc_pki_set_pk_functions(nullptr);
-    public_key_size = 0;
-    memset(&public_key[0], 0, public_key.size());
-  }
-
-protected:
-  static std::array<uint8_t, OC_ECDSA_PUBKEY_SIZE> public_key;
-  static size_t public_key_size;
-  static std::array<uint8_t, OC_ECDSA_PRIVKEY_SIZE> private_key;
-  static size_t private_key_size;
-
-  static int simulate_tpm_mbedtls_pk_parse_key(
-    size_t /*device*/, mbedtls_pk_context *pk, const unsigned char *key,
-    size_t keylen, const unsigned char *pwd, size_t pwdlen,
-    int (*f_rng)(void *, unsigned char *, size_t), void *p_rng)
-  {
-    if (keylen == public_key_size &&
-        memcmp(key, &public_key[0], public_key_size) == 0) {
-      return mbedtls_pk_parse_key(pk, &private_key[0], private_key_size, pwd,
-                                  pwdlen, f_rng, p_rng);
-    }
-    return MBEDTLS_ERR_PK_KEY_INVALID_FORMAT;
-  }
-
-  static int simulate_tpm_mbedtls_pk_write_key_der(size_t /*device*/,
-                                                   const mbedtls_pk_context *pk,
-                                                   unsigned char *buf,
-                                                   size_t size)
-  {
-    std::array<uint8_t, OC_ECDSA_PUBKEY_SIZE> pub_key;
-    int ret = mbedtls_pk_write_pubkey_der(pk, &pub_key[0], sizeof(pub_key));
-    if (ret > 0) {
-      memmove(&pub_key[0], &pub_key[0] + pub_key.size() - ret, ret);
-    } else {
-      return ret;
-    }
-    if (((size_t)ret) != public_key_size) {
-      return MBEDTLS_ERR_PK_KEY_INVALID_FORMAT;
-    }
-    if (memcmp(&pub_key[0], &public_key[0], ret) != 0) {
-      return MBEDTLS_ERR_PK_KEY_INVALID_FORMAT;
-    }
-    if (size < (size_t)ret) {
-      return MBEDTLS_ERR_PK_BUFFER_TOO_SMALL;
-    }
-    memcpy(buf + size - ret, &pub_key[0], ret);
-    return ret;
-  }
-
-  static int simulate_tpm_mbedtls_pk_ecp_gen_key(
-    size_t device, mbedtls_ecp_group_id grp_id, mbedtls_pk_context *pk,
-    int (*f_rng)(void *, unsigned char *, size_t), void *p_rng)
-  {
-    (void)device;
-    int ret = mbedtls_ecp_gen_key(grp_id, (mbedtls_ecp_keypair *)pk->pk_ctx,
-                                  f_rng, p_rng);
-    if (ret == 0) {
-      ret = mbedtls_pk_write_pubkey_der(pk, &public_key[0], public_key.size());
-      if (ret > 0) {
-        memmove(&public_key[0], &public_key[0] + public_key.size() - ret, ret);
-        public_key_size = ret;
-        ret = 0;
-      }
-    }
-    if (ret == 0) {
-      ret = mbedtls_pk_write_key_der(pk, &private_key[0], private_key.size());
-      if (ret > 0) {
-        memmove(&private_key[0], &private_key[0] + private_key.size() - ret,
-                ret);
-        private_key_size = ret;
-        ret = 0;
-      }
-    }
-    return ret;
-  }
-};
-
-std::array<uint8_t, OC_ECDSA_PUBKEY_SIZE> TestCSRWithDeviceTPM::public_key;
-size_t TestCSRWithDeviceTPM::public_key_size;
-std::array<uint8_t, OC_ECDSA_PRIVKEY_SIZE> TestCSRWithDeviceTPM::private_key;
-size_t TestCSRWithDeviceTPM::private_key_size;
-
-TEST_F(TestCSRWithDeviceTPM, Validate256SimulateTPM)
+TEST_F(TestCSRWithDevice, Reset)
 {
-  std::array<unsigned char, 512> csr_pem{};
-  EXPECT_EQ(0, oc_sec_csr_generate(/*device*/ 0, MBEDTLS_MD_SHA256,
-                                   csr_pem.data(), csr_pem.size()));
-
-  mbedtls_x509_csr csr;
-  EXPECT_EQ(0, mbedtls_x509_csr_parse(&csr, csr_pem.data(), csr_pem.size()));
-
-  EXPECT_FALSE(oc_sec_csr_validate(&csr, MBEDTLS_PK_OPAQUE,
-                                   MBEDTLS_X509_ID_FLAG(MBEDTLS_MD_SHA256)))
-    << "unexpected public key type";
-
-  EXPECT_FALSE(oc_sec_csr_validate(&csr, MBEDTLS_PK_ECKEY,
-                                   MBEDTLS_X509_ID_FLAG(MBEDTLS_MD_SHA384)))
-    << "wrong signature type";
-
-  EXPECT_TRUE(oc_sec_csr_validate(&csr, MBEDTLS_PK_ECKEY,
-                                  MBEDTLS_X509_ID_FLAG(MBEDTLS_MD_SHA256)));
-
-  std::array<char, 1> too_small_sub{};
-  EXPECT_GT(0, oc_sec_csr_extract_subject_DN(&csr, too_small_sub.data(),
-                                             too_small_sub.size()))
-    << "buffer too small";
-
-  std::array<char, 128> sub{};
-  EXPECT_LT(0, oc_sec_csr_extract_subject_DN(&csr, sub.data(), sub.size()))
-    << "cannot extract subject";
-  OC_DBG("Subject: %s", sub.data());
-
-  mbedtls_x509_csr_free(&csr);
+  // TODO: test positive path
+  // compare oc_sec_ecdsa_get_keypair(device) before and after
 }
 
 static mbedtls_x509_csr
 generateValidCSR(mbedtls_md_type_t md, mbedtls_ecp_group_id grpid,
                  size_t device)
 {
-  oc_sec_ecdsa_generate_keypair_for_device(grpid, device);
+  oc_sec_ecdsa_update_or_generate_keypair_for_device(grpid, device);
   std::array<unsigned char, 1024> csr_pem{};
   EXPECT_EQ(0, oc_sec_csr_generate(device, md, csr_pem.data(), csr_pem.size()));
 
@@ -431,5 +303,156 @@ TEST_F(TestCSRWithDevice, Resource)
 }
 
 #endif /* OC_HAS_FEATURE_RESOURCE_ACCESS_IN_RFOTM */
+
+class TestCSRWithDeviceTPM : public TestCSRWithDevice {
+public:
+  void SetUp() override
+  {
+    TestCSRWithDevice::SetUp();
+    static oc_pki_pk_functions_t pk_functions{
+      /*mbedtls_pk_parse_key=*/TestCSRWithDeviceTPM::
+        simulate_tpm_mbedtls_pk_parse_key,
+      /*mbedtls_pk_write_key_der*/
+      TestCSRWithDeviceTPM::simulate_tpm_mbedtls_pk_write_key_der,
+      /*mbedtls_pk_ecp_gen_key=*/
+      TestCSRWithDeviceTPM::simulate_tpm_mbedtls_pk_ecp_gen_key,
+      /*pk_free_key=*/nullptr,
+    };
+    oc_pki_set_pk_functions(&pk_functions);
+    clear_keypair();
+  }
+
+  void TearDown() override
+  {
+    oc_pki_set_pk_functions(nullptr);
+    clear_keypair();
+    TestCSRWithDevice::TearDown();
+  }
+
+protected:
+  static oc::keypair_t g_key_pair;
+
+  static void clear_keypair()
+  {
+    memset(&g_key_pair.public_key[0], 0, g_key_pair.public_key.size());
+    g_key_pair.public_key_size = 0;
+    memset(&g_key_pair.private_key[0], 0, g_key_pair.private_key.size());
+    g_key_pair.private_key_size = 0;
+  }
+
+  static int simulate_tpm_mbedtls_pk_parse_key(
+    size_t /*device*/, mbedtls_pk_context *pk, const unsigned char *key,
+    size_t keylen, const unsigned char *pwd, size_t pwdlen,
+    int (*f_rng)(void *, unsigned char *, size_t), void *p_rng)
+  {
+    if (keylen == g_key_pair.public_key_size &&
+        memcmp(key, &g_key_pair.public_key[0], g_key_pair.public_key_size) ==
+          0) {
+      return mbedtls_pk_parse_key(pk, &g_key_pair.private_key[0],
+                                  g_key_pair.private_key_size, pwd, pwdlen,
+                                  f_rng, p_rng);
+    }
+    return MBEDTLS_ERR_PK_KEY_INVALID_FORMAT;
+  }
+
+  static int simulate_tpm_mbedtls_pk_write_key_der(size_t /*device*/,
+                                                   const mbedtls_pk_context *pk,
+                                                   unsigned char *buf,
+                                                   size_t size)
+  {
+    std::array<uint8_t, OC_ECDSA_PUBKEY_SIZE> pub_key;
+    int ret = mbedtls_pk_write_pubkey_der(pk, &pub_key[0], sizeof(pub_key));
+    if (ret > 0) {
+      memmove(&pub_key[0], &pub_key[0] + pub_key.size() - ret, ret);
+    } else {
+      return ret;
+    }
+    if (((size_t)ret) != g_key_pair.public_key_size) {
+      return MBEDTLS_ERR_PK_KEY_INVALID_FORMAT;
+    }
+    if (memcmp(&pub_key[0], &g_key_pair.public_key[0], ret) != 0) {
+      return MBEDTLS_ERR_PK_KEY_INVALID_FORMAT;
+    }
+    if (size < (size_t)ret) {
+      return MBEDTLS_ERR_PK_BUFFER_TOO_SMALL;
+    }
+    memcpy(buf + size - ret, &pub_key[0], ret);
+    return ret;
+  }
+
+  static int simulate_tpm_mbedtls_pk_ecp_gen_key(
+    size_t device, mbedtls_ecp_group_id grp_id, mbedtls_pk_context *pk,
+    int (*f_rng)(void *, unsigned char *, size_t), void *p_rng)
+  {
+    (void)device;
+    int ret = mbedtls_ecp_gen_key(grp_id, (mbedtls_ecp_keypair *)pk->pk_ctx,
+                                  f_rng, p_rng);
+    if (ret == 0) {
+      ret = mbedtls_pk_write_pubkey_der(pk, &g_key_pair.public_key[0],
+                                        g_key_pair.public_key.size());
+      if (ret > 0) {
+        memmove(&g_key_pair.public_key[0],
+                &g_key_pair.public_key[0] + g_key_pair.public_key.size() - ret,
+                ret);
+        g_key_pair.public_key_size = ret;
+        ret = 0;
+      }
+    }
+    if (ret == 0) {
+      ret = mbedtls_pk_write_key_der(pk, &g_key_pair.private_key[0],
+                                     g_key_pair.private_key.size());
+      if (ret > 0) {
+        memmove(&g_key_pair.private_key[0],
+                &g_key_pair.private_key[0] + g_key_pair.private_key.size() -
+                  ret,
+                ret);
+        g_key_pair.private_key_size = ret;
+        ret = 0;
+      }
+    }
+    return ret;
+  }
+};
+
+oc::keypair_t TestCSRWithDeviceTPM::g_key_pair{};
+
+TEST_F(TestCSRWithDeviceTPM, Validate256SimulateTPM)
+{
+  std::array<unsigned char, 512> csr_pem{};
+  EXPECT_EQ(0, oc_sec_csr_generate(/*device*/ 0, MBEDTLS_MD_SHA256,
+                                   csr_pem.data(), csr_pem.size()));
+
+  mbedtls_x509_csr csr;
+  EXPECT_EQ(0, mbedtls_x509_csr_parse(&csr, csr_pem.data(), csr_pem.size()));
+
+  EXPECT_FALSE(oc_sec_csr_validate(&csr, MBEDTLS_PK_OPAQUE,
+                                   MBEDTLS_X509_ID_FLAG(MBEDTLS_MD_SHA256)))
+    << "unexpected public key type";
+
+  EXPECT_FALSE(oc_sec_csr_validate(&csr, MBEDTLS_PK_ECKEY,
+                                   MBEDTLS_X509_ID_FLAG(MBEDTLS_MD_SHA384)))
+    << "wrong signature type";
+
+  EXPECT_TRUE(oc_sec_csr_validate(&csr, MBEDTLS_PK_ECKEY,
+                                  MBEDTLS_X509_ID_FLAG(MBEDTLS_MD_SHA256)));
+
+  std::array<char, 1> too_small_sub{};
+  EXPECT_GT(0, oc_sec_csr_extract_subject_DN(&csr, too_small_sub.data(),
+                                             too_small_sub.size()))
+    << "buffer too small";
+
+  std::array<char, 128> sub{};
+  EXPECT_LT(0, oc_sec_csr_extract_subject_DN(&csr, sub.data(), sub.size()))
+    << "cannot extract subject";
+  OC_DBG("Subject: %s", sub.data());
+
+  mbedtls_x509_csr_free(&csr);
+}
+
+TEST_F(TestCSRWithDeviceTPM, Reset)
+{
+  // TODO: override oc_pk_free_key -> return false
+  // compare oc_sec_ecdsa_get_keypair(device) before and after
+}
 
 #endif /* OC_SECURITY && OC_PKI */

--- a/security/unittest/keypairtest.cpp
+++ b/security/unittest/keypairtest.cpp
@@ -265,8 +265,8 @@ TEST_F(TestKeyPair, Decode)
 TEST_F(TestKeyPair, GenerateForDeviceFail_UnsupportedEllipticCurve)
 {
   EXPECT_FALSE(
-    oc_sec_ecdsa_generate_keypair_for_device(MBEDTLS_ECP_DP_SECP192R1,
-                                             /*device*/ 0));
+    oc_sec_ecdsa_update_or_generate_keypair_for_device(MBEDTLS_ECP_DP_SECP192R1,
+                                                       /*device*/ 0));
 }
 
 TEST_F(TestKeyPair, GenerateForDevice)
@@ -275,12 +275,14 @@ TEST_F(TestKeyPair, GenerateForDevice)
     OC_DBG("generate ecdsa keypair with elliptic-curve %d", (int)grpid);
     EXPECT_EQ(0, oc_sec_ecdsa_count_keypairs())
       << "error for ec(" << grpid << ")";
-    EXPECT_TRUE(oc_sec_ecdsa_generate_keypair_for_device(grpid,
+    EXPECT_TRUE(
+      oc_sec_ecdsa_update_or_generate_keypair_for_device(grpid,
                                                          /*device*/ 0))
       << "error for ec(" << grpid << ")";
     EXPECT_EQ(1, oc_sec_ecdsa_count_keypairs())
       << "error for ec(" << grpid << ")";
-    EXPECT_TRUE(oc_sec_ecdsa_generate_keypair_for_device(grpid,
+    EXPECT_TRUE(
+      oc_sec_ecdsa_update_or_generate_keypair_for_device(grpid,
                                                          /*device*/ 0))
       << "error for ec(" << grpid << ")";
     EXPECT_EQ(1, oc_sec_ecdsa_count_keypairs())
@@ -303,7 +305,7 @@ TEST_F(TestKeyPair, GenerateForMultipleDevices)
 {
 #ifdef OC_DYNAMIC_ALLOCATION
   for (size_t i = 0; i < 4; ++i) {
-    EXPECT_TRUE(oc_sec_ecdsa_generate_keypair_for_device(
+    EXPECT_TRUE(oc_sec_ecdsa_update_or_generate_keypair_for_device(
       MBEDTLS_ECP_DP_SECP256R1, /*device*/ i));
   }
   EXPECT_EQ(4, oc_sec_ecdsa_count_keypairs());
@@ -311,13 +313,13 @@ TEST_F(TestKeyPair, GenerateForMultipleDevices)
   // without dynamic allocation, the number of items is limited to
   // OC_MAX_NUM_DEVICES
   for (size_t i = 0; i < OC_MAX_NUM_DEVICES; ++i) {
-    EXPECT_TRUE(oc_sec_ecdsa_generate_keypair_for_device(
+    EXPECT_TRUE(oc_sec_ecdsa_update_or_generate_keypair_for_device(
       MBEDTLS_ECP_DP_SECP256R1, /*device*/ i));
   }
   EXPECT_EQ(OC_MAX_NUM_DEVICES, oc_sec_ecdsa_count_keypairs());
 
   // additional allocations should fail
-  EXPECT_FALSE(oc_sec_ecdsa_generate_keypair_for_device(
+  EXPECT_FALSE(oc_sec_ecdsa_update_or_generate_keypair_for_device(
     MBEDTLS_ECP_DP_SECP256R1, /*device*/ OC_MAX_NUM_DEVICES));
 #endif /* OC_DYNAMIC_ALLOCATION */
 }
@@ -332,7 +334,8 @@ TEST_F(TestKeyPair, EncodeForDevice)
     EXPECT_FALSE(oc_sec_ecdsa_encode_keypair_for_device(device))
       << "error for ec(" << grpid << ")";
 
-    EXPECT_TRUE(oc_sec_ecdsa_generate_keypair_for_device(grpid, device))
+    EXPECT_TRUE(
+      oc_sec_ecdsa_update_or_generate_keypair_for_device(grpid, device))
       << "error for ec(" << grpid << ")";
     EXPECT_TRUE(oc_sec_ecdsa_encode_keypair_for_device(device))
       << "error for ec(" << grpid << ")";

--- a/security/unittest/keypairtest.cpp
+++ b/security/unittest/keypairtest.cpp
@@ -89,13 +89,13 @@ TEST_F(TestKeyPair, GenerateFail_SmallBuffers)
   std::array<uint8_t, OC_ECDSA_PRIVKEY_SIZE> private_key{};
   size_t public_key_size = 0;
   int ret = oc_sec_ecdsa_generate_keypair(
-    MBEDTLS_ECP_DP_SECP256R1, too_small.data(), too_small.size(),
+    0, MBEDTLS_ECP_DP_SECP256R1, too_small.data(), too_small.size(),
     &public_key_size, private_key.data(), private_key.size(),
     &private_key_size);
   EXPECT_NE(0, ret);
 
   ret = oc_sec_ecdsa_generate_keypair(
-    MBEDTLS_ECP_DP_SECP256R1, public_key.data(), public_key.size(),
+    0, MBEDTLS_ECP_DP_SECP256R1, public_key.data(), public_key.size(),
     &public_key_size, too_small.data(), too_small.size(), &private_key_size);
   EXPECT_NE(0, ret);
 }
@@ -107,7 +107,7 @@ TEST_F(TestKeyPair, GenerateFail_UnsupportedECP)
   std::array<uint8_t, OC_ECDSA_PRIVKEY_SIZE> private_key{};
   size_t public_key_size = 0;
   int ret = oc_sec_ecdsa_generate_keypair(
-    MBEDTLS_ECP_DP_SECP192R1, public_key.data(), public_key.size(),
+    0, MBEDTLS_ECP_DP_SECP192R1, public_key.data(), public_key.size(),
     &public_key_size, private_key.data(), private_key.size(),
     &private_key_size);
   EXPECT_NE(0, ret);
@@ -122,7 +122,7 @@ TEST_F(TestKeyPair, Generate)
     std::array<uint8_t, OC_ECDSA_PRIVKEY_SIZE> private_key{};
     size_t public_key_size = 0;
     int ret = oc_sec_ecdsa_generate_keypair(
-      grpid, public_key.data(), public_key.size(), &public_key_size,
+      0, grpid, public_key.data(), public_key.size(), &public_key_size,
       private_key.data(), private_key.size(), &private_key_size);
     EXPECT_EQ(0, ret) << "error for ec(" << grpid << ")";
 

--- a/security/unittest/obt_certstest.cpp
+++ b/security/unittest/obt_certstest.cpp
@@ -253,7 +253,7 @@ TEST_F(TestObtCerts, GenerateValidSelfSignedCertificate)
   OC_DBG("serial: %s", &serial[0]);
 
   std::array<uint8_t, 200> private_key{};
-  ret = oc_certs_parse_private_key(&cert_buf[0], cert_buf.size(),
+  ret = oc_certs_parse_private_key(0, &cert_buf[0], cert_buf.size(),
                                    private_key.data(), private_key.size());
   EXPECT_EQ(kp256_.private_key_size, ret);
 
@@ -369,7 +369,7 @@ TEST_F(TestObtCerts, GenerateValidIdentityCertificate)
   EXPECT_NE(std::string::npos, uuid_.find(uuid_cstr.data(), 0));
 
   std::array<uint8_t, 200> private_key{};
-  ret = oc_certs_parse_private_key(&id_cert[0], id_cert.size(),
+  ret = oc_certs_parse_private_key(0, &id_cert[0], id_cert.size(),
                                    private_key.data(), private_key.size());
   EXPECT_EQ(kp256_.private_key_size, ret);
 
@@ -500,7 +500,7 @@ TEST_F(TestObtCerts, GenerateValidRoleCertificate)
   EXPECT_NE(std::string::npos, uuid_.find(uuid_cstr.data(), 0));
 
   std::array<uint8_t, 200> private_key{};
-  ret = oc_certs_parse_private_key(&role_cert[0], role_cert.size(),
+  ret = oc_certs_parse_private_key(0, &role_cert[0], role_cert.size(),
                                    private_key.data(), private_key.size());
   EXPECT_EQ(kp256_.private_key_size, ret);
 

--- a/security/unittest/pkitest.cpp
+++ b/security/unittest/pkitest.cpp
@@ -109,13 +109,12 @@ TEST_F(TestPKIPK, pk_functions)
   pk_functions.pk_free_key = nullptr;
   EXPECT_FALSE(oc_pki_set_pk_functions(&pk_functions));
 
-  oc_pki_pk_functions_t get_pk_functions;
-  memset(&get_pk_functions, 0, sizeof(oc_pki_pk_functions_t));
+  oc_pki_pk_functions_t get_pk_functions{};
   EXPECT_TRUE(oc_pki_get_pk_functions(&get_pk_functions));
-  EXPECT_EQ(get_pk_functions.mbedtls_pk_parse_key, MbedtlsPKParseKey);
-  EXPECT_EQ(get_pk_functions.mbedtls_pk_write_key_der, MbedtlsPKWriteKeyDer);
-  EXPECT_EQ(get_pk_functions.mbedtls_pk_ecp_gen_key, MbedtlsPKEcpGenKey);
-  EXPECT_EQ(get_pk_functions.pk_free_key, PKFreeKey);
+  EXPECT_EQ(get_pk_functions.mbedtls_pk_parse_key, &MbedtlsPKParseKey);
+  EXPECT_EQ(get_pk_functions.mbedtls_pk_write_key_der, &MbedtlsPKWriteKeyDer);
+  EXPECT_EQ(get_pk_functions.mbedtls_pk_ecp_gen_key, &MbedtlsPKEcpGenKey);
+  EXPECT_EQ(get_pk_functions.pk_free_key, &PKFreeKey);
 }
 
 TEST_F(TestPKIPK, pk_free_key)

--- a/security/unittest/pkitest.cpp
+++ b/security/unittest/pkitest.cpp
@@ -1,0 +1,155 @@
+/******************************************************************
+ *
+ * Copyright 2023 Daniel Adam, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"),
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************/
+
+#if defined(OC_SECURITY) && defined(OC_PKI)
+
+#include "oc_pki.h"
+#include "oc_config.h"
+#include "security/oc_pki_internal.h"
+
+#include <stdbool.h>
+#include <gtest/gtest.h>
+
+class TestPKIPK : public testing::Test {
+public:
+  void SetUp() override
+  {
+    pk_free_key_invoked = false;
+    pk_gen_key_invoked = false;
+    pk_write_key_der_invoked = false;
+    pk_parse_key_invoked = false;
+  }
+
+  void TearDown() override { oc_pki_set_pk_functions(nullptr); }
+
+  static bool PKFreeKey(size_t /*device*/, const unsigned char * /*key*/,
+                        size_t /*keylen*/)
+  {
+    pk_free_key_invoked = true;
+    return true;
+  }
+  static int MbedtlsPKEcpGenKey(
+    size_t /*device*/, mbedtls_ecp_group_id /*grp_id*/,
+    mbedtls_pk_context * /*pk*/,
+    int (* /*f_rng*/)(void *, unsigned char *, size_t), void * /*p_rng*/)
+  {
+    pk_gen_key_invoked = true;
+    return 0;
+  }
+  static int MbedtlsPKWriteKeyDer(size_t /*device*/,
+                                  const mbedtls_pk_context * /*pk*/,
+                                  unsigned char * /*buf*/, size_t /*size*/)
+  {
+    pk_write_key_der_invoked = true;
+    return 0;
+  }
+  static int MbedtlsPKParseKey(size_t /*device*/, mbedtls_pk_context * /*pk*/,
+                               const unsigned char * /*key*/, size_t /*keylen*/,
+                               const unsigned char * /*pwd*/, size_t /*pwdlen*/,
+                               int (* /*f_rng*/)(void *, unsigned char *,
+                                                 size_t),
+                               void * /*p_rng*/)
+  {
+    pk_parse_key_invoked = true;
+    return 0;
+  }
+
+  static oc_pki_pk_functions_t GetPKFunctions()
+  {
+    oc_pki_pk_functions_t pk_functions;
+    pk_functions.mbedtls_pk_parse_key = MbedtlsPKParseKey;
+    pk_functions.mbedtls_pk_write_key_der = MbedtlsPKWriteKeyDer;
+    pk_functions.mbedtls_pk_ecp_gen_key = MbedtlsPKEcpGenKey;
+    pk_functions.pk_free_key = PKFreeKey;
+    return pk_functions;
+  }
+
+  static bool pk_free_key_invoked;
+  static bool pk_gen_key_invoked;
+  static bool pk_write_key_der_invoked;
+  static bool pk_parse_key_invoked;
+};
+
+bool TestPKIPK::pk_free_key_invoked = false;
+bool TestPKIPK::pk_gen_key_invoked = false;
+bool TestPKIPK::pk_write_key_der_invoked = false;
+bool TestPKIPK::pk_parse_key_invoked = false;
+
+TEST_F(TestPKIPK, pk_functions)
+{
+  EXPECT_TRUE(oc_pki_set_pk_functions(nullptr));
+  EXPECT_FALSE(oc_pki_get_pk_functions(nullptr));
+  oc_pki_pk_functions_t pk_functions = GetPKFunctions();
+  EXPECT_TRUE(oc_pki_set_pk_functions(&pk_functions));
+  EXPECT_TRUE(oc_pki_get_pk_functions(nullptr));
+  pk_functions.mbedtls_pk_parse_key = nullptr;
+  EXPECT_FALSE(oc_pki_set_pk_functions(&pk_functions));
+  pk_functions.mbedtls_pk_parse_key = MbedtlsPKParseKey;
+  pk_functions.mbedtls_pk_write_key_der = nullptr;
+  EXPECT_FALSE(oc_pki_set_pk_functions(&pk_functions));
+  pk_functions.mbedtls_pk_write_key_der = MbedtlsPKWriteKeyDer;
+  pk_functions.mbedtls_pk_ecp_gen_key = nullptr;
+  EXPECT_FALSE(oc_pki_set_pk_functions(&pk_functions));
+  pk_functions.mbedtls_pk_ecp_gen_key = MbedtlsPKEcpGenKey;
+  pk_functions.pk_free_key = nullptr;
+  EXPECT_FALSE(oc_pki_set_pk_functions(&pk_functions));
+
+  oc_pki_pk_functions_t get_pk_functions;
+  memset(&get_pk_functions, 0, sizeof(oc_pki_pk_functions_t));
+  EXPECT_TRUE(oc_pki_get_pk_functions(&get_pk_functions));
+  EXPECT_EQ(get_pk_functions.mbedtls_pk_parse_key, MbedtlsPKParseKey);
+  EXPECT_EQ(get_pk_functions.mbedtls_pk_write_key_der, MbedtlsPKWriteKeyDer);
+  EXPECT_EQ(get_pk_functions.mbedtls_pk_ecp_gen_key, MbedtlsPKEcpGenKey);
+  EXPECT_EQ(get_pk_functions.pk_free_key, PKFreeKey);
+}
+
+TEST_F(TestPKIPK, pk_free_key)
+{
+  oc_pki_pk_functions_t pk_functions = GetPKFunctions();
+  EXPECT_FALSE(oc_pk_free_key(0, nullptr, 0));
+  EXPECT_TRUE(oc_pki_set_pk_functions(&pk_functions));
+  EXPECT_TRUE(oc_pk_free_key(0, nullptr, 0));
+  EXPECT_TRUE(pk_free_key_invoked);
+}
+
+TEST_F(TestPKIPK, pk_gen_key)
+{
+  oc_pki_pk_functions_t pk_functions = GetPKFunctions();
+  EXPECT_TRUE(oc_pki_set_pk_functions(&pk_functions));
+  oc_mbedtls_pk_ecp_gen_key(0, MBEDTLS_ECP_DP_SECP256R1, nullptr, nullptr,
+                            nullptr);
+  EXPECT_TRUE(pk_gen_key_invoked);
+}
+
+TEST_F(TestPKIPK, pk_write_key_der)
+{
+  oc_pki_pk_functions_t pk_functions = GetPKFunctions();
+  EXPECT_TRUE(oc_pki_set_pk_functions(&pk_functions));
+  oc_mbedtls_pk_write_key_der(0, nullptr, nullptr, 0);
+  EXPECT_TRUE(pk_write_key_der_invoked);
+}
+
+TEST_F(TestPKIPK, pk_parse_key)
+{
+  oc_pki_pk_functions_t pk_functions = GetPKFunctions();
+  EXPECT_TRUE(oc_pki_set_pk_functions(&pk_functions));
+  oc_mbedtls_pk_parse_key(0, nullptr, nullptr, 0, nullptr, 0, nullptr, nullptr);
+  EXPECT_TRUE(pk_parse_key_invoked);
+}
+
+#endif /* OC_SECURITY && OC_PKI */

--- a/tests/gtest/KeyPair.cpp
+++ b/tests/gtest/KeyPair.cpp
@@ -29,7 +29,7 @@ GetECPKeyPair(mbedtls_ecp_group_id grpid)
 {
   keypair_t kp{};
   int err = oc_sec_ecdsa_generate_keypair(
-    grpid, kp.public_key.data(), kp.public_key.size(), &kp.public_key_size,
+    0, grpid, kp.public_key.data(), kp.public_key.size(), &kp.public_key_size,
     kp.private_key.data(), kp.private_key.size(), &kp.private_key_size);
   EXPECT_EQ(0, err);
   return kp;
@@ -41,7 +41,7 @@ GetOCKeyPair(mbedtls_ecp_group_id grpid)
   oc_ecdsa_keypair_t kp{};
   size_t public_key_size{};
   int err = oc_sec_ecdsa_generate_keypair(
-    grpid, kp.public_key, sizeof(kp.public_key), &public_key_size,
+    0, grpid, kp.public_key, sizeof(kp.public_key), &public_key_size,
     kp.private_key, sizeof(kp.private_key), &kp.private_key_size);
   EXPECT_EQ(0, err);
   return kp;


### PR DESCRIPTION
To integrate TPM with iotivity-lite, the mbedtls library is used for cryptography. There are four main functions that need to be implemented:

1. **Generate public and private key**: The `mbedtls_pk_ecp_gen_key` function generates a private key for the CSR of the identity certificate when iotivity-lite doesn't have a private key in the keypair storage. In this function, a private key needs to be generated in the TPM, and the public key `mbedtls_pk_context` needs to be filled.
2. **Free private key in TPM**: The `pk_free_key` function frees the private key in the TPM. This function is called when a factory reset is performed or when the keypair storage does not match the TPM during the generation of the CSR with the reference key.
3. **Store reference key to credential resource**: The `mbedtls_pk_write_key_der` function writes the private key to a buffer for the credential resource. A reference key associated with the private key in the TPM needs to be created according to `mbedtls_pk_context *pk`. This reference key is written to the buffer and stored in the credential resource or keypair storage
4. **Load public key with reference key**: This function parses the public key/certificate and private key from the keypair storage or credential resource. The reference key to the private key in the TPM, as written by `mbedtls_pk_write_key_der`, needs to be used as the key to set the public key mbedtls_pk_context *pk by the TPM chip.

To make use of these TPM functions in iotivity-lite, you need to set the TPM implementations as `oc_pki_set_pk_functions` before calling `oc_main_init`.

```c

#include <iotivity-lite/oc_pki.h>

oc_pki_pk_functions_t pk_functions = {
    .mbedtls_pk_ecp_gen_key = tpm_mbedtls_pk_ecp_gen_key,
    .pk_free_key = simulate_tpm_pk_free_key,
    .mbedtls_pk_parse_key = tpm_mbedtls_pk_parse_key,
    .mbedtls_pk_write_key_der = tpm_mbedtls_pk_write_key_der,
};
if (!oc_pki_set_pk_functions(&pk_functions)) {
  // Failed to set PKI function
  return -1;
}
```