### PR TITLE
validate incoming data in network thread

### DIFF
--- a/api/oc_tcp_internal.h
+++ b/api/oc_tcp_internal.h
@@ -21,7 +21,7 @@
 
 #include "util/oc_features.h"
 
-#ifdef OC_HAS_FEATURE_TCP_ASYNC_CONNECT
+#ifdef OC_TCP
 
 #include "port/oc_connectivity.h"
 #include "oc_endpoint.h"
@@ -30,6 +30,7 @@
 extern "C" {
 #endif
 
+#ifdef OC_HAS_FEATURE_TCP_ASYNC_CONNECT
 typedef struct oc_tcp_on_connect_event_s
 {
   struct oc_tcp_on_connect_data_s *next;
@@ -46,10 +47,17 @@ oc_tcp_on_connect_event_t *oc_tcp_on_connect_event_create(
 /** @brief Free TCP on connect event */
 void oc_tcp_on_connect_event_free(oc_tcp_on_connect_event_t *event);
 
+#endif /* OC_HAS_FEATURE_TCP_ASYNC_CONNECT */
+
+/** @brief Check if the message is a valid CoAP/TLS header */
+bool oc_tcp_is_valid_header(const oc_message_t *message);
+
+/** @brief Check if the message is a valid for CoAP TCP */
+bool oc_tcp_is_valid_message(oc_message_t *message);
+
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* OC_HAS_FEATURE_TCP_ASYNC_CONNECT */
-
+#endif /* OC_TCP */
 #endif /* OC_TCP_INTERNAL_H */

--- a/api/oc_udp.c
+++ b/api/oc_udp.c
@@ -1,0 +1,98 @@
+/****************************************************************************
+ *
+ * Copyright (c) 2022 plgd.dev s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"),
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#include "oc_endpoint.h"
+#include "oc_udp_internal.h"
+#include "messaging/coap/coap.h"
+#include "port/oc_connectivity.h"
+#ifdef OC_SECURITY
+#include <mbedtls/ssl.h>
+#ifdef OC_OSCORE
+#include "messaging/coap/oscore.h"
+#endif /* OC_OSCORE */
+#endif /* OC_SECURITY */
+
+#include <assert.h>
+
+bool
+oc_udp_is_valid_message(oc_message_t *message)
+{
+  assert(message != NULL);
+#ifdef OC_SECURITY
+  if ((message->endpoint.flags & SECURED) != 0) {
+    if (message->length < 3) {
+      OC_ERR("invalid DTLS header length: %lu", (long unsigned)message->length);
+      // Invalid DTLS header length
+      return false;
+    }
+
+    // Parse the header fields
+    uint8_t type = message->data[0];
+    uint8_t major_version = 255 - message->data[1] + 2;
+    uint8_t minor_version = 255 - message->data[2] + 1;
+    OC_DBG("TLS header: record type: %d, major %d(%d), minor %d(%d)", type,
+           major_version, message->data[1], minor_version, message->data[2]);
+    if (major_version != MBEDTLS_SSL_MAJOR_VERSION_3) {
+      OC_ERR("invalid major version: %d", major_version);
+      // Invalid major version
+      return false;
+    }
+    if (
+      // TLS 1.0 - some implementations doesn't set the minor version (eg
+      // golang)
+      minor_version != 1 &&
+      // TLS 1.1
+      minor_version != 2 &&
+      // TLS 1.2
+      minor_version != MBEDTLS_SSL_MINOR_VERSION_3 &&
+      // TLS 1.3
+      minor_version != MBEDTLS_SSL_MINOR_VERSION_4) {
+      OC_ERR("invalid minor version: %d", minor_version);
+      return false;
+    }
+    // Validate the header fields
+    switch (type) {
+    case MBEDTLS_SSL_MSG_HANDSHAKE:
+    case MBEDTLS_SSL_MSG_CHANGE_CIPHER_SPEC:
+    case MBEDTLS_SSL_MSG_ALERT:
+    case MBEDTLS_SSL_MSG_APPLICATION_DATA:
+    case MBEDTLS_SSL_MSG_CID:
+      // Valid record type
+      break;
+    default:
+      OC_WRN("invalid record type: %d", type);
+      // mbedtls need to get invalid record type to handle it
+    }
+    return true;
+  }
+#ifdef OC_OSCORE
+  if (oscore_is_oscore_message(message) >= 0) {
+    // it is oscore message
+    return true;
+  }
+#endif /* OC_OSCORE */
+#endif /* OC_SECURITY */
+  coap_packet_t packet;
+  coap_status_t s =
+    coap_udp_parse_message(&packet, message->data, message->length, true);
+  if (s == BAD_REQUEST_4_00) {
+    OC_ERR("coap_udp_parse_message failed: %d", s);
+    return false;
+  }
+  return true;
+}

--- a/api/oc_udp_internal.h
+++ b/api/oc_udp_internal.h
@@ -1,0 +1,35 @@
+/****************************************************************************
+ *
+ * Copyright (c) 2022 plgd.dev s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"),
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifndef OC_UDP_INTERNAL_H
+#define OC_UDP_INTERNAL_H
+
+#include "port/oc_connectivity.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief Check if the message is a valid CoAP/TLS header */
+bool oc_udp_is_valid_message(oc_message_t *message);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OC_UDP_INTERNAL_H */

--- a/api/unittest/tcptest.cpp
+++ b/api/unittest/tcptest.cpp
@@ -1,0 +1,92 @@
+/****************************************************************************
+ *
+ * Copyright (c) 2023 plgd.dev s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"),
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifdef OC_TCP
+
+#include "oc_config.h"
+#include "oc_endpoint.h"
+#include "oc_buffer.h"
+#include "api/oc_tcp_internal.h"
+#include "port/oc_network_event_handler_internal.h"
+
+#include <array>
+#include <cstdlib>
+#include <gtest/gtest.h>
+
+#ifdef _WIN32
+#include <WinSock2.h>
+#endif /* _WIN32 */
+
+#ifdef OC_SECURITY
+#include <mbedtls/ssl.h>
+#endif /* OC_SECURITY */
+
+class TCPMessage : public testing::Test {
+public:
+  void SetUp() override
+  {
+    oc_network_event_handler_mutex_init();
+#ifdef _WIN32
+    WSADATA wsaData;
+    WSAStartup(MAKEWORD(2, 2), &wsaData);
+#endif /* _WIN32 */
+  }
+
+  void TearDown() override
+  {
+#ifdef _WIN32
+    WSACleanup();
+#endif /* _WIN32 */
+    oc_network_event_handler_mutex_destroy();
+  }
+
+  static void ValidateMessage(bool exp, bool secure,
+                              const std::vector<uint8_t> &data)
+  {
+    oc_message_t *msg = oc_allocate_message();
+    msg->endpoint.flags = secure ? SECURED : (transport_flags)0;
+    memcpy(msg->data, &data[0], data.size());
+    msg->length = data.size();
+    EXPECT_EQ(exp, oc_tcp_is_valid_header(msg));
+    oc_message_unref(msg);
+  }
+};
+
+TEST_F(TCPMessage, ValidateHeader)
+{
+  ValidateMessage(true, false, { 1, 2, 3, 4 });
+  ValidateMessage(false, false, { 0xff, 2, 3, 4 });
+#ifdef OC_SECURITY
+  ValidateMessage(true, true,
+                  { MBEDTLS_SSL_MSG_HANDSHAKE, MBEDTLS_SSL_MAJOR_VERSION_3,
+                    MBEDTLS_SSL_MINOR_VERSION_3 });
+  ValidateMessage(
+    false, true,
+    { MBEDTLS_SSL_MSG_HANDSHAKE, 0xff, MBEDTLS_SSL_MINOR_VERSION_3 });
+  ValidateMessage(
+    false, true,
+    { MBEDTLS_SSL_MSG_HANDSHAKE, MBEDTLS_SSL_MAJOR_VERSION_3, 0xff });
+  ValidateMessage(false, true,
+                  { MBEDTLS_SSL_MSG_HANDSHAKE, MBEDTLS_SSL_MAJOR_VERSION_3 });
+  ValidateMessage(
+    false, true,
+    { 0xff, MBEDTLS_SSL_MAJOR_VERSION_3, MBEDTLS_SSL_MINOR_VERSION_3 });
+#endif /* OC_SECURITY */
+}
+
+#endif /* OC_TCP */

--- a/api/unittest/udptest.cpp
+++ b/api/unittest/udptest.cpp
@@ -1,0 +1,104 @@
+/****************************************************************************
+ *
+ * Copyright (c) 2023 plgd.dev s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"),
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#include "oc_config.h"
+#include "oc_endpoint.h"
+#include "oc_buffer.h"
+#include "api/oc_udp_internal.h"
+#include "port/oc_log.h"
+#include "port/oc_network_event_handler_internal.h"
+
+#include <array>
+#include <cstdlib>
+#include <gtest/gtest.h>
+
+#ifdef _WIN32
+#include <WinSock2.h>
+#endif /* _WIN32 */
+
+#ifdef OC_SECURITY
+#include <mbedtls/ssl.h>
+#endif /* OC_SECURITY */
+
+class UDPMessage : public testing::Test {
+public:
+  void SetUp() override
+  {
+    oc_network_event_handler_mutex_init();
+#ifdef _WIN32
+    WSADATA wsaData;
+    WSAStartup(MAKEWORD(2, 2), &wsaData);
+#endif /* _WIN32 */
+  }
+
+  void TearDown() override
+  {
+#ifdef _WIN32
+    WSACleanup();
+#endif /* _WIN32 */
+    oc_network_event_handler_mutex_destroy();
+  }
+
+  static void ValidateMessage(bool exp, bool secure,
+                              const std::vector<uint8_t> &data)
+  {
+    oc_message_t *msg = oc_allocate_message();
+    msg->endpoint.flags = secure ? SECURED : (transport_flags)0;
+    memcpy(msg->data, &data[0], data.size());
+    msg->length = data.size();
+    EXPECT_EQ(exp, oc_udp_is_valid_message(msg));
+    oc_message_unref(msg);
+  }
+};
+
+TEST_F(UDPMessage, ValidateHeader)
+{
+  ValidateMessage(true, false, { 1 << COAP_HEADER_VERSION_POSITION, 2, 3, 4 });
+  ValidateMessage(false, false, { 0xff, 2, 3, 4 });
+#ifdef OC_SECURITY
+  OC_DBG(
+    "ValidateMessage(true, true, {MBEDTLS_SSL_MSG_HANDSHAKE, "
+    "255-MBEDTLS_SSL_MAJOR_VERSION_3+2, 255-MBEDTLS_SSL_MINOR_VERSION_3+1});");
+  ValidateMessage(true, true,
+                  { MBEDTLS_SSL_MSG_HANDSHAKE,
+                    255 - MBEDTLS_SSL_MAJOR_VERSION_3 + 2,
+                    255 - MBEDTLS_SSL_MINOR_VERSION_3 + 1 });
+  OC_DBG("ValidateMessage(false, true, {MBEDTLS_SSL_MSG_HANDSHAKE, 0xff, "
+         "255-MBEDTLS_SSL_MINOR_VERSION_3+1});");
+  ValidateMessage(
+    false, true,
+    { MBEDTLS_SSL_MSG_HANDSHAKE, 0xff, 255 - MBEDTLS_SSL_MINOR_VERSION_3 + 1 });
+  OC_DBG("ValidateMessage(false, true, {MBEDTLS_SSL_MSG_HANDSHAKE, "
+         "255-MBEDTLS_SSL_MAJOR_VERSION_3+2, 128});");
+  ValidateMessage(
+    false, true,
+    { MBEDTLS_SSL_MSG_HANDSHAKE, 255 - MBEDTLS_SSL_MAJOR_VERSION_3 + 2, 128 });
+  OC_DBG("ValidateMessage(false, true, {MBEDTLS_SSL_MSG_HANDSHAKE, "
+         "255-MBEDTLS_SSL_MAJOR_VERSION_3+2, 0xff});");
+  ValidateMessage(
+    false, true,
+    { MBEDTLS_SSL_MSG_HANDSHAKE, 255 - MBEDTLS_SSL_MAJOR_VERSION_3 + 2 });
+  OC_DBG(
+    "ValidateMessage(false, true, {0xff, 255-MBEDTLS_SSL_MAJOR_VERSION_3+2, "
+    "255-MBEDTLS_SSL_MINOR_VERSION_3+1});");
+  // produces just warning
+  ValidateMessage(true, true,
+                  { 0xff, 255 - MBEDTLS_SSL_MAJOR_VERSION_3 + 2,
+                    255 - MBEDTLS_SSL_MINOR_VERSION_3 + 1 });
+#endif /* OC_SECURITY */
+}

--- a/messaging/coap/coap.h
+++ b/messaging/coap/coap.h
@@ -180,12 +180,36 @@ size_t coap_serialize_message(void *packet, uint8_t *buffer);
 size_t coap_oscore_serialize_message(void *packet, uint8_t *buffer, bool inner,
                                      bool outer, bool oscore);
 void coap_send_message(oc_message_t *message);
-coap_status_t coap_oscore_parse_options(void *packet, uint8_t *data,
-                                        uint32_t data_len,
+
+/**
+ * @brief Parse CoAP message options
+ *
+ * @param packet pointer to coap_packet_t struct
+ * @param data raw message data
+ * @param data_len length of raw message data
+ * @param current_option offset of current option in raw message data
+ * @param inner oscore inner option
+ * @param outer oscore outer option
+ * @param oscore oscore used
+ * @param validate if true, it doesn't modify data, and validation stops on
+ * first BAD_REQUEST
+ * @return coap_status_t
+ */
+coap_status_t coap_oscore_parse_options(void *packet, const uint8_t *data,
+                                        size_t data_len,
                                         uint8_t *current_option, bool inner,
-                                        bool outer, bool oscore);
+                                        bool outer, bool oscore, bool validate);
+/**
+ * @brief Parse UDP CoAP message
+ *
+ * @param request pointer to coap_packet_t struct
+ * @param data raw message data
+ * @param data_len length of raw message data
+ * @param validate if true, it doesn't modify data
+ * @return coap_status_t
+ */
 coap_status_t coap_udp_parse_message(void *request, uint8_t *data,
-                                     uint16_t data_len);
+                                     size_t data_len, bool validate);
 
 int coap_get_query_variable(void *packet, const char *name,
                             const char **output);
@@ -286,8 +310,17 @@ void coap_tcp_init_message(void *packet, uint8_t code);
 
 size_t coap_tcp_get_packet_size(const uint8_t *data);
 
+/**
+ * @brief Parse TCP CoAP message
+ *
+ * @param request pointer to coap_packet_t struct
+ * @param data raw message data
+ * @param data_len length of raw message data
+ * @param validate if true, it doesn't modify data
+ * @return coap_status_t
+ */
 coap_status_t coap_tcp_parse_message(void *packet, uint8_t *data,
-                                     uint32_t data_len);
+                                     size_t data_len, bool validate);
 
 void coap_tcp_parse_message_length(const uint8_t *data, size_t *message_length,
                                    uint8_t *num_extended_length_bytes);

--- a/messaging/coap/engine.c
+++ b/messaging/coap/engine.c
@@ -195,11 +195,11 @@ coap_receive(oc_message_t *msg)
   coap_status_t status;
 #ifdef OC_TCP
   if (msg->endpoint.flags & TCP) {
-    status = coap_tcp_parse_message(message, msg->data, (uint32_t)msg->length);
+    status = coap_tcp_parse_message(message, msg->data, msg->length, false);
   } else
 #endif /* OC_TCP */
   {
-    status = coap_udp_parse_message(message, msg->data, (uint16_t)msg->length);
+    status = coap_udp_parse_message(message, msg->data, msg->length, false);
   }
   coap_set_global_status_code(status);
 

--- a/messaging/coap/oscore.c
+++ b/messaging/coap/oscore.c
@@ -401,7 +401,7 @@ oscore_parse_inner_message(uint8_t *data, size_t data_len,
 
   /* Parse inner options */
   coap_status_t ret = coap_oscore_parse_options(
-    packet, data, data_len, current_option, true, false, true);
+    packet, data, data_len, current_option, true, false, true, false);
   if (COAP_NO_ERROR != ret) {
     OC_DBG("coap_oscore_parse_options failed! %d", ret);
     return ret;
@@ -552,7 +552,7 @@ oscore_parse_outer_message(oc_message_t *msg, coap_packet_t *packet)
 
   /* Parse outer options */
   coap_status_t ret = coap_oscore_parse_options(
-    packet, msg->data, msg->length, current_option, false, true, true);
+    packet, msg->data, msg->length, current_option, false, true, true, false);
   if (COAP_NO_ERROR != ret) {
     OC_DBG("coap_oscore_parse_options failed! %d", ret);
     return ret;

--- a/messaging/coap/unittest/coapsignaltest.cpp
+++ b/messaging/coap/unittest/coapsignaltest.cpp
@@ -625,7 +625,7 @@ TEST_F(TestCoapSignal, SignalSerializeParseTest_CSM)
 
   coap_packet_t parse_packet{};
   coap_status_t ret =
-    coap_tcp_parse_message(&parse_packet, buffer.data(), (uint32_t)buffer_len);
+    coap_tcp_parse_message(&parse_packet, buffer.data(), buffer_len, false);
 
   ASSERT_EQ(COAP_NO_ERROR, ret);
   ASSERT_EQ(packet.code, parse_packet.code);
@@ -645,7 +645,7 @@ TEST_F(TestCoapSignal, SignalSerializeParseTest_PING)
 
   coap_packet_t parse_packet{};
   coap_status_t ret =
-    coap_tcp_parse_message(&parse_packet, buffer.data(), (uint32_t)buffer_len);
+    coap_tcp_parse_message(&parse_packet, buffer.data(), buffer_len, false);
 
   ASSERT_EQ(COAP_NO_ERROR, ret);
   ASSERT_EQ(packet.code, parse_packet.code);
@@ -664,7 +664,7 @@ TEST_F(TestCoapSignal, SignalSerializeParseTest_PONG)
 
   coap_packet_t parse_packet{};
   coap_status_t ret =
-    coap_tcp_parse_message(&parse_packet, buffer.data(), (uint32_t)buffer_len);
+    coap_tcp_parse_message(&parse_packet, buffer.data(), buffer_len, false);
 
   ASSERT_EQ(COAP_NO_ERROR, ret);
   ASSERT_EQ(packet.code, parse_packet.code);
@@ -688,7 +688,7 @@ TEST_F(TestCoapSignal, SignalSerializeParseTest_RELEASE)
 
   coap_packet_t parse_packet{};
   coap_status_t ret =
-    coap_tcp_parse_message(&parse_packet, buffer.data(), (uint32_t)buffer_len);
+    coap_tcp_parse_message(&parse_packet, buffer.data(), buffer_len, false);
 
   ASSERT_EQ(COAP_NO_ERROR, ret);
   ASSERT_EQ(packet.code, parse_packet.code);
@@ -715,7 +715,7 @@ TEST_F(TestCoapSignal, SignalSerializeParseTest_ABORT)
 
   coap_packet_t parse_packet{};
   coap_status_t ret =
-    coap_tcp_parse_message(&parse_packet, buffer.data(), (uint32_t)buffer_len);
+    coap_tcp_parse_message(&parse_packet, buffer.data(), buffer_len, false);
 
   ASSERT_EQ(COAP_NO_ERROR, ret);
   ASSERT_EQ(packet.code, parse_packet.code);

--- a/port/android/tcpadapter.c
+++ b/port/android/tcpadapter.c
@@ -20,6 +20,7 @@
 
 #include "tcpadapter.h"
 #include "api/oc_session_events_internal.h"
+#include "api/oc_tcp_internal.h"
 #include "ipcontext.h"
 #include "messaging/coap/coap.h"
 #include "oc_endpoint.h"
@@ -414,12 +415,24 @@ oc_tcp_receive_message(ip_context_t *dev, fd_set *fds, oc_message_t *message)
     want_read -= (size_t)count;
 
     if (total_length == 0) {
+      memcpy(&message->endpoint, &session->endpoint, sizeof(oc_endpoint_t));
+#ifdef OC_SECURITY
+      if (message->endpoint.flags & SECURED) {
+        message->encrypted = 1;
+      }
+#endif /* OC_SECURITY */
+      if (!oc_tcp_is_valid_header(message)) {
+        OC_ERR("invalid header");
+        free_tcp_session(session);
+        ret_with_code(ADAPTER_STATUS_ERROR);
+      }
       total_length = get_total_length_from_header(message, &session->endpoint);
       if (total_length >
           (unsigned)(OC_MAX_APP_DATA_SIZE + COAP_MAX_HEADER_SIZE)) {
         OC_ERR("total receive length(%zu) is bigger than max pdu size(%ld)",
                total_length, (OC_MAX_APP_DATA_SIZE + COAP_MAX_HEADER_SIZE));
         OC_ERR("It may occur buffer overflow.");
+        free_tcp_session(session);
         ret_with_code(ADAPTER_STATUS_ERROR);
       }
       OC_DBG("tcp packet total length : %zu bytes.", total_length);
@@ -428,12 +441,10 @@ oc_tcp_receive_message(ip_context_t *dev, fd_set *fds, oc_message_t *message)
     }
   } while (total_length > message->length);
 
-  memcpy(&message->endpoint, &session->endpoint, sizeof(oc_endpoint_t));
-#ifdef OC_SECURITY
-  if (message->endpoint.flags & SECURED) {
-    message->encrypted = 1;
+  if (!oc_tcp_is_valid_message(message)) {
+    free_tcp_session(session);
+    return ADAPTER_STATUS_ERROR;
   }
-#endif /* OC_SECURITY */
 
   FD_CLR(session->sock, fds);
   ret = ADAPTER_STATUS_RECEIVE;

--- a/port/esp32/main/CMakeLists.txt
+++ b/port/esp32/main/CMakeLists.txt
@@ -47,6 +47,7 @@ set(sources
 	${CMAKE_CURRENT_SOURCE_DIR}/../../../api/oc_session_events.c
 	${CMAKE_CURRENT_SOURCE_DIR}/../../../api/oc_storage.c
 	${CMAKE_CURRENT_SOURCE_DIR}/../../../api/oc_uuid.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../../api/oc_udp.c
 	${CMAKE_CURRENT_SOURCE_DIR}/../../../messaging/coap/coap.c
 	${CMAKE_CURRENT_SOURCE_DIR}/../../../messaging/coap/engine.c
 	${CMAKE_CURRENT_SOURCE_DIR}/../../../messaging/coap/observe.c
@@ -74,6 +75,7 @@ if (CONFIG_TCP)
   add_definitions(-DOC_TCP)
   list(APPEND sources
   	${CMAKE_CURRENT_SOURCE_DIR}/../adapter/src/tcpadapter.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../../api/oc_tcp.c
 	${CMAKE_CURRENT_SOURCE_DIR}/../../../messaging/coap/coap_signal.c
   )
 endif()

--- a/port/windows/vs2015/IoTivity-lite.vcxproj
+++ b/port/windows/vs2015/IoTivity-lite.vcxproj
@@ -222,6 +222,8 @@
     <ClInclude Include="..\..\..\api\oc_resource_factory.h" />
     <ClInclude Include="..\..\..\api\oc_session_events_internal.h" />
     <ClInclude Include="..\..\..\api\oc_swupdate_internal.h" />
+    <ClInclude Include="..\..\..\api\oc_tcp_internal.h" />
+    <ClInclude Include="..\..\..\api\oc_udp_internal.h" />
     <ClInclude Include="..\..\..\deps\tinycbor\src\cbor.h" />
     <ClInclude Include="..\..\..\deps\tinycbor\src\cborjson.h" />
     <ClInclude Include="..\..\..\include\oc_acl.h" />
@@ -337,6 +339,8 @@
     <ClCompile Include="..\..\..\api\oc_server_api.c" />
     <ClCompile Include="..\..\..\api\oc_session_events.c" />
     <ClCompile Include="..\..\..\api\oc_swupdate.c" />
+    <ClCompile Include="..\..\..\api\oc_tcp.c" />
+    <ClCompile Include="..\..\..\api\oc_udp.c" />
     <ClCompile Include="..\..\..\api\oc_uuid.c" />
     <ClCompile Include="..\..\..\deps\mbedtls\library\aes.c" />
     <ClCompile Include="..\..\..\deps\mbedtls\library\aesni.c" />

--- a/port/windows/vs2015/IoTivity-lite.vcxproj.filters
+++ b/port/windows/vs2015/IoTivity-lite.vcxproj.filters
@@ -287,6 +287,12 @@
     <ClCompile Include="..\..\..\api\oc_session_events.c">
       <Filter>Core</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\api\oc_tcp.c">
+      <Filter>Core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\api\oc_udp.c">
+      <Filter>Core</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\security\oc_certs.c">
       <Filter>Security</Filter>
     </ClCompile>
@@ -679,13 +685,16 @@
     <ClInclude Include="..\..\..\api\oc_session_events_internal.h">
       <Filter>Core</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\api\oc_tcp_internal.h">
+      <Filter>Core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\api\oc_udp_internal.h">
+      <Filter>Core</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\..\security\oc_obt_internal.h">
       <Filter>Security</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\api\oc_mnt_internal.h">
-      <Filter>Core</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\api\oc_session_events_internal.h">
       <Filter>Core</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\include\oc_acl.h">

--- a/port/zephyr/src/Makefile
+++ b/port/zephyr/src/Makefile
@@ -57,6 +57,7 @@ obj-y += ../../../deps/tinycbor/src/cborencoder_close_container_checked.o \
          ../../../api/oc_network_events.o \
          ../../../api/oc_blockwise.o \
          ../../../api/oc_base64.o \
+         ../../../api/oc_udp.o \
          ipadapter.o \
          random.o \
          clock.o \

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -386,8 +386,8 @@ oc_oscore_send_multicast_message(oc_message_t *message)
     /* Parse CoAP message */
     coap_packet_t coap_pkt[1];
     coap_status_t code = 0;
-    code = coap_udp_parse_message(coap_pkt, message->data,
-                                  (uint16_t)message->length);
+    code =
+      coap_udp_parse_message(coap_pkt, message->data, message->length, false);
 
     if (code != COAP_NO_ERROR) {
       OC_ERR("***error parsing CoAP packet***");
@@ -578,13 +578,13 @@ oc_oscore_send_message(oc_message_t *msg)
     coap_status_t code = 0;
 #ifdef OC_TCP
     if (message->endpoint.flags & TCP) {
-      code = coap_tcp_parse_message(coap_pkt, message->data,
-                                    (uint32_t)message->length);
+      code =
+        coap_tcp_parse_message(coap_pkt, message->data, message->length, false);
     } else
 #endif /* OC_TCP */
     {
-      code = coap_udp_parse_message(coap_pkt, message->data,
-                                    (uint16_t)message->length);
+      code =
+        coap_udp_parse_message(coap_pkt, message->data, message->length, false);
     }
 
     if (code != COAP_NO_ERROR) {

--- a/security/unittest/oscore_test.cpp
+++ b/security/unittest/oscore_test.cpp
@@ -580,7 +580,8 @@ TEST_F(TestOSCORE, ClientRequest1_P)
             0);
 
   coap_packet_t coap_pkt[1];
-  coap_status_t code = coap_udp_parse_message(coap_pkt, buffer, buffer_len);
+  coap_status_t code =
+    coap_udp_parse_message(coap_pkt, buffer, buffer_len, false);
 
   EXPECT_EQ(code, COAP_NO_ERROR);
 
@@ -694,7 +695,8 @@ TEST_F(TestOSCORE, ClientRequest2_P)
             0);
 
   coap_packet_t coap_pkt[1];
-  coap_status_t code = coap_udp_parse_message(coap_pkt, buffer, buffer_len);
+  coap_status_t code =
+    coap_udp_parse_message(coap_pkt, buffer, buffer_len, false);
 
   EXPECT_EQ(code, COAP_NO_ERROR);
 
@@ -807,7 +809,8 @@ TEST_F(TestOSCORE, ClientRequest3_P)
             0);
 
   coap_packet_t coap_pkt[1];
-  coap_status_t code = coap_udp_parse_message(coap_pkt, buffer, buffer_len);
+  coap_status_t code =
+    coap_udp_parse_message(coap_pkt, buffer, buffer_len, false);
 
   EXPECT_EQ(code, COAP_NO_ERROR);
 
@@ -929,7 +932,8 @@ TEST_F(TestOSCORE, ServerResponse1_P)
             0);
 
   coap_packet_t coap_pkt[1];
-  coap_status_t code = coap_udp_parse_message(coap_pkt, buffer, buffer_len);
+  coap_status_t code =
+    coap_udp_parse_message(coap_pkt, buffer, buffer_len, false);
 
   EXPECT_EQ(code, COAP_NO_ERROR);
 
@@ -1046,7 +1050,8 @@ TEST_F(TestOSCORE, ServerResponse2_P)
             0);
 
   coap_packet_t coap_pkt[1];
-  coap_status_t code = coap_udp_parse_message(coap_pkt, buffer, buffer_len);
+  coap_status_t code =
+    coap_udp_parse_message(coap_pkt, buffer, buffer_len, false);
 
   EXPECT_EQ(code, COAP_NO_ERROR);
 


### PR DESCRIPTION
The network thread will now perform a validation check on incoming data via TCP/UDP. Any data that fails the validation check will result in the termination of the connection for TCP or dropping message for UDP.

Fixes #417