### PR TITLE
plgd-time: enable to use custom verification for fetch

### DIFF
--- a/api/plgd/plgd_time.c
+++ b/api/plgd/plgd_time.c
@@ -73,7 +73,7 @@ static uint16_t PLGD_TIME_FETCH_TIMEOUT = 4;
 typedef struct time_verify_certificate_params_t
 {
   oc_pki_verify_certificate_cb_t verify_certificate;
-  oc_tls_peer_user_data_t peer_data;
+  oc_pki_user_data_t peer_data;
 } time_verify_certificate_params_t;
 
 OC_MEMB(g_time_verify_certificate_params_s, time_verify_certificate_params_t,
@@ -152,7 +152,7 @@ dev_time_set_time(oc_clock_time_t lst, bool dump, bool notify)
   char lst_ts[64] = { 0 };
   oc_clock_encode_time_rfc3339(lst, lst_ts, sizeof(lst_ts));
   uint64_t ut_s = (uint64_t)(updateTime / (double)OC_CLOCK_SECOND);
-  OC_DBG("plgd-time: %s (update: %" PRIu64 ")", lst_ts, ut_s);
+  OC_DBG("plgd-time: %s (update: %" PRIu64 "s)", lst_ts, ut_s);
 #endif /* OC_DEBUG */
 
   plgd_time_set(lst, updateTime, dump, notify);
@@ -197,18 +197,28 @@ dev_plgd_time(plgd_time_t pt)
     return -1;
   }
 
-  long shift = cur - pt.update_time;
-  assert(shift >= 0);
-  oc_clock_time_t ptime = (pt.store.last_synced_time + shift);
+  long elapsed = cur - pt.update_time;
+  assert(elapsed >= 0);
+  oc_clock_time_t ptime = (pt.store.last_synced_time + elapsed);
 
 #ifdef OC_DEBUG
-  char pt_ts[64] = { 0 };
-  oc_clock_encode_time_rfc3339(pt.store.last_synced_time, pt_ts, sizeof(pt_ts));
+#define RFC3339_BUFFER_SIZE 64
+  double to_micros = (10000000 / (double)OC_CLOCK_SECOND);
+  char lst_ts[RFC3339_BUFFER_SIZE] = { 0 };
+  oc_clock_encode_time_rfc3339(pt.store.last_synced_time, lst_ts,
+                               sizeof(lst_ts));
+  OC_DBG("calculating plgd-time: last_synced_time=%s, update_time=%ldus, "
+         "current_time=%ldus, elapsed_time=%ldus",
+         lst_ts, (long)(pt.update_time * to_micros), (long)(cur * to_micros),
+         (long)(elapsed * to_micros));
+
+  char pt_ts[RFC3339_BUFFER_SIZE] = { 0 };
+  oc_clock_encode_time_rfc3339(ptime, pt_ts, sizeof(pt_ts));
 
   oc_clock_time_t time = oc_clock_time();
-  char ts[64] = { 0 };
+  char ts[RFC3339_BUFFER_SIZE] = { 0 };
   oc_clock_encode_time_rfc3339(time, ts, sizeof(ts));
-  long diff = (time - ptime) / OC_CLOCK_SECOND;
+  long diff = (long)((time - ptime) / (double)OC_CLOCK_SECOND);
   OC_DBG("calculated plgd-time: %s, system time: %s, diff: %lds", pt_ts, ts,
          diff);
 #endif /* OC_DEBUG */
@@ -607,6 +617,9 @@ plgd_time_fetch_config(const oc_endpoint_t *endpoint, const char *uri,
                        uint16_t timeout, int selected_identity_credid,
                        bool disable_time_verification)
 {
+  assert(endpoint != NULL);
+  assert(uri != NULL);
+  assert(on_fetch != NULL);
   plgd_time_fetch_config_t fetch = {
     .endpoint = endpoint,
     .uri = uri,
@@ -617,10 +630,41 @@ plgd_time_fetch_config(const oc_endpoint_t *endpoint, const char *uri,
 
 #if defined(OC_SECURITY) && defined(OC_PKI)
   fetch.selected_identity_credid = selected_identity_credid;
-  fetch.disable_time_verification = disable_time_verification;
+  fetch.verification.disable_time_verification = disable_time_verification;
 #else  /* !OC_SECURITY || !OC_PKI */
   (void)selected_identity_credid;
   (void)disable_time_verification;
+#endif /* OC_SECURITY && OC_PKI */
+
+  return fetch;
+}
+
+plgd_time_fetch_config_t
+plgd_time_fetch_config_with_custom_verification(
+  const oc_endpoint_t *endpoint, const char *uri,
+  plgd_time_on_fetch_fn_t on_fetch, void *on_fetch_data, uint16_t timeout,
+  int selected_identity_credid, oc_pki_verify_certificate_cb_t verify,
+  oc_pki_user_data_t verify_data)
+{
+  assert(endpoint != NULL);
+  assert(uri != NULL);
+  assert(on_fetch != NULL);
+  assert(verify != NULL);
+
+  plgd_time_fetch_config_t fetch = {
+    .endpoint = endpoint,
+    .uri = uri,
+    .on_fetch = on_fetch,
+    .on_fetch_data = on_fetch_data,
+    .timeout = timeout,
+  };
+
+#if defined(OC_SECURITY) && defined(OC_PKI)
+  fetch.selected_identity_credid = selected_identity_credid;
+  fetch.verification.verify = verify;
+  fetch.verification.verify_data = verify_data;
+#else  /* !OC_SECURITY || !OC_PKI */
+  (void)selected_identity_credid;
 #endif /* OC_SECURITY && OC_PKI */
 
   return fetch;
@@ -664,7 +708,7 @@ dev_time_on_fetch(oc_client_response_t *data)
   fp->on_fetch(code, time, fp->on_fetch_data);
 #if defined(OC_TCP) || defined(OC_SECURITY)
   // session is closed automatically on timeout, close or cancel
-  if (fp->close_peer_after_fetch && oc_ri_client_cb_terminated(code)) {
+  if (fp->close_peer_after_fetch && !oc_ri_client_cb_terminated(code)) {
     OC_DBG("plgd-time: close fetch time session");
     oc_close_session(data->endpoint);
   }
@@ -715,12 +759,15 @@ dev_time_verify_certificate(oc_tls_peer_t *peer, const mbedtls_x509_crt *crt,
 }
 
 static bool
-dev_time_add_peer(const oc_endpoint_t *ep, bool disable_time_verification)
+dev_time_add_peer(const oc_endpoint_t *endpoint,
+                  plgd_time_fetch_verification_config_t verify_config)
 {
+  // must be only called when there is no peer yet for the endpoint
+  assert(oc_tls_get_peer(endpoint) == NULL);
   OC_DBG("plgd-time: add new peer");
 
   time_verify_certificate_params_t *vcp = NULL;
-  if (disable_time_verification) {
+  if (verify_config.verify == NULL && verify_config.disable_time_verification) {
     vcp = (time_verify_certificate_params_t *)oc_memb_alloc(
       &g_time_verify_certificate_params_s);
     if (vcp == NULL) {
@@ -730,7 +777,7 @@ dev_time_add_peer(const oc_endpoint_t *ep, bool disable_time_verification)
     }
   }
 
-  oc_tls_peer_t *peer = oc_tls_add_peer(ep, MBEDTLS_SSL_IS_CLIENT);
+  oc_tls_peer_t *peer = oc_tls_add_peer(endpoint, MBEDTLS_SSL_IS_CLIENT);
   if (peer == NULL) {
     OC_ERR("plgd-time add peer failed: oc_tls_add_peer failed");
     oc_memb_free(&g_time_verify_certificate_params_s, vcp);
@@ -745,8 +792,15 @@ dev_time_add_peer(const oc_endpoint_t *ep, bool disable_time_verification)
     peer->user_data.data = vcp;
     peer->user_data.free = time_verify_certificate_params_free;
     peer->verify_certificate = dev_time_verify_certificate;
+  } else if (verify_config.verify != NULL) {
+    OC_DBG("plgd-time: custom verification for peer");
+    if (peer->user_data.free != NULL &&
+        verify_config.verify_data.data != peer->user_data.data) {
+      peer->user_data.free(peer->user_data.data);
+    }
+    peer->user_data = verify_config.verify_data;
+    peer->verify_certificate = verify_config.verify;
   }
-
   return true;
 }
 
@@ -769,7 +823,7 @@ dev_time_has_session(const oc_endpoint_t *endpoint)
   if ((endpoint->flags & TCP) != 0) {
     int tcp = oc_tcp_connection_state(endpoint);
     OC_DBG("plgd-time: session state=%d", tcp);
-    return tcp <= 0;
+    return tcp > 0;
   }
 #endif /* OC_TCP */
   return false;
@@ -823,7 +877,7 @@ plgd_time_fetch(plgd_time_fetch_config_t fetch, unsigned *flags)
   if (add_insecure_peer) {
     oc_tls_select_identity_cert_chain(fetch.selected_identity_credid);
 
-    if (!dev_time_add_peer(fetch.endpoint, fetch.disable_time_verification)) {
+    if (!dev_time_add_peer(fetch.endpoint, fetch.verification)) {
       oc_memb_free(&g_fetch_params_s, fetch_params);
       return false;
     }

--- a/api/unittest/plgdtimetest.cpp
+++ b/api/unittest/plgdtimetest.cpp
@@ -32,8 +32,10 @@
 #include "port/oc_network_event_handler_internal.h"
 #include "port/oc_storage.h"
 #include "port/oc_storage_internal.h"
+#include "security/oc_tls_internal.h"
 #include "tests/gtest/Device.h"
 #include "tests/gtest/Endpoint.h"
+#include "tests/gtest/PKI.h"
 #include "tests/gtest/RepPool.h"
 #include "util/oc_macros.h"
 
@@ -52,6 +54,9 @@
 
 #ifdef OC_SECURITY
 #include <mbedtls/platform_time.h>
+#ifdef OC_PKI
+#include <mbedtls/ssl.h>
+#endif /* OC_PKI */
 #endif /* OC_SECURITY */
 
 static const std::string testStorage{ "storage_test" };
@@ -547,31 +552,17 @@ TEST_F(TestPlgdTimeWithServer, FetchTimeFail)
 #endif /* OC_SECURITY */
 }
 
-TEST_F(TestPlgdTimeWithServer, FetchTimeConnectInsecure)
-{
-  unsigned flags = 0;
-#ifdef OC_TCP
-  flags |= TCP;
-#endif /* OC_TCP */
-  const oc_endpoint_t *ep =
-    oc::TestDevice::GetEndpoint(/*device*/ 0, flags, SECURED);
-  ASSERT_NE(nullptr, ep);
-
-  auto fetch_handler = [](oc_status_t code, oc_clock_time_t time, void *data) {
-    OC_DBG("fetch time handler");
-    EXPECT_EQ(OC_STATUS_OK, code);
-    auto *t = static_cast<oc_clock_time_t *>(data);
-    *t = time;
-    oc::TestDevice::Terminate();
-  };
-
 #if defined(OC_TCP) && defined(OC_SESSION_EVENTS)
-  struct TCPSessionData
-  {
-    bool disconnected;
-    const oc_endpoint_t *ep;
-  };
 
+struct TCPSessionData
+{
+  bool disconnected;
+  const oc_endpoint_t *ep;
+};
+
+static session_event_handler_v1_t
+addTCPEventCallback(TCPSessionData *tcp_data)
+{
   auto tcp_events = [](const oc_endpoint_t *endpoint, oc_session_state_t state,
                        void *data) {
 #ifdef OC_DEBUG
@@ -583,17 +574,54 @@ TEST_F(TestPlgdTimeWithServer, FetchTimeConnectInsecure)
     auto *tsd = static_cast<TCPSessionData *>(data);
     if ((oc_endpoint_compare(endpoint, tsd->ep) == 0) &&
         (state == OC_SESSION_DISCONNECTED)) {
+      OC_DBG("tcp session disconnected");
       tsd->disconnected = true;
       oc::TestDevice::Terminate();
     }
   };
 
-  TCPSessionData tsd{};
-  tsd.ep = ep;
+  EXPECT_EQ(0, oc_add_session_event_callback_v1(tcp_events, tcp_data));
+  return tcp_events;
+}
+
+static void
+waitForTCPEventCallback(TCPSessionData *tcp_data)
+{
+  if (!tcp_data->disconnected) {
+    OC_DBG("waiting to close insecure TCP session");
+    oc::TestDevice::PoolEvents(5);
+  }
+  EXPECT_TRUE(tcp_data->disconnected);
+}
+
+#endif /* OC_TCP || OC_SESSION_EVENTS */
+
+TEST_F(TestPlgdTimeWithServer, FetchTimeConnectInsecureConnection)
+{
+  unsigned flags = 0;
+#ifdef OC_TCP
+  flags |= TCP;
+#endif /* OC_TCP */
+  const oc_endpoint_t *ep =
+    oc::TestDevice::GetEndpoint(/*device*/ 0, flags, SECURED);
+  ASSERT_NE(nullptr, ep);
+
+#if defined(OC_TCP) && defined(OC_SESSION_EVENTS)
+  TCPSessionData tcp_data{};
+  session_event_handler_v1_t tcp_events{};
   if ((ep->flags & TCP) != 0) {
-    EXPECT_EQ(0, oc_add_session_event_callback_v1(tcp_events, &tsd));
+    tcp_data.ep = ep;
+    tcp_events = addTCPEventCallback(&tcp_data);
   }
 #endif /* OC_TCP && OC_SESSION_EVENTS */
+
+  auto fetch_handler = [](oc_status_t code, oc_clock_time_t time, void *data) {
+    OC_DBG("fetch time handler");
+    EXPECT_EQ(OC_STATUS_OK, code);
+    auto *t = static_cast<oc_clock_time_t *>(data);
+    *t = time;
+    oc::TestDevice::Terminate();
+  };
 
   oc_clock_time_t time = 0;
   unsigned fetch_flags = 0;
@@ -607,25 +635,126 @@ TEST_F(TestPlgdTimeWithServer, FetchTimeConnectInsecure)
   EXPECT_NE(0, time);
 
 #if defined(OC_TCP) && defined(OC_SESSION_EVENTS)
-  if (!tsd.disconnected &&
+  if (tcp_events != nullptr &&
       (fetch_flags & PLGD_TIME_FETCH_FLAG_TCP_SESSION_OPENED) != 0) {
-    oc::TestDevice::PoolEvents(5);
-  }
-  if ((ep->flags & TCP) != 0) {
+    waitForTCPEventCallback(&tcp_data);
     EXPECT_EQ(0,
               oc_remove_session_event_callback_v1(tcp_events, nullptr, true));
   }
 #endif /* OC_TCP && OC_SESSION_EVENTS */
 }
 
-TEST_F(TestPlgdTimeWithServer, FetchTimeAlreadyConnected)
+TEST_F(TestPlgdTimeWithServer, FetchTimeAlreadyConnectedInsecure)
+{
+  // TODO: use already connected endpoint
+}
+
+#ifdef OC_SECURITY
+
+static void
+prepareSecureDevice(size_t device)
+{
+  oc_sec_self_own(device);
+
+  // valid from Nov 29, 2018 to Nov 29, 2068
+  oc::pki::TrustAnchor trustCA{
+    "pki_certs/certification_tests_rootca1.pem",
+    true,
+  };
+  ASSERT_TRUE(trustCA.Add(device));
+
+  // valid from Nov 29, 2018 to Nov 29, 2068
+  oc::pki::IdentityCertificate mfgCertificate{
+    "pki_certs/certification_tests_ee.pem",
+    "pki_certs/certification_tests_key.pem",
+    true,
+  };
+  ASSERT_TRUE(mfgCertificate.Add(device));
+
+  // expired: was valid from Apr 14, 2020 to May 14, 2020
+  // TODO: get a valid certificate and remove oc_pki_set_verify_certificate_cb
+  oc::pki::IntermediateCertificate subCertificate{
+    "pki_certs/certification_tests_subca1.pem"
+  };
+  ASSERT_TRUE(subCertificate.Add(device, mfgCertificate.CredentialID()));
+
+  oc_pki_set_verify_certificate_cb(
+    [](oc_tls_peer_t *peer, const mbedtls_x509_crt *, int, uint32_t *flags) {
+      if (peer->role == MBEDTLS_SSL_IS_SERVER) {
+        OC_DBG("disable time verification for server (peer=%p)", (void *)peer);
+        *flags &= ~((uint32_t)(MBEDTLS_X509_BADCERT_EXPIRED |
+                               MBEDTLS_X509_BADCERT_FUTURE));
+      }
+      return 0;
+    });
+}
+
+TEST_F(TestPlgdTimeWithServer, FetchTimeConnectSkipVerification)
+{
+  unsigned flags = SECURED;
+#ifdef OC_TCP
+  flags |= TCP;
+#endif /* OC_TCP */
+  const oc_endpoint_t *ep = oc::TestDevice::GetEndpoint(/*device*/ 0, flags);
+  ASSERT_NE(nullptr, ep);
+
+  prepareSecureDevice(/*device*/ 0);
+
+#if defined(OC_TCP) && defined(OC_SESSION_EVENTS)
+  session_event_handler_v1_t tcp_events{};
+  TCPSessionData tcp_data{};
+  if ((ep->flags & TCP) != 0) {
+    tcp_data.ep = ep;
+    tcp_events = addTCPEventCallback(&tcp_data);
+  }
+#endif /* OC_TCP && OC_SESSION_EVENTS */
+
+  auto verify_connection = [](oc_tls_peer_t *, const mbedtls_x509_crt *, int,
+                              uint32_t *flags) {
+    OC_DBG("skip verification for fetch time connection");
+    *flags = 0;
+    return 0;
+  };
+
+  auto fetch_handler = [](oc_status_t code, oc_clock_time_t time, void *data) {
+    OC_DBG("fetch time handler");
+    EXPECT_EQ(OC_STATUS_OK, code);
+    auto *t = static_cast<oc_clock_time_t *>(data);
+    *t = time;
+    oc::TestDevice::Terminate();
+  };
+
+  oc_clock_time_t time = 0;
+  unsigned fetch_flags = 0;
+  EXPECT_TRUE(
+    plgd_time_fetch(plgd_time_fetch_config_with_custom_verification(
+                      ep, PLGD_TIME_URI, fetch_handler, &time,
+                      /*timeout*/ 5,
+                      /*selected_identity_credid*/ -1, verify_connection, {}),
+                    &fetch_flags));
+
+  oc::TestDevice::PoolEvents(5);
+  EXPECT_NE(0, time);
+
+#if defined(OC_TCP) && defined(OC_SESSION_EVENTS)
+  if (tcp_events != nullptr &&
+      (fetch_flags & PLGD_TIME_FETCH_FLAG_TCP_SESSION_OPENED) != 0) {
+    waitForTCPEventCallback(&tcp_data);
+    EXPECT_EQ(0,
+              oc_remove_session_event_callback_v1(tcp_events, nullptr, true));
+  }
+#endif /* OC_TCP && OC_SESSION_EVENTS */
+
+  oc_pki_set_verify_certificate_cb(nullptr);
+  oc_pstat_reset_device(/*device*/ 0, true);
+}
+
+TEST_F(TestPlgdTimeWithServer, FetchTimeAlreadyConnectedSecure)
 {
   // TODO: use already connected endpoint
 }
 
 #endif /* OC_CLIENT */
-
-#ifdef OC_SECURITY
 
 class TestMbedTLSPlgdTime : public testing::Test {
 public:

--- a/include/oc_pki.h
+++ b/include/oc_pki.h
@@ -128,9 +128,15 @@ int oc_pki_add_mfg_trust_anchor(size_t device, const unsigned char *cert,
 int oc_pki_add_trust_anchor(size_t device, const unsigned char *cert,
                             size_t cert_size);
 
+typedef struct
+{
+  void *data;           ///< pointer to custom user data
+  void (*free)(void *); ///< function to deallocate custom user data (set to
+                        ///< NULL if the data shouldn't be deallocated)
+} oc_pki_user_data_t;
+
 /**
  * @brief TLS peer connection
- *
  */
 struct oc_tls_peer_t;
 

--- a/security/oc_tls_internal.h
+++ b/security/oc_tls_internal.h
@@ -46,12 +46,6 @@ typedef struct
   oc_clock_time_t int_ticks;
 } oc_tls_retr_timer_t;
 
-typedef struct
-{
-  void *data;
-  void (*free)(void *data);
-} oc_tls_peer_user_data_t;
-
 typedef struct oc_tls_peer_t
 {
   struct oc_tls_peer_t *next;
@@ -75,11 +69,11 @@ typedef struct oc_tls_peer_t
   oc_message_t *processed_recv_message;
 #endif /* OC_TCP */
 #ifdef OC_PKI
-  oc_tls_peer_user_data_t
-    user_data; // user data for the peer, can be used by application
+  oc_pki_user_data_t
+    user_data; ///< user data for the peer, can be used by application
   oc_pki_verify_certificate_cb_t
-    verify_certificate; // callback for certificate verification, filled by
-                        // default callback
+    verify_certificate; ///< callback for certificate verification, filled by
+                        ///< default callback
 #endif                  /* OC_PKI */
 } oc_tls_peer_t;
 

--- a/tests/gtest/PKI.cpp
+++ b/tests/gtest/PKI.cpp
@@ -1,0 +1,163 @@
+/****************************************************************************
+ *
+ * Copyright 2023 Daniel Adam, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"),
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifdef OC_PKI
+
+#include "PKI.h"
+#include "oc_pki.h"
+#include "port/oc_log.h"
+
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <string>
+
+namespace oc::pki {
+
+std::vector<unsigned char>
+ReadPem(const std::string &path)
+{
+  namespace fs = std::filesystem;
+
+  std::ifstream f(path);
+  if (!f.is_open()) {
+    return {};
+  }
+  f.unsetf(std::ios_base::skipws);
+  std::vector<unsigned char> data{};
+  data.assign((std::istream_iterator<char>(f)), std::istream_iterator<char>());
+  data.push_back('\0');
+  return data;
+}
+
+PemData::PemData(const std::string &path)
+  : path_{ path }
+{
+  auto pem = ReadPem(path_);
+  if (pem.empty()) {
+    throw "failed to read PEM string from file " + path;
+  }
+  pem_ = std::move(pem);
+}
+
+TrustAnchor::TrustAnchor(const std::string &certificatePath, bool isMfg)
+  : certificate_{ certificatePath }
+  , isMfg_{ isMfg }
+{
+}
+
+bool
+TrustAnchor::Add(size_t device)
+{
+  if (certificate_.DataSize() == 0) {
+    OC_ERR("invalid data");
+    return false;
+  }
+  if (device_ != static_cast<size_t>(-1)) {
+    OC_ERR("mfg certificate already assigned to a device");
+    return false;
+  }
+
+  int credid;
+  if (isMfg_) {
+    credid = oc_pki_add_mfg_trust_anchor(device, certificate_.Data().data(),
+                                         certificate_.DataSize());
+  } else {
+    credid = oc_pki_add_trust_anchor(device, certificate_.Data().data(),
+                                     certificate_.DataSize());
+  }
+  if (credid < 0) {
+    return false;
+  }
+  device_ = device;
+  credid_ = credid;
+  return true;
+}
+
+IdentityCertificate::IdentityCertificate(const std::string &certificatePath,
+                                         const std::string &keyPath, bool isMfg)
+  : certificate_{ certificatePath }
+  , key_{ keyPath }
+  , isMfg_{ isMfg }
+{
+}
+
+bool
+IdentityCertificate::Add(size_t device)
+{
+  if (certificate_.DataSize() == 0 || key_.DataSize() == 0) {
+    OC_ERR("invalid data");
+    return false;
+  }
+  if (device_ != static_cast<size_t>(-1)) {
+    OC_ERR("mfg certificate already assigned to a device");
+    return false;
+  }
+
+  int credid;
+  if (isMfg_) {
+    credid = oc_pki_add_mfg_cert(device, certificate_.Data().data(),
+                                 certificate_.DataSize(), key_.Data().data(),
+                                 key_.DataSize());
+  } else {
+    credid = oc_pki_add_identity_cert(device, certificate_.Data().data(),
+                                      certificate_.DataSize(),
+                                      key_.Data().data(), key_.DataSize());
+  }
+  if (credid < 0) {
+    return false;
+  }
+  device_ = device;
+  credid_ = credid;
+  return true;
+}
+
+IntermediateCertificate::IntermediateCertificate(
+  const std::string &certificatePath)
+  : certificate_{ certificatePath }
+{
+}
+
+bool
+IntermediateCertificate::Add(size_t device, int entity_credid)
+{
+  if (certificate_.DataSize() == 0 || entity_credid == -1) {
+    OC_ERR("invalid data");
+    return false;
+  }
+  if (device_ != static_cast<size_t>(-1)) {
+    OC_ERR("mfg certificate already assigned to a device");
+    return false;
+  }
+
+  int credid = oc_pki_add_mfg_intermediate_cert(
+    device, entity_credid, certificate_.Data().data(), certificate_.DataSize());
+
+  if (credid < 0) {
+    return false;
+  }
+
+  device_ = device;
+  entity_credid_ = entity_credid;
+  credid_ = credid;
+  return true;
+}
+
+} // namespace oc::pki
+
+#endif /* OC_PKI */

--- a/tests/gtest/PKI.h
+++ b/tests/gtest/PKI.h
@@ -1,0 +1,97 @@
+/****************************************************************************
+ *
+ * Copyright 2023 Daniel Adam, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"),
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#ifdef OC_PKI
+
+#include <string>
+#include <vector>
+
+namespace oc::pki {
+
+std::vector<unsigned char> ReadPem(const std::string &path);
+
+class PemData {
+public:
+  PemData(const std::string &path);
+
+  const std::string &Path() const { return path_; }
+  const std::vector<unsigned char> &Data() const { return pem_; }
+  size_t DataSize() const { return pem_.size(); }
+
+private:
+  std::string path_{};
+  std::vector<unsigned char> pem_{};
+};
+
+class TrustAnchor {
+public:
+  TrustAnchor(const std::string &certificatePath, bool isMfg = false);
+
+  bool Add(size_t device);
+
+  bool IsMfg() const { return isMfg_; }
+  int CredentialID() const { return credid_; }
+  size_t Device() const { return device_; }
+
+private:
+  PemData certificate_;
+  int credid_{ -1 };
+  size_t device_{ static_cast<size_t>(-1) };
+  bool isMfg_{ false };
+};
+
+class IdentityCertificate {
+public:
+  IdentityCertificate(const std::string &certificatePath,
+                      const std::string &keyPath, bool isMfg = false);
+
+  bool Add(size_t device);
+
+  bool IsMfg() const { return isMfg_; }
+  int CredentialID() const { return credid_; }
+  size_t Device() const { return device_; }
+
+private:
+  PemData certificate_;
+  PemData key_;
+  int credid_{ -1 };
+  size_t device_{ static_cast<size_t>(-1) };
+  bool isMfg_{ false };
+};
+
+class IntermediateCertificate {
+public:
+  IntermediateCertificate(const std::string &certificatePath);
+
+  bool Add(size_t device, int entity_credid);
+
+  int CredentialID() const { return credid_; }
+  int EntityCredentialID() const { return entity_credid_; }
+  size_t Device() const { return device_; }
+
+private:
+  PemData certificate_;
+  int entity_credid_{ -1 };
+  int credid_{ -1 };
+  size_t device_{ static_cast<size_t>(-1) };
+};
+} // namespace oc::pki
+
+#endif /* OC_PKI */

--- a/tests/gtest/RepPool.cpp
+++ b/tests/gtest/RepPool.cpp
@@ -18,7 +18,7 @@
 
 #include "RepPool.h"
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 namespace oc {
 


### PR DESCRIPTION
Enable user to override the verification function that will be used to verify the credentials of the fetch time connection. If left empty the default verification function for fetch which ignores the validity of the certificates will be used.