### PR TITLE
provides API to set callback for oc_send_response

### DIFF
--- a/api/cloud/oc_cloud_resource.c
+++ b/api/cloud/oc_cloud_resource.c
@@ -22,7 +22,6 @@
 
 #include "oc_cloud_resource_internal.h"
 #include "api/oc_core_res_internal.h"
-#include "api/oc_server_api_internal.h"
 #include "oc_api.h"
 #include "oc_cloud_internal.h"
 #include "oc_cloud_store_internal.h"
@@ -100,13 +99,14 @@ get_cloud(oc_request_t *request, oc_interface_mask_t interface, void *user_data)
   (void)interface;
   oc_cloud_context_t *ctx = oc_cloud_get_context(request->resource->device);
   if (!ctx) {
-    oc_send_response_v1(request, OC_STATUS_INTERNAL_SERVER_ERROR, true);
+    oc_send_response_with_callback(request, OC_STATUS_INTERNAL_SERVER_ERROR,
+                                   true);
     return;
   }
   OC_DBG("GET request received");
 
   cloud_response(ctx);
-  oc_send_response_v1(request, OC_STATUS_OK, true);
+  oc_send_response_with_callback(request, OC_STATUS_OK, true);
 }
 
 static bool
@@ -152,7 +152,8 @@ post_cloud(oc_request_t *request, oc_interface_mask_t interface,
   (void)interface;
   oc_cloud_context_t *ctx = oc_cloud_get_context(request->resource->device);
   if (!ctx) {
-    oc_send_response_v1(request, OC_STATUS_INTERNAL_SERVER_ERROR, true);
+    oc_send_response_with_callback(request, OC_STATUS_INTERNAL_SERVER_ERROR,
+                                   true);
     return;
   }
   OC_DBG("POST request received");
@@ -178,20 +179,20 @@ post_cloud(oc_request_t *request, oc_interface_mask_t interface,
   }
   }
   if (request_invalid_in_state) {
-    oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
+    oc_send_response_with_callback(request, OC_STATUS_BAD_REQUEST, true);
     return;
   }
 
   char *cps;
   size_t cps_len = 0;
   if (oc_rep_get_string(request->request_payload, "cps", &cps, &cps_len)) {
-    oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
+    oc_send_response_with_callback(request, OC_STATUS_BAD_REQUEST, true);
     return;
   }
 
   bool changed = cloud_update_from_request(ctx, request);
   cloud_response(ctx);
-  oc_send_response_v1(
+  oc_send_response_with_callback(
     request, changed ? OC_STATUS_CHANGED : OC_STATUS_BAD_REQUEST, true);
   if (changed) {
     cloud_store_dump_async(&ctx->store);

--- a/api/cloud/oc_cloud_resource.c
+++ b/api/cloud/oc_cloud_resource.c
@@ -22,6 +22,7 @@
 
 #include "oc_cloud_resource_internal.h"
 #include "api/oc_core_res_internal.h"
+#include "api/oc_server_api_internal.h"
 #include "oc_api.h"
 #include "oc_cloud_internal.h"
 #include "oc_cloud_store_internal.h"
@@ -99,13 +100,13 @@ get_cloud(oc_request_t *request, oc_interface_mask_t interface, void *user_data)
   (void)interface;
   oc_cloud_context_t *ctx = oc_cloud_get_context(request->resource->device);
   if (!ctx) {
-    oc_send_response(request, OC_STATUS_INTERNAL_SERVER_ERROR);
+    oc_send_response_v1(request, OC_STATUS_INTERNAL_SERVER_ERROR, true);
     return;
   }
   OC_DBG("GET request received");
 
   cloud_response(ctx);
-  oc_send_response(request, OC_STATUS_OK);
+  oc_send_response_v1(request, OC_STATUS_OK, true);
 }
 
 static bool
@@ -151,7 +152,7 @@ post_cloud(oc_request_t *request, oc_interface_mask_t interface,
   (void)interface;
   oc_cloud_context_t *ctx = oc_cloud_get_context(request->resource->device);
   if (!ctx) {
-    oc_send_response(request, OC_STATUS_INTERNAL_SERVER_ERROR);
+    oc_send_response_v1(request, OC_STATUS_INTERNAL_SERVER_ERROR, true);
     return;
   }
   OC_DBG("POST request received");
@@ -177,21 +178,21 @@ post_cloud(oc_request_t *request, oc_interface_mask_t interface,
   }
   }
   if (request_invalid_in_state) {
-    oc_send_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
     return;
   }
 
   char *cps;
   size_t cps_len = 0;
   if (oc_rep_get_string(request->request_payload, "cps", &cps, &cps_len)) {
-    oc_send_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
     return;
   }
 
   bool changed = cloud_update_from_request(ctx, request);
   cloud_response(ctx);
-  oc_send_response(request,
-                   changed ? OC_STATUS_CHANGED : OC_STATUS_BAD_REQUEST);
+  oc_send_response_v1(
+    request, changed ? OC_STATUS_CHANGED : OC_STATUS_BAD_REQUEST, true);
   if (changed) {
     cloud_store_dump_async(&ctx->store);
   }

--- a/api/oc_collection.c
+++ b/api/oc_collection.c
@@ -24,6 +24,7 @@
 #include "oc_core_res.h"
 #include "oc_core_res_internal.h"
 #include "oc_discovery_internal.h"
+#include "oc_server_api_internal.h"
 #include "util/oc_memb.h"
 
 #ifdef OC_COLLECTIONS_IF_CREATE
@@ -845,6 +846,7 @@ oc_handle_collection_batch_request(oc_method_t method, oc_request_t *request,
   response.response_buffer = &response_buffer;
   rest_request.response = &response;
   rest_request.origin = request->origin;
+  rest_request.method = method;
 
   oc_rep_start_links_array();
   memcpy(&encoder, oc_rep_get_encoder(), sizeof(CborEncoder));
@@ -1101,6 +1103,8 @@ oc_handle_collection_request(oc_method_t method, oc_request_t *request,
   request->response->response_buffer->content_format = APPLICATION_VND_OCF_CBOR;
   request->response->response_buffer->response_length = size;
   request->response->response_buffer->code = code;
+
+  oc_trigger_send_response_callback(request, code);
 
   if ((method == OC_PUT || method == OC_POST) &&
       code < oc_status_code(OC_STATUS_BAD_REQUEST)) {

--- a/api/oc_collection.c
+++ b/api/oc_collection.c
@@ -1100,11 +1100,8 @@ oc_handle_collection_request(oc_method_t method, oc_request_t *request,
       break;
     }
   }
-  request->response->response_buffer->content_format = APPLICATION_VND_OCF_CBOR;
-  request->response->response_buffer->response_length = size;
-  request->response->response_buffer->code = code;
-
-  oc_trigger_send_response_callback(request, code);
+  oc_send_response_internal(request, code, APPLICATION_VND_OCF_CBOR, size,
+                            true);
 
   if ((method == OC_PUT || method == OC_POST) &&
       code < oc_status_code(OC_STATUS_BAD_REQUEST)) {

--- a/api/oc_collection.c
+++ b/api/oc_collection.c
@@ -1078,23 +1078,23 @@ oc_handle_collection_request(oc_method_t method, oc_request_t *request,
     return false;
   }
 
-  int code = oc_status_code(OC_STATUS_BAD_REQUEST);
+  oc_status_t code = OC_STATUS_BAD_REQUEST;
   if (ecode < oc_status_code(OC_STATUS_BAD_REQUEST) &&
       pcode < oc_status_code(OC_STATUS_BAD_REQUEST)) {
     switch (method) {
     case OC_GET:
-      code = oc_status_code(OC_STATUS_OK);
+      code = OC_STATUS_OK;
       break;
     case OC_POST:
     case OC_PUT:
       if (iface_mask == OC_IF_CREATE) {
-        code = oc_status_code(OC_STATUS_CREATED);
+        code = OC_STATUS_CREATED;
       } else {
-        code = oc_status_code(OC_STATUS_CHANGED);
+        code = OC_STATUS_CHANGED;
       }
       break;
     case OC_DELETE:
-      code = oc_status_code(OC_STATUS_DELETED);
+      code = OC_STATUS_DELETED;
       break;
     default:
       break;
@@ -1104,7 +1104,7 @@ oc_handle_collection_request(oc_method_t method, oc_request_t *request,
                             true);
 
   if ((method == OC_PUT || method == OC_POST) &&
-      code < oc_status_code(OC_STATUS_BAD_REQUEST)) {
+      oc_status_code(code) < oc_status_code(OC_STATUS_BAD_REQUEST)) {
     if (iface_mask == OC_IF_CREATE) {
       coap_notify_collection_observers(
         collection, request->response->response_buffer, iface_mask);

--- a/api/oc_core_res.c
+++ b/api/oc_core_res.c
@@ -27,6 +27,7 @@
 #include "oc_resource_internal.h"
 #include "oc_ri_internal.h"
 #include "oc_main.h"
+#include "oc_server_api_internal.h"
 #include "port/oc_assert.h"
 #include "util/oc_atomic.h"
 #include "util/oc_compiler.h"
@@ -230,7 +231,7 @@ oc_core_device_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
   }
 
   oc_rep_end_root_object();
-  oc_send_response(request, OC_STATUS_OK);
+  oc_send_response_v1(request, OC_STATUS_OK, true);
 }
 
 static void
@@ -261,7 +262,7 @@ oc_core_con_handler_get(oc_request_t *request, oc_interface_mask_t iface_mask,
   }
 
   oc_rep_end_root_object();
-  oc_send_response(request, OC_STATUS_OK);
+  oc_send_response_v1(request, OC_STATUS_OK, true);
 }
 
 static void
@@ -276,7 +277,7 @@ oc_core_con_handler_post(oc_request_t *request, oc_interface_mask_t iface_mask,
   while (rep != NULL) {
     if (strcmp(oc_string(rep->name), "n") == 0) {
       if (rep->type != OC_REP_STRING || oc_string_len(rep->value.string) == 0) {
-        oc_send_response(request, OC_STATUS_BAD_REQUEST);
+        oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
         return;
       }
 
@@ -298,12 +299,12 @@ oc_core_con_handler_post(oc_request_t *request, oc_interface_mask_t iface_mask,
     }
     if (strcmp(oc_string(rep->name), "locn") == 0) {
       if (rep->type != OC_REP_STRING || oc_string_len(rep->value.string) == 0) {
-        oc_send_response(request, OC_STATUS_BAD_REQUEST);
+        oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
         return;
       }
       oc_resource_t *device_res = oc_core_get_resource_by_index(OCF_D, device);
       if (device_res->tag_locn == 0) {
-        oc_send_response(request, OC_STATUS_BAD_REQUEST);
+        oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
         return;
       }
 
@@ -324,9 +325,9 @@ oc_core_con_handler_post(oc_request_t *request, oc_interface_mask_t iface_mask,
   }
 
   if (changed) {
-    oc_send_response(request, OC_STATUS_CHANGED);
+    oc_send_response_v1(request, OC_STATUS_CHANGED, true);
   } else {
-    oc_send_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
   }
 }
 
@@ -541,7 +542,7 @@ oc_core_platform_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
   }
 
   oc_rep_end_root_object();
-  oc_send_response(request, OC_STATUS_OK);
+  oc_send_response_v1(request, OC_STATUS_OK, true);
 }
 
 oc_platform_info_t *

--- a/api/oc_core_res.c
+++ b/api/oc_core_res.c
@@ -231,7 +231,7 @@ oc_core_device_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
   }
 
   oc_rep_end_root_object();
-  oc_send_response_v1(request, OC_STATUS_OK, true);
+  oc_send_response_with_callback(request, OC_STATUS_OK, true);
 }
 
 static void
@@ -262,7 +262,7 @@ oc_core_con_handler_get(oc_request_t *request, oc_interface_mask_t iface_mask,
   }
 
   oc_rep_end_root_object();
-  oc_send_response_v1(request, OC_STATUS_OK, true);
+  oc_send_response_with_callback(request, OC_STATUS_OK, true);
 }
 
 static void
@@ -277,7 +277,7 @@ oc_core_con_handler_post(oc_request_t *request, oc_interface_mask_t iface_mask,
   while (rep != NULL) {
     if (strcmp(oc_string(rep->name), "n") == 0) {
       if (rep->type != OC_REP_STRING || oc_string_len(rep->value.string) == 0) {
-        oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
+        oc_send_response_with_callback(request, OC_STATUS_BAD_REQUEST, true);
         return;
       }
 
@@ -299,12 +299,12 @@ oc_core_con_handler_post(oc_request_t *request, oc_interface_mask_t iface_mask,
     }
     if (strcmp(oc_string(rep->name), "locn") == 0) {
       if (rep->type != OC_REP_STRING || oc_string_len(rep->value.string) == 0) {
-        oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
+        oc_send_response_with_callback(request, OC_STATUS_BAD_REQUEST, true);
         return;
       }
       oc_resource_t *device_res = oc_core_get_resource_by_index(OCF_D, device);
       if (device_res->tag_locn == 0) {
-        oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
+        oc_send_response_with_callback(request, OC_STATUS_BAD_REQUEST, true);
         return;
       }
 
@@ -325,9 +325,9 @@ oc_core_con_handler_post(oc_request_t *request, oc_interface_mask_t iface_mask,
   }
 
   if (changed) {
-    oc_send_response_v1(request, OC_STATUS_CHANGED, true);
+    oc_send_response_with_callback(request, OC_STATUS_CHANGED, true);
   } else {
-    oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
+    oc_send_response_with_callback(request, OC_STATUS_BAD_REQUEST, true);
   }
 }
 
@@ -542,7 +542,7 @@ oc_core_platform_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
   }
 
   oc_rep_end_root_object();
-  oc_send_response_v1(request, OC_STATUS_OK, true);
+  oc_send_response_with_callback(request, OC_STATUS_OK, true);
 }
 
 oc_platform_info_t *

--- a/api/oc_discovery.c
+++ b/api/oc_discovery.c
@@ -399,7 +399,7 @@ process_device_resources(CborEncoder *links, const oc_request_t *request,
 
 static void
 send_response(oc_request_t *request, oc_content_format_t content_format,
-              int matches, int response_length)
+              int matches, size_t response_length)
 {
   oc_status_t code = OC_STATUS_OK;
   if (matches && response_length) {
@@ -654,8 +654,9 @@ oc_core_1_1_discovery_handler(oc_request_t *request,
     break;
   }
 
+  int response_length = oc_rep_get_encoded_payload_size();
   send_response(request, APPLICATION_CBOR, matches,
-                oc_rep_get_encoded_payload_size());
+                response_length < 0 ? 0 : (size_t)response_length);
 }
 #endif /* OC_SPEC_VER_OIC */
 
@@ -888,8 +889,10 @@ oc_core_discovery_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
   default:
     break;
   }
+
+  int response_length = oc_rep_get_encoded_payload_size();
   send_response(request, APPLICATION_VND_OCF_CBOR, matches,
-                oc_rep_get_encoded_payload_size());
+                response_length < 0 ? 0 : (size_t)response_length);
 }
 
 #ifdef OC_WKCORE

--- a/api/oc_discovery.c
+++ b/api/oc_discovery.c
@@ -31,12 +31,13 @@
 #include "oc_client_state.h"
 #endif /* OC_CLIENT */
 
-#ifdef OC_RES_BATCH_SUPPORT
+#if defined(OC_SERVER) || defined(OC_RES_BATCH_SUPPORT)
 #include "oc_server_api_internal.h"
-#ifdef OC_SECURITY
+#endif /* OC_SERVER || OC_RES_BATCH_SUPPORT */
+
+#if defined(OC_SECURITY) && defined(OC_RES_BATCH_SUPPORT)
 #include "security/oc_acl_internal.h"
-#endif /* OC_SECURITY */
-#endif /* OC_RES_BATCH_SUPPORT */
+#endif /* OC_SECURITY && OC_RES_BATCH_SUPPORT*/
 
 #if defined(OC_COLLECTIONS) && defined(OC_SERVER)
 #include "oc_collection.h"
@@ -641,11 +642,18 @@ oc_core_1_1_discovery_handler(oc_request_t *request,
   int response_length = oc_rep_get_encoded_payload_size();
   request->response->response_buffer->content_format = APPLICATION_CBOR;
   if (matches && response_length) {
+    oc_status_t code = OC_STATUS_OK;
+#ifdef OC_SERVER
+    oc_trigger_send_response_callback(request, code);
+#endif
     request->response->response_buffer->response_length = response_length;
-    request->response->response_buffer->code = oc_status_code(OC_STATUS_OK);
+    request->response->response_buffer->code = oc_status_code(code);
   } else if (request->origin && (request->origin->flags & MULTICAST) == 0) {
-    request->response->response_buffer->code =
-      oc_status_code(OC_STATUS_BAD_REQUEST);
+    oc_status_t code = OC_STATUS_BAD_REQUEST;
+#ifdef OC_SERVER
+    oc_trigger_send_response_callback(request, code);
+#endif
+    request->response->response_buffer->code = oc_status_code(code);
   } else {
     request->response->response_buffer->code = OC_IGNORE;
   }
@@ -669,6 +677,7 @@ process_batch_response(CborEncoder *links_array, oc_resource_t *resource,
   rest_request.origin = endpoint;
   rest_request.query = 0;
   rest_request.query_len = 0;
+  rest_request.method = OC_GET;
 #ifdef OC_SECURITY
   if (oc_sec_check_acl(OC_GET, resource, endpoint)) {
 #endif /* OC_SECURITY */
@@ -883,11 +892,18 @@ oc_core_discovery_handler(oc_request_t *request, oc_interface_mask_t iface_mask,
   int response_length = oc_rep_get_encoded_payload_size();
   request->response->response_buffer->content_format = APPLICATION_VND_OCF_CBOR;
   if (matches && response_length > 0) {
+    oc_status_t code = OC_STATUS_OK;
+#ifdef OC_SERVER
+    oc_trigger_send_response_callback(request, code);
+#endif
     request->response->response_buffer->response_length = response_length;
-    request->response->response_buffer->code = oc_status_code(OC_STATUS_OK);
+    request->response->response_buffer->code = oc_status_code(code);
   } else if (request->origin && (request->origin->flags & MULTICAST) == 0) {
-    request->response->response_buffer->code =
-      oc_status_code(OC_STATUS_BAD_REQUEST);
+    oc_status_t code = OC_STATUS_BAD_REQUEST;
+#ifdef OC_SERVER
+    oc_trigger_send_response_callback(request, code);
+#endif
+    request->response->response_buffer->code = oc_status_code(code);
   } else {
     request->response->response_buffer->code = OC_IGNORE;
   }
@@ -905,8 +921,11 @@ oc_wkcore_discovery_handler(oc_request_t *request,
 
   /* check if the accept header is link-format */
   if (request->accept != APPLICATION_LINK_FORMAT) {
-    request->response->response_buffer->code =
-      oc_status_code(OC_STATUS_BAD_REQUEST);
+    oc_status_t code = OC_STATUS_BAD_REQUEST;
+#ifdef OC_SERVER
+    oc_trigger_send_response_callback(request, code);
+#endif
+    request->response->response_buffer->code = oc_status_code(code);
     return;
   }
 
@@ -992,11 +1011,18 @@ oc_wkcore_discovery_handler(oc_request_t *request,
 
   request->response->response_buffer->content_format = APPLICATION_LINK_FORMAT;
   if (matches && response_length > 0) {
+    oc_status_t code = OC_STATUS_OK;
+#ifdef OC_SERVER
+    oc_trigger_send_response_callback(request, code);
+#endif
     request->response->response_buffer->response_length = response_length;
-    request->response->response_buffer->code = oc_status_code(OC_STATUS_OK);
+    request->response->response_buffer->code = oc_status_code(code);
   } else if (request->origin && (request->origin->flags & MULTICAST) == 0) {
-    request->response->response_buffer->code =
-      oc_status_code(OC_STATUS_BAD_REQUEST);
+    oc_status_t code = OC_STATUS_BAD_REQUEST;
+#ifdef OC_SERVER
+    oc_trigger_send_response_callback(request, code);
+#endif
+    request->response->response_buffer->code = oc_status_code(code);
   } else {
     request->response->response_buffer->code = OC_IGNORE;
   }

--- a/api/oc_introspection.c
+++ b/api/oc_introspection.c
@@ -28,6 +28,10 @@
 #include <inttypes.h>
 #include <stdio.h>
 
+#ifdef OC_SERVER
+#include "oc_server_api_internal.h"
+#endif
+
 #ifndef OC_IDD_API
 #include "server_introspection.dat.h"
 #else /* OC_IDD_API */
@@ -88,15 +92,22 @@ oc_core_introspection_data_handler(oc_request_t *request,
 #endif /* OC_IDD_API */
   request->response->response_buffer->content_format = APPLICATION_VND_OCF_CBOR;
   if (IDD_size >= 0 && IDD_size < OC_MAX_APP_DATA_SIZE) {
+    oc_status_t code = OC_STATUS_OK;
+#ifdef OC_SERVER
+    oc_trigger_send_response_callback(request, code);
+#endif
     request->response->response_buffer->response_length = IDD_size;
-    request->response->response_buffer->code = oc_status_code(OC_STATUS_OK);
+    request->response->response_buffer->code = oc_status_code(code);
   } else {
+    oc_status_t code = OC_STATUS_INTERNAL_SERVER_ERROR;
+#ifdef OC_SERVER
+    oc_trigger_send_response_callback(request, code);
+#endif
     OC_ERR(
       "oc_core_introspection_data_handler : %ld is too big for buffer %ld \n",
       IDD_size, (long)OC_MAX_APP_DATA_SIZE);
     request->response->response_buffer->response_length = 0;
-    request->response->response_buffer->code =
-      oc_status_code(OC_STATUS_INTERNAL_SERVER_ERROR);
+    request->response->response_buffer->code = oc_status_code(code);
   }
 }
 

--- a/api/oc_introspection.c
+++ b/api/oc_introspection.c
@@ -132,7 +132,7 @@ oc_core_introspection_wk_handler(oc_request_t *request,
 
   if (oc_string_len(uri) <= 0) {
     OC_ERR("could not obtain introspection resource uri");
-    oc_send_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
     return;
   }
 
@@ -155,7 +155,7 @@ oc_core_introspection_wk_handler(oc_request_t *request,
   }
 
   oc_rep_end_root_object();
-  oc_send_response(request, OC_STATUS_OK);
+  oc_send_response_v1(request, OC_STATUS_OK, true);
 
   OC_DBG("got introspection resource uri %s", oc_string(uri));
   oc_free_string(&uri);

--- a/api/oc_introspection.c
+++ b/api/oc_introspection.c
@@ -132,7 +132,7 @@ oc_core_introspection_wk_handler(oc_request_t *request,
 
   if (oc_string_len(uri) <= 0) {
     OC_ERR("could not obtain introspection resource uri");
-    oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
+    oc_send_response_with_callback(request, OC_STATUS_BAD_REQUEST, true);
     return;
   }
 
@@ -155,7 +155,7 @@ oc_core_introspection_wk_handler(oc_request_t *request,
   }
 
   oc_rep_end_root_object();
-  oc_send_response_v1(request, OC_STATUS_OK, true);
+  oc_send_response_with_callback(request, OC_STATUS_OK, true);
 
   OC_DBG("got introspection resource uri %s", oc_string(uri));
   oc_free_string(&uri);

--- a/api/oc_mnt.c
+++ b/api/oc_mnt.c
@@ -23,7 +23,6 @@
 #include "oc_mnt_internal.h"
 #include "oc_core_res.h"
 #include "oc_core_res_internal.h"
-#include "oc_server_api_internal.h"
 #include "util/oc_compiler.h"
 
 #ifdef OC_SECURITY
@@ -48,7 +47,7 @@ get_mnt(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
     break;
   }
   oc_rep_end_root_object();
-  oc_send_response_v1(request, OC_STATUS_OK, true);
+  oc_send_response_with_callback(request, OC_STATUS_OK, true);
 }
 
 static void
@@ -83,9 +82,9 @@ post_mnt(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
     request->response->response_buffer->buffer =
       oc_rep_shrink_encoder_buf(request->response->response_buffer->buffer);
 #endif /* OC_DYNAMIC_ALLOCATION */
-    oc_send_response_v1(request, OC_STATUS_CHANGED, true);
+    oc_send_response_with_callback(request, OC_STATUS_CHANGED, true);
   } else {
-    oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
+    oc_send_response_with_callback(request, OC_STATUS_BAD_REQUEST, true);
   }
 }
 

--- a/api/oc_mnt.c
+++ b/api/oc_mnt.c
@@ -23,6 +23,7 @@
 #include "oc_mnt_internal.h"
 #include "oc_core_res.h"
 #include "oc_core_res_internal.h"
+#include "oc_server_api_internal.h"
 #include "util/oc_compiler.h"
 
 #ifdef OC_SECURITY
@@ -47,7 +48,7 @@ get_mnt(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
     break;
   }
   oc_rep_end_root_object();
-  oc_send_response(request, OC_STATUS_OK);
+  oc_send_response_v1(request, OC_STATUS_OK, true);
 }
 
 static void
@@ -82,9 +83,9 @@ post_mnt(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
     request->response->response_buffer->buffer =
       oc_rep_shrink_encoder_buf(request->response->response_buffer->buffer);
 #endif /* OC_DYNAMIC_ALLOCATION */
-    oc_send_response(request, OC_STATUS_CHANGED);
+    oc_send_response_v1(request, OC_STATUS_CHANGED, true);
   } else {
-    oc_send_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
   }
 }
 

--- a/api/oc_push.c
+++ b/api/oc_push.c
@@ -33,7 +33,6 @@
 #include "oc_push_internal.h"
 #include "oc_rep.h"
 #include "oc_ri.h"
-#include "oc_server_api_internal.h"
 #include "oc_signal_event_loop.h"
 #include "util/oc_compiler.h"
 #include "util/oc_list.h"
@@ -629,7 +628,7 @@ static void
 get_ns(oc_request_t *request, oc_interface_mask_t iface_mask, void *user_data)
 {
   get_ns_properties(request->resource, iface_mask, user_data);
-  oc_send_response_v1(request, OC_STATUS_OK, true);
+  oc_send_response_with_callback(request, OC_STATUS_OK, true);
 }
 
 /**
@@ -650,9 +649,9 @@ post_ns(oc_request_t *request, oc_interface_mask_t iface_mask, void *user_data)
 
   if (set_ns_properties(request->resource, request->request_payload,
                         user_data)) {
-    oc_send_response_v1(request, OC_STATUS_CHANGED, true);
+    oc_send_response_with_callback(request, OC_STATUS_CHANGED, true);
   } else {
-    oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
+    oc_send_response_with_callback(request, OC_STATUS_BAD_REQUEST, true);
   }
 }
 
@@ -675,9 +674,9 @@ delete_ns(oc_request_t *request, oc_interface_mask_t iface_mask,
               oc_string(request->resource->uri));
 
   if (oc_delete_resource(request->resource)) {
-    oc_send_response_v1(request, OC_STATUS_DELETED, true);
+    oc_send_response_with_callback(request, OC_STATUS_DELETED, true);
   } else {
-    oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
+    oc_send_response_with_callback(request, OC_STATUS_BAD_REQUEST, true);
   }
 }
 
@@ -1104,13 +1103,13 @@ get_pushd_rsc(oc_request_t *request, oc_interface_mask_t iface_mask,
     }
     oc_rep_end_root_object();
 
-    oc_send_response_v1(request, result, true);
+    oc_send_response_with_callback(request, result, true);
   } else {
     OC_PUSH_ERR("resource representation for pushed resource (%s) is found, "
                 "but no resource representation for it is built yet!",
                 oc_string(request->resource->uri));
 
-    oc_send_response_v1(request, OC_STATUS_NOT_FOUND, true);
+    oc_send_response_with_callback(request, OC_STATUS_NOT_FOUND, true);
   }
 }
 
@@ -1623,7 +1622,7 @@ post_pushd_rsc(oc_request_t *request, oc_interface_mask_t iface_mask,
     oc_resource_set_discoverable(pushd_rsc_rep->resource, true);
   }
 
-  oc_send_response_v1(request, result, true);
+  oc_send_response_with_callback(request, result, true);
 }
 
 /**
@@ -1688,7 +1687,7 @@ get_pushrecv(oc_request_t *request, oc_interface_mask_t iface_mask,
   }
   oc_rep_end_root_object();
 
-  oc_send_response_v1(request, result, true);
+  oc_send_response_with_callback(request, result, true);
 }
 
 /**
@@ -2138,7 +2137,7 @@ post_pushrecv(oc_request_t *request, oc_interface_mask_t iface_mask,
   }
 
 exit:
-  oc_send_response_v1(request, result, true);
+  oc_send_response_with_callback(request, result, true);
 }
 
 /**
@@ -2221,7 +2220,7 @@ delete_pushrecv(oc_request_t *request, oc_interface_mask_t iface_mask,
     recvs_instance = recvs_instance->next;
   }
 
-  oc_send_response_v1(request, result, true);
+  oc_send_response_with_callback(request, result, true);
 }
 
 /**

--- a/api/oc_push.c
+++ b/api/oc_push.c
@@ -33,6 +33,7 @@
 #include "oc_push_internal.h"
 #include "oc_rep.h"
 #include "oc_ri.h"
+#include "oc_server_api_internal.h"
 #include "oc_signal_event_loop.h"
 #include "util/oc_compiler.h"
 #include "util/oc_list.h"
@@ -628,7 +629,7 @@ static void
 get_ns(oc_request_t *request, oc_interface_mask_t iface_mask, void *user_data)
 {
   get_ns_properties(request->resource, iface_mask, user_data);
-  oc_send_response(request, OC_STATUS_OK);
+  oc_send_response_v1(request, OC_STATUS_OK, true);
 }
 
 /**
@@ -649,9 +650,9 @@ post_ns(oc_request_t *request, oc_interface_mask_t iface_mask, void *user_data)
 
   if (set_ns_properties(request->resource, request->request_payload,
                         user_data)) {
-    oc_send_response(request, OC_STATUS_CHANGED);
+    oc_send_response_v1(request, OC_STATUS_CHANGED, true);
   } else {
-    oc_send_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
   }
 }
 
@@ -674,9 +675,9 @@ delete_ns(oc_request_t *request, oc_interface_mask_t iface_mask,
               oc_string(request->resource->uri));
 
   if (oc_delete_resource(request->resource)) {
-    oc_send_response(request, OC_STATUS_DELETED);
+    oc_send_response_v1(request, OC_STATUS_DELETED, true);
   } else {
-    oc_send_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
   }
 }
 
@@ -1103,13 +1104,13 @@ get_pushd_rsc(oc_request_t *request, oc_interface_mask_t iface_mask,
     }
     oc_rep_end_root_object();
 
-    oc_send_response(request, result);
+    oc_send_response_v1(request, result, true);
   } else {
     OC_PUSH_ERR("resource representation for pushed resource (%s) is found, "
                 "but no resource representation for it is built yet!",
                 oc_string(request->resource->uri));
 
-    oc_send_response(request, OC_STATUS_NOT_FOUND);
+    oc_send_response_v1(request, OC_STATUS_NOT_FOUND, true);
   }
 }
 
@@ -1622,7 +1623,7 @@ post_pushd_rsc(oc_request_t *request, oc_interface_mask_t iface_mask,
     oc_resource_set_discoverable(pushd_rsc_rep->resource, true);
   }
 
-  oc_send_response(request, result);
+  oc_send_response_v1(request, result, true);
 }
 
 /**
@@ -1687,7 +1688,7 @@ get_pushrecv(oc_request_t *request, oc_interface_mask_t iface_mask,
   }
   oc_rep_end_root_object();
 
-  oc_send_response(request, result);
+  oc_send_response_v1(request, result, true);
 }
 
 /**
@@ -2137,7 +2138,7 @@ post_pushrecv(oc_request_t *request, oc_interface_mask_t iface_mask,
   }
 
 exit:
-  oc_send_response(request, result);
+  oc_send_response_v1(request, result, true);
 }
 
 /**
@@ -2220,7 +2221,7 @@ delete_pushrecv(oc_request_t *request, oc_interface_mask_t iface_mask,
     recvs_instance = recvs_instance->next;
   }
 
-  oc_send_response(request, result);
+  oc_send_response_v1(request, result, true);
 }
 
 /**

--- a/api/oc_ri.c
+++ b/api/oc_ri.c
@@ -551,7 +551,7 @@ oc_ri_init(void)
 }
 
 static const char *method_strs[] = {
-  "EMPTY",  /* 0 */
+  "",       /* 0 */
   "GET",    /* OC_GET */
   "POST",   /* OC_POST */
   "PUT",    /* OC_PUT */
@@ -563,7 +563,7 @@ const char *
 oc_method_to_str(oc_method_t method)
 {
   if (method < 0 || method >= sizeof(method_strs) / sizeof(method_strs[0]))
-    return "";
+    return method_strs[0];
   return method_strs[method];
 }
 

--- a/api/oc_ri.c
+++ b/api/oc_ri.c
@@ -218,10 +218,11 @@ oc_status_code(oc_status_t key)
   return (int)oc_coap_status_codes[key];
 }
 
-OC_API
 const char *
 oc_status_to_str(oc_status_t key)
 {
+  if (key < 0 || key >= sizeof(cli_status_strs) / sizeof(cli_status_strs[0]))
+    return "";
   return cli_status_strs[key];
 }
 
@@ -547,6 +548,23 @@ oc_ri_init(void)
 
   oc_process_init();
   start_processes();
+}
+
+static const char *method_strs[] = {
+  "EMPTY",  /* 0 */
+  "GET",    /* OC_GET */
+  "POST",   /* OC_POST */
+  "PUT",    /* OC_PUT */
+  "DELETE", /* OC_DELETE */
+  "FETCH",  /*OC_FETCH */
+};
+
+const char *
+oc_method_to_str(oc_method_t method)
+{
+  if (method < 0 || method >= sizeof(method_strs) / sizeof(method_strs[0]))
+    return "";
+  return method_strs[method];
 }
 
 #ifdef OC_SERVER
@@ -1116,6 +1134,7 @@ oc_ri_invoke_coap_entity_handler(void *request, void *response, uint8_t *buffer,
   request_obj.origin = endpoint;
   request_obj._payload = NULL;
   request_obj._payload_len = 0;
+  request_obj.method = method;
 
   /* Obtain request uri from the CoAP packet. */
   const char *uri_path = NULL;

--- a/api/oc_server_api.c
+++ b/api/oc_server_api.c
@@ -32,10 +32,6 @@
 #include "oc_collection.h"
 #endif /* OC_COLLECTIONS && OC_SERVER */
 
-#if defined(OC_CLOUD) && defined(OC_SERVER)
-#include "oc_server_api_internal.h"
-#endif /* OC_CLOUD && OC_SERVER */
-
 #ifdef OC_SECURITY
 #include "oc_store.h"
 #endif /* OC_SECURITY */
@@ -133,8 +129,8 @@ oc_send_response_internal(oc_request_t *request, oc_status_t response_code,
 }
 
 void
-oc_send_response_v1(oc_request_t *request, oc_status_t response_code,
-                    bool trigger_cb)
+oc_send_response_with_callback(oc_request_t *request, oc_status_t response_code,
+                               bool trigger_cb)
 {
   if (!request) {
     return;
@@ -152,7 +148,7 @@ oc_send_response_v1(oc_request_t *request, oc_status_t response_code,
 void
 oc_send_response(oc_request_t *request, oc_status_t response_code)
 {
-  oc_send_response_v1(request, response_code, false);
+  oc_send_response_with_callback(request, response_code, false);
 }
 
 void
@@ -680,7 +676,7 @@ oc_indicate_separate_response(oc_request_t *request,
                               oc_separate_response_t *response)
 {
   request->response->separate_response = response;
-  oc_send_response_v1(request, OC_STATUS_OK, false);
+  oc_send_response_with_callback(request, OC_STATUS_OK, false);
 }
 
 void

--- a/api/oc_server_api.c
+++ b/api/oc_server_api.c
@@ -152,7 +152,7 @@ oc_send_response_v1(oc_request_t *request, oc_status_t response_code,
 void
 oc_send_response(oc_request_t *request, oc_status_t response_code)
 {
-  oc_send_response_v1(request, response_code, true);
+  oc_send_response_v1(request, response_code, false);
 }
 
 void

--- a/api/oc_server_api.c
+++ b/api/oc_server_api.c
@@ -97,7 +97,7 @@ response_length(void)
 }
 
 void
-oc_set_send_response_cb(oc_send_response_cb_t cb)
+oc_set_send_response_callback(oc_send_response_cb_t cb)
 {
   g_oc_send_response_cb = cb;
 }

--- a/api/oc_server_api_internal.h
+++ b/api/oc_server_api_internal.h
@@ -84,8 +84,9 @@ void oc_process_baseline_interface_with_filter(
   const oc_resource_t *resource,
   oc_process_baseline_interface_filter_fn_t filter, void *filter_data);
 
-/** Notify callback about send the response */
-void oc_trigger_send_response_callback(oc_request_t *request,
-                                       oc_status_t response_code);
+/** Setup response for the request */
+void oc_send_response_internal(oc_request_t *request, oc_status_t response_code,
+                               oc_content_format_t content_format,
+                               size_t response_length, bool trigger_cb);
 
 #endif /* OC_SERVER_API_INTERNAL_H */

--- a/api/oc_server_api_internal.h
+++ b/api/oc_server_api_internal.h
@@ -89,4 +89,24 @@ void oc_send_response_internal(oc_request_t *request, oc_status_t response_code,
                                oc_content_format_t content_format,
                                size_t response_length, bool trigger_cb);
 
+/**
+ * Called after the response to a GET, PUT, POST or DELETE call has been
+ * prepared completed
+ *
+ * The function oc_send_response is called at the end of a
+ * oc_request_callback_t to inform the caller about the status of the requested
+ * action.
+ *
+ *
+ * @param[in] request the request being responded to
+ * @param[in] response_code the status of the response
+ * @param[in] trigger_cb if true, the send response callback will be triggered
+ *
+ * @see oc_request_callback_t
+ * @see oc_ignore_request
+ * @see oc_indicate_separate_response
+ */
+void oc_send_response_v1(oc_request_t *request, oc_status_t response_code,
+                         bool trigger_cb);
+
 #endif /* OC_SERVER_API_INTERNAL_H */

--- a/api/oc_server_api_internal.h
+++ b/api/oc_server_api_internal.h
@@ -84,4 +84,8 @@ void oc_process_baseline_interface_with_filter(
   const oc_resource_t *resource,
   oc_process_baseline_interface_filter_fn_t filter, void *filter_data);
 
+/** Notify callback about send the response */
+void oc_trigger_send_response_callback(oc_request_t *request,
+                                       oc_status_t response_code);
+
 #endif /* OC_SERVER_API_INTERNAL_H */

--- a/api/oc_server_api_internal.h
+++ b/api/oc_server_api_internal.h
@@ -89,24 +89,4 @@ void oc_send_response_internal(oc_request_t *request, oc_status_t response_code,
                                oc_content_format_t content_format,
                                size_t response_length, bool trigger_cb);
 
-/**
- * Called after the response to a GET, PUT, POST or DELETE call has been
- * prepared completed
- *
- * The function oc_send_response is called at the end of a
- * oc_request_callback_t to inform the caller about the status of the requested
- * action.
- *
- *
- * @param[in] request the request being responded to
- * @param[in] response_code the status of the response
- * @param[in] trigger_cb if true, the send response callback will be triggered
- *
- * @see oc_request_callback_t
- * @see oc_ignore_request
- * @see oc_indicate_separate_response
- */
-void oc_send_response_v1(oc_request_t *request, oc_status_t response_code,
-                         bool trigger_cb);
-
 #endif /* OC_SERVER_API_INTERNAL_H */

--- a/api/oc_swupdate.c
+++ b/api/oc_swupdate.c
@@ -21,6 +21,7 @@
 #include "oc_api.h"
 #include "oc_core_res.h"
 #include "oc_core_res_internal.h"
+#include "oc_server_api_internal.h"
 #include "oc_storage_internal.h"
 #include "oc_swupdate.h"
 #include "oc_swupdate_internal.h"
@@ -555,11 +556,11 @@ post_swu(oc_request_t *request, oc_interface_mask_t interfaces, void *user_data)
     /* set the response */
     oc_swupdate_encode(OC_IF_RW, request->resource->device);
 
-    oc_send_response(request, OC_STATUS_CHANGED);
+    oc_send_response_v1(request, OC_STATUS_CHANGED, true);
 
     oc_dump_sw(request->resource->device);
   } else {
-    oc_send_response(request, OC_STATUS_NOT_ACCEPTABLE);
+    oc_send_response_v1(request, OC_STATUS_NOT_ACCEPTABLE, true);
   }
 }
 
@@ -581,7 +582,7 @@ get_swu(oc_request_t *request, oc_interface_mask_t interfaces, void *user_data)
 {
   (void)user_data;
   oc_swupdate_encode(interfaces, request->resource->device);
-  oc_send_response(request, OC_STATUS_OK);
+  oc_send_response_v1(request, OC_STATUS_OK, true);
 }
 
 void

--- a/api/oc_swupdate.c
+++ b/api/oc_swupdate.c
@@ -21,7 +21,6 @@
 #include "oc_api.h"
 #include "oc_core_res.h"
 #include "oc_core_res_internal.h"
-#include "oc_server_api_internal.h"
 #include "oc_storage_internal.h"
 #include "oc_swupdate.h"
 #include "oc_swupdate_internal.h"
@@ -556,11 +555,11 @@ post_swu(oc_request_t *request, oc_interface_mask_t interfaces, void *user_data)
     /* set the response */
     oc_swupdate_encode(OC_IF_RW, request->resource->device);
 
-    oc_send_response_v1(request, OC_STATUS_CHANGED, true);
+    oc_send_response_with_callback(request, OC_STATUS_CHANGED, true);
 
     oc_dump_sw(request->resource->device);
   } else {
-    oc_send_response_v1(request, OC_STATUS_NOT_ACCEPTABLE, true);
+    oc_send_response_with_callback(request, OC_STATUS_NOT_ACCEPTABLE, true);
   }
 }
 
@@ -582,7 +581,7 @@ get_swu(oc_request_t *request, oc_interface_mask_t interfaces, void *user_data)
 {
   (void)user_data;
   oc_swupdate_encode(interfaces, request->resource->device);
-  oc_send_response_v1(request, OC_STATUS_OK, true);
+  oc_send_response_with_callback(request, OC_STATUS_OK, true);
 }
 
 void

--- a/api/plgd/plgd_time.c
+++ b/api/plgd/plgd_time.c
@@ -535,12 +535,13 @@ plgd_time_resource_post(oc_request_t *request, oc_interface_mask_t iface_mask,
   plgd_time_t pt = { 0 };
   if (!plgd_time_decode(request->request_payload, &pt)) {
     OC_ERR("cannot decode data for plgd-time resource");
-    oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
+    oc_send_response_with_callback(request, OC_STATUS_BAD_REQUEST, true);
     return;
   }
 
   if (dev_time_set_time(pt.store.last_synced_time, false, false) != 0) {
-    oc_send_response_v1(request, OC_STATUS_INTERNAL_SERVER_ERROR, true);
+    oc_send_response_with_callback(request, OC_STATUS_INTERNAL_SERVER_ERROR,
+                                   true);
     return;
   }
 
@@ -548,11 +549,12 @@ plgd_time_resource_post(oc_request_t *request, oc_interface_mask_t iface_mask,
                                             // must have secure access
   if (plgd_time_encode(g_oc_plgd_time, OC_IF_RW, flags) != 0) {
     OC_ERR("cannot encode plgd-time resource");
-    oc_send_response_v1(request, OC_STATUS_INTERNAL_SERVER_ERROR, true);
+    oc_send_response_with_callback(request, OC_STATUS_INTERNAL_SERVER_ERROR,
+                                   true);
     return;
   }
 
-  oc_send_response_v1(request, OC_STATUS_CHANGED, true);
+  oc_send_response_with_callback(request, OC_STATUS_CHANGED, true);
   plgd_time_dump();
 }
 
@@ -570,11 +572,12 @@ plgd_time_resource_get(oc_request_t *request, oc_interface_mask_t iface_mask,
 #endif /* OC_SECURITY */
   if (plgd_time_encode(g_oc_plgd_time, iface_mask, flags) != 0) {
     OC_ERR("cannot encode plgd-time resource");
-    oc_send_response_v1(request, OC_STATUS_INTERNAL_SERVER_ERROR, true);
+    oc_send_response_with_callback(request, OC_STATUS_INTERNAL_SERVER_ERROR,
+                                   true);
     return;
   }
 
-  oc_send_response_v1(request, OC_STATUS_OK, true);
+  oc_send_response_with_callback(request, OC_STATUS_OK, true);
 }
 
 void

--- a/api/plgd/plgd_time.c
+++ b/api/plgd/plgd_time.c
@@ -535,12 +535,12 @@ plgd_time_resource_post(oc_request_t *request, oc_interface_mask_t iface_mask,
   plgd_time_t pt = { 0 };
   if (!plgd_time_decode(request->request_payload, &pt)) {
     OC_ERR("cannot decode data for plgd-time resource");
-    oc_send_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
     return;
   }
 
   if (dev_time_set_time(pt.store.last_synced_time, false, false) != 0) {
-    oc_send_response(request, OC_STATUS_INTERNAL_SERVER_ERROR);
+    oc_send_response_v1(request, OC_STATUS_INTERNAL_SERVER_ERROR, true);
     return;
   }
 
@@ -548,11 +548,11 @@ plgd_time_resource_post(oc_request_t *request, oc_interface_mask_t iface_mask,
                                             // must have secure access
   if (plgd_time_encode(g_oc_plgd_time, OC_IF_RW, flags) != 0) {
     OC_ERR("cannot encode plgd-time resource");
-    oc_send_response(request, OC_STATUS_INTERNAL_SERVER_ERROR);
+    oc_send_response_v1(request, OC_STATUS_INTERNAL_SERVER_ERROR, true);
     return;
   }
 
-  oc_send_response(request, OC_STATUS_CHANGED);
+  oc_send_response_v1(request, OC_STATUS_CHANGED, true);
   plgd_time_dump();
 }
 
@@ -570,11 +570,11 @@ plgd_time_resource_get(oc_request_t *request, oc_interface_mask_t iface_mask,
 #endif /* OC_SECURITY */
   if (plgd_time_encode(g_oc_plgd_time, iface_mask, flags) != 0) {
     OC_ERR("cannot encode plgd-time resource");
-    oc_send_response(request, OC_STATUS_INTERNAL_SERVER_ERROR);
+    oc_send_response_v1(request, OC_STATUS_INTERNAL_SERVER_ERROR, true);
     return;
   }
 
-  oc_send_response(request, OC_STATUS_OK);
+  oc_send_response_v1(request, OC_STATUS_OK, true);
 }
 
 void

--- a/api/unittest/resourcetest.cpp
+++ b/api/unittest/resourcetest.cpp
@@ -35,6 +35,7 @@ class TestResourceWithDevice : public testing::Test {
 public:
   static void SetUpTestCase()
   {
+    oc_set_send_response_cb(SendResponseCallback);
     EXPECT_TRUE(oc::TestDevice::StartServer());
 #ifdef OC_HAS_FEATURE_RESOURCE_ACCESS_IN_RFOTM
     oc_resource_t *con = oc_core_get_resource_by_index(OCF_CON, /*device*/ 0);
@@ -47,8 +48,26 @@ public:
   static void TearDownTestCase()
   {
     oc::TestDevice::StopServer();
+    oc_set_send_response_cb(nullptr);
+    m_send_response_cb_invoked = false;
   }
+  static void SendResponseCallback(oc_request_t *request,
+                                   oc_status_t response_code)
+  {
+    (void)request;
+    (void)response_code;
+    m_send_response_cb_invoked = true;
+  }
+  static bool IsSendResponseCallbackInvoked()
+  {
+    return m_send_response_cb_invoked;
+  }
+
+private:
+  static bool m_send_response_cb_invoked;
 };
+
+bool TestResourceWithDevice::m_send_response_cb_invoked = false;
 
 #if !defined(OC_SECURITY) || defined(OC_HAS_FEATURE_RESOURCE_ACCESS_IN_RFOTM)
 
@@ -140,6 +159,8 @@ TEST_F(TestResourceWithDevice, BaselineInterfaceProperties)
   EXPECT_TRUE(oc_do_get("/oc/con", ep, "if=" OC_IF_BASELINE_STR, get_handler,
                         HIGH_QOS, &invoked));
   oc::TestDevice::PoolEvents(5);
+
+  EXPECT_TRUE(IsSendResponseCallbackInvoked());
 
   EXPECT_TRUE(invoked);
 }

--- a/api/unittest/resourcetest.cpp
+++ b/api/unittest/resourcetest.cpp
@@ -35,7 +35,7 @@ class TestResourceWithDevice : public testing::Test {
 public:
   static void SetUpTestCase()
   {
-    oc_set_send_response_cb(SendResponseCallback);
+    oc_set_send_response_callback(SendResponseCallback);
     EXPECT_TRUE(oc::TestDevice::StartServer());
 #ifdef OC_HAS_FEATURE_RESOURCE_ACCESS_IN_RFOTM
     oc_resource_t *con = oc_core_get_resource_by_index(OCF_CON, /*device*/ 0);
@@ -48,7 +48,7 @@ public:
   static void TearDownTestCase()
   {
     oc::TestDevice::StopServer();
-    oc_set_send_response_cb(nullptr);
+    oc_set_send_response_callback(nullptr);
     m_send_response_cb_invoked = false;
   }
   static void SendResponseCallback(oc_request_t *request,

--- a/apps/cloud_server.c
+++ b/apps/cloud_server.c
@@ -1270,7 +1270,7 @@ main(int argc, char *argv[])
                                         .register_resources =
                                           register_resources };
   oc_log_set_function(cloud_server_log);
-  oc_set_send_response_cb(cloud_server_send_response_cb);
+  oc_set_send_response_callback(cloud_server_send_response_cb);
 #ifdef OC_STORAGE
   oc_storage_config("./cloud_server_creds/");
 #endif /* OC_STORAGE */

--- a/apps/cloud_server.c
+++ b/apps/cloud_server.c
@@ -1196,6 +1196,21 @@ cloud_server_log(oc_log_level_t log_level, oc_log_component_t component,
   fflush(stdout);
 }
 
+static void
+cloud_server_send_response_cb(oc_request_t *request, oc_status_t response_code)
+{
+  const char *uri = "???";
+  if (request->resource != NULL) {
+    uri = oc_string(request->resource->uri);
+  }
+  const char *response_code_str = oc_status_to_str(response_code);
+  const char *method_str = oc_method_to_str(request->method);
+  PRINT(
+    "<cloud_server_send_response_cb> method(%d): %s, uri: %s, code(%d): %s\n",
+    request->method, method_str, uri, response_code, response_code_str);
+  fflush(stdout);
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -1255,6 +1270,7 @@ main(int argc, char *argv[])
                                         .register_resources =
                                           register_resources };
   oc_log_set_function(cloud_server_log);
+  oc_set_send_response_cb(cloud_server_send_response_cb);
 #ifdef OC_STORAGE
   oc_storage_config("./cloud_server_creds/");
 #endif /* OC_STORAGE */

--- a/include/oc_api.h
+++ b/include/oc_api.h
@@ -1555,7 +1555,32 @@ int oc_query_value_exists(const oc_request_t *request, const char *key);
  * oc_request_callback_t to inform the caller about the status of the requested
  * action.
  *
- * @note This function does not trigger oc_send_response_cb_t callback function.
+ *
+ * @param[in] request the request being responded to
+ * @param[in] response_code the status of the response
+ * @param[in] trigger_cb if true, the send response callback will be triggered
+ *
+ * @note For libraries it is recommended to set trigger_cb to true to allow
+ * modify the response body.
+ *
+ * @see oc_request_callback_t
+ * @see oc_ignore_request
+ * @see oc_indicate_separate_response
+ */
+OC_API
+void oc_send_response_with_callback(oc_request_t *request,
+                                    oc_status_t response_code, bool trigger_cb);
+
+/**
+ * Called after the response to a GET, PUT, POST or DELETE call has been
+ * prepared completed
+ *
+ * The function oc_send_response is called at the end of a
+ * oc_request_callback_t to inform the caller about the status of the requested
+ * action.
+ *
+ * @note This function just calls oc_send_response_with_callback with trigger_cb
+ * set to false.
  *
  * @param[in] request the request being responded to
  * @param[in] response_code the status of the response
@@ -1563,6 +1588,7 @@ int oc_query_value_exists(const oc_request_t *request, const char *key);
  * @see oc_request_callback_t
  * @see oc_ignore_request
  * @see oc_indicate_separate_response
+ * @see oc_send_response_with_callback
  */
 OC_API
 void oc_send_response(oc_request_t *request, oc_status_t response_code);
@@ -1587,7 +1613,8 @@ typedef void (*oc_send_response_cb_t)(oc_request_t *request,
  * @note This function is not thread safe. It should be called before
  * oc_main_init().
  *
- * @param cb that will be triggered for each response from the stack.
+ * @param cb that will be triggered by oc_send_response_with_callback when the
+ * trigger_cb is true.
  */
 OC_API
 void oc_set_send_response_cb(oc_send_response_cb_t cb);

--- a/include/oc_api.h
+++ b/include/oc_api.h
@@ -1617,7 +1617,7 @@ typedef void (*oc_send_response_cb_t)(oc_request_t *request,
  * trigger_cb is true.
  */
 OC_API
-void oc_set_send_response_cb(oc_send_response_cb_t cb);
+void oc_set_send_response_callback(oc_send_response_cb_t cb);
 
 /**
  * @brief retrieve the payload from the request, no processing

--- a/include/oc_api.h
+++ b/include/oc_api.h
@@ -257,6 +257,7 @@ typedef void (*oc_add_device_cb_t)(void *data);
  * @see oc_set_random_pin_callback
  * @see oc_storage_config
  */
+OC_API
 int oc_main_init(const oc_handler_t *handler);
 
 /**
@@ -265,11 +266,13 @@ int oc_main_init(const oc_handler_t *handler);
  * @return
  *  - time for the next poll event
  */
+OC_API
 oc_clock_time_t oc_main_poll(void);
 
 /**
  * Shutdown and free all stack related resources
  */
+OC_API
 void oc_main_shutdown(void);
 
 /**
@@ -366,6 +369,7 @@ typedef void (*oc_factory_presets_cb_t)(size_t device, void *data);
  *                 the pointer must be a valid pointer till after oc_main_init()
  *                 call completes.
  */
+OC_API
 void oc_set_factory_presets_cb(oc_factory_presets_cb_t cb, void *data);
 
 /**
@@ -417,6 +421,7 @@ void oc_set_factory_presets_cb(oc_factory_presets_cb_t cb, void *data);
  *
  * @see init
  */
+OC_API
 int oc_add_device(const char *uri, const char *rt, const char *name,
                   const char *spec_version, const char *data_model_version,
                   oc_add_device_cb_t add_device_cb, void *data);
@@ -457,6 +462,7 @@ int oc_add_device(const char *uri, const char *rt, const char *name,
  * @see init
  * @see oc_init_platform_cb_t
  */
+OC_API
 int oc_init_platform(const char *mfg_name,
                      oc_init_platform_cb_t init_platform_cb, void *data);
 
@@ -529,6 +535,7 @@ typedef void (*oc_random_pin_cb_t)(const unsigned char *pin, size_t pin_len,
  * @see oc_random_pin_cb_t
  * @see oc_main_init
  */
+OC_API
 void oc_set_random_pin_callback(oc_random_pin_cb_t cb, void *data);
 
 /**
@@ -541,6 +548,7 @@ void oc_set_random_pin_callback(oc_random_pin_cb_t cb, void *data);
  * @see oc_set_con_res_announced
  * @see oc_set_con_write_cb
  */
+OC_API
 bool oc_get_con_res_announced(void);
 
 /**
@@ -553,6 +561,7 @@ bool oc_get_con_res_announced(void);
  * @see oc_get_con_res_announced
  * @see oc_set_con_write_cb
  */
+OC_API
 void oc_set_con_res_announced(bool announce);
 
 /**
@@ -571,6 +580,7 @@ void oc_set_con_res_announced(bool announce);
  * @note A device connected to a cloud is not unregistered from the cloud since
  * the connection has been closed immediately.
  */
+OC_API
 void oc_reset(void);
 
 /**
@@ -591,6 +601,7 @@ void oc_reset(void);
  * delay. Set to false if the device is connected to a cloud and you want to
  * unregister it.
  */
+OC_API
 void oc_reset_v1(bool close_all_tls_connections_immediately);
 
 /**
@@ -610,6 +621,7 @@ void oc_reset_v1(bool close_all_tls_connections_immediately);
  *
  * @param[in] device index of the logical device to reset
  */
+OC_API
 void oc_reset_device(size_t device);
 
 /**
@@ -632,6 +644,7 @@ void oc_reset_device(size_t device);
  * delay. Set to false if the device is connected to a cloud and you want to
  * unregister it.
  */
+OC_API
 bool oc_reset_device_v1(size_t device,
                         bool close_all_tls_connections_immediately);
 
@@ -663,6 +676,7 @@ typedef void (*oc_ownership_status_cb_t)(const oc_uuid_t *device_uuid,
  * @param[in] user_data context pointer passed to the oc_ownership_status_cb_t
  * callback the pointer must remain valid till callback is removed.
  */
+OC_API
 void oc_add_ownership_status_cb(oc_ownership_status_cb_t cb, void *user_data);
 
 /**
@@ -674,6 +688,7 @@ void oc_add_ownership_status_cb(oc_ownership_status_cb_t cb, void *user_data);
  * @param[in] cb callback function to remove
  * @param[in] user_data the context pointer used when the callback was added
  */
+OC_API
 void oc_remove_ownership_status_cb(oc_ownership_status_cb_t cb,
                                    void *user_data);
 
@@ -691,6 +706,7 @@ void oc_remove_ownership_status_cb(oc_ownership_status_cb_t cb,
  *
  * @return true if the device is owned by an onboarding tool
  */
+OC_API
 bool oc_is_owned_device(size_t device_index);
 
 /**
@@ -721,6 +737,7 @@ typedef void (*oc_select_oxms_cb_t)(size_t device_index, int *oxms,
  *                 simply replaced.
  * @param[in] user_data context pointer
  */
+OC_API
 void oc_set_select_oxms_cb(oc_select_oxms_cb_t callback, void *user_data);
 
 /* Server side */
@@ -779,6 +796,7 @@ void oc_set_select_oxms_cb(oc_select_oxms_cb_t callback, void *user_data);
  * @see oc_resource_set_periodic_observable
  * @see oc_resource_set_request_handler
  */
+OC_API
 oc_resource_t *oc_new_resource(const char *name, const char *uri,
                                uint8_t num_resource_types, size_t device);
 
@@ -821,6 +839,7 @@ oc_resource_t *oc_new_resource(const char *name, const char *uri,
  * @see oc_interface_mask_t
  * @see oc_resource_set_default_interface
  */
+OC_API
 void oc_resource_bind_resource_interface(oc_resource_t *resource,
                                          oc_interface_mask_t iface_mask);
 
@@ -840,6 +859,7 @@ void oc_resource_bind_resource_interface(oc_resource_t *resource,
  * @param[in] iface_mask a single interface that will will be used as the
  *                       default interface
  */
+OC_API
 void oc_resource_set_default_interface(oc_resource_t *resource,
                                        oc_interface_mask_t iface_mask);
 
@@ -867,6 +887,7 @@ void oc_resource_set_default_interface(oc_resource_t *resource,
  * @see oc_new_resource
  * @see oc_device_bind_resource_type
  */
+OC_API
 void oc_resource_bind_resource_type(oc_resource_t *resource, const char *type);
 
 /**
@@ -879,6 +900,7 @@ void oc_resource_bind_resource_type(oc_resource_t *resource, const char *type);
  * @param[in] type the Resource type to add to the Resource Type "rt" property
  * (cannot be NULL)
  */
+OC_API
 void oc_device_bind_resource_type(size_t device, const char *type);
 
 /**
@@ -887,6 +909,7 @@ void oc_device_bind_resource_type(size_t device, const char *type);
  * @param resource the resource
  * @param pos the descriptive text for the tag
  */
+OC_API
 void oc_resource_tag_pos_desc(oc_resource_t *resource,
                               oc_pos_description_t pos);
 
@@ -898,6 +921,7 @@ void oc_resource_tag_pos_desc(oc_resource_t *resource,
  * @param y the y value in 3D space
  * @param z the z value in 3D space
  */
+OC_API
 void oc_resource_tag_pos_rel(oc_resource_t *resource, double x, double y,
                              double z);
 
@@ -907,6 +931,7 @@ void oc_resource_tag_pos_rel(oc_resource_t *resource, double x, double y,
  * @param resource the resource to apply the tag too.
  * @param func the function description
  */
+OC_API
 void oc_resource_tag_func_desc(oc_resource_t *resource, oc_enum_t func);
 
 /**
@@ -915,6 +940,7 @@ void oc_resource_tag_func_desc(oc_resource_t *resource, oc_enum_t func);
  * @param resource the resource to apply the tag too.
  * @param locn the location
  */
+OC_API
 void oc_resource_tag_locn(oc_resource_t *resource, oc_locn_t locn);
 
 /**
@@ -950,6 +976,7 @@ void oc_resource_tag_locn(oc_resource_t *resource, oc_locn_t locn);
  * @param[in] resource the resource the baseline Common Properties will be read
  *            from to respond to the GET request (cannot be NULL)
  */
+OC_API
 void oc_process_baseline_interface(const oc_resource_t *resource);
 
 /**
@@ -984,6 +1011,7 @@ void oc_process_baseline_interface(const oc_resource_t *resource);
  * @see oc_add_collection
  * @see oc_collection_add_link
  */
+OC_API
 oc_resource_t *oc_new_collection(const char *name, const char *uri,
                                  uint8_t num_resource_types, size_t device);
 
@@ -1002,6 +1030,7 @@ oc_resource_t *oc_new_collection(const char *name, const char *uri,
  * @see oc_collection_get_links
  * @see oc_delete_link
  */
+OC_API
 void oc_delete_collection(oc_resource_t *collection);
 
 /**
@@ -1016,6 +1045,7 @@ void oc_delete_collection(oc_resource_t *collection);
  * @see oc_collection_add_link
  * @see oc_new_resource
  */
+OC_API
 oc_link_t *oc_new_link(oc_resource_t *resource);
 
 /**
@@ -1027,6 +1057,7 @@ oc_link_t *oc_new_link(oc_resource_t *resource);
  * @param[in,out] link The link to delete. The function does nothing, if the
  *                     parameter is NULL
  */
+OC_API
 void oc_delete_link(oc_link_t *link);
 
 /**
@@ -1035,6 +1066,7 @@ void oc_delete_link(oc_link_t *link);
  * @param[in,out] link Link to add the relation to. Must not be NULL
  * @param[in] rel Relation to add. Must not be NULL
  */
+OC_API
 void oc_link_add_rel(oc_link_t *link, const char *rel);
 
 /**
@@ -1044,6 +1076,7 @@ void oc_link_add_rel(oc_link_t *link, const char *rel);
  * @param[in] key Key to identify the link parameter. Must not be NULL
  * @param[in] value Link parameter value. Must not be NULL
  */
+OC_API
 void oc_link_add_link_param(oc_link_t *link, const char *key,
                             const char *value);
 
@@ -1059,6 +1092,7 @@ void oc_link_add_link_param(oc_link_t *link, const char *key,
  * @see oc_new_link
  * @see oc_collection_remove_link
  */
+OC_API
 void oc_collection_add_link(oc_resource_t *collection, oc_link_t *link);
 
 /**
@@ -1070,6 +1104,7 @@ void oc_collection_add_link(oc_resource_t *collection, oc_link_t *link);
  *                 part of the collection. The link and its resource are not
  *                 freed.
  */
+OC_API
 void oc_collection_remove_link(oc_resource_t *collection, oc_link_t *link);
 
 /**
@@ -1082,6 +1117,7 @@ void oc_collection_remove_link(oc_resource_t *collection, oc_link_t *link);
  *
  * @see oc_collection_add_link
  */
+OC_API
 oc_link_t *oc_collection_get_links(oc_resource_t *collection);
 
 /**
@@ -1097,6 +1133,7 @@ oc_link_t *oc_collection_get_links(oc_resource_t *collection);
  * @see oc_resource_set_discoverable
  * @see oc_new_collection
  */
+OC_API
 void oc_add_collection(oc_resource_t *collection);
 
 /**
@@ -1107,6 +1144,7 @@ void oc_add_collection(oc_resource_t *collection);
  *         Collections created only via oc_new_collection() but not added will
  *         not be returned by this function.
  */
+OC_API
 oc_resource_t *oc_collection_get_collections(void);
 
 /**
@@ -1121,6 +1159,7 @@ oc_resource_t *oc_collection_get_collections(void);
  *
  * @return true on success
  */
+OC_API
 bool oc_collection_add_supported_rt(oc_resource_t *collection, const char *rt);
 
 /**
@@ -1135,6 +1174,7 @@ bool oc_collection_add_supported_rt(oc_resource_t *collection, const char *rt);
  *
  * @return true on success
  */
+OC_API
 bool oc_collection_add_mandatory_rt(oc_resource_t *collection, const char *rt);
 
 #ifdef OC_COLLECTIONS_IF_CREATE
@@ -1163,6 +1203,7 @@ typedef void (*oc_resource_free_instance_t)(oc_resource_t *);
  * @return true
  * @return false
  */
+OC_API
 bool oc_collections_add_rt_factory(const char *rt,
                                    oc_resource_get_instance_t get_instance,
                                    oc_resource_free_instance_t free_instance);
@@ -1193,6 +1234,7 @@ void oc_resource_make_public(oc_resource_t *resource);
  *
  * @see oc_new_resource for example code using this function
  */
+OC_API
 void oc_resource_set_discoverable(oc_resource_t *resource, bool state);
 
 #ifdef OC_HAS_FEATURE_PUSH
@@ -1203,6 +1245,7 @@ void oc_resource_set_discoverable(oc_resource_t *resource, bool state);
  * @param[in] state if true the resource will be pushable if false the
  *                  resource will be non-pushable
  */
+OC_API
 OC_API
 void oc_resource_set_pushable(oc_resource_t *resource, bool state);
 #endif
@@ -1221,6 +1264,7 @@ void oc_resource_set_pushable(oc_resource_t *resource, bool state);
  * @see oc_new_resource to see example code using this function
  * @see oc_resource_set_periodic_observable
  */
+OC_API
 void oc_resource_set_observable(oc_resource_t *resource, bool state);
 
 /**
@@ -1237,6 +1281,7 @@ void oc_resource_set_observable(oc_resource_t *resource, bool state);
  * @param[in] seconds the frequency in seconds that the resource will send out
  *                    an notification of is property values.
  */
+OC_API
 void oc_resource_set_periodic_observable(oc_resource_t *resource,
                                          uint16_t seconds);
 
@@ -1271,6 +1316,7 @@ void oc_resource_set_periodic_observable(oc_resource_t *resource,
  *
  * @see oc_new_resource to see example code using this function
  */
+OC_API
 void oc_resource_set_request_handler(oc_resource_t *resource,
                                      oc_method_t method,
                                      oc_request_callback_t callback,
@@ -1287,6 +1333,7 @@ void oc_resource_set_request_handler(oc_resource_t *resource,
  * @param set_props_user_data the user data for the set_properties callback
  * function
  */
+OC_API
 void oc_resource_set_properties_cbs(oc_resource_t *resource,
                                     oc_get_properties_cb_t get_properties,
                                     void *get_props_user_data,
@@ -1300,6 +1347,7 @@ void oc_resource_set_properties_cbs(oc_resource_t *resource,
  * @param resource the resource
  * @param supported true: supported
  */
+OC_API
 void oc_resource_set_secure_mcast(oc_resource_t *resource, bool supported);
 #endif /* OC_OSCORE */
 
@@ -1314,6 +1362,7 @@ void oc_resource_set_secure_mcast(oc_resource_t *resource, bool supported);
  *  - true: the resource was successfully added to the stack.
  *  - false: the resource can not be added to the stack.
  */
+OC_API
 bool oc_add_resource(oc_resource_t *resource);
 
 /**
@@ -1329,6 +1378,7 @@ bool oc_add_resource(oc_resource_t *resource);
  *  - true: when the resource has been deleted and memory freed.
  *  - false: there was an issue deleting the resource.
  */
+OC_API
 bool oc_delete_resource(oc_resource_t *resource);
 
 /**
@@ -1336,6 +1386,7 @@ bool oc_delete_resource(oc_resource_t *resource);
  *
  * @param[in] resource the resource to delete
  */
+OC_API
 void oc_delayed_delete_resource(oc_resource_t *resource);
 
 /**
@@ -1374,6 +1425,7 @@ typedef void (*oc_con_write_cb_t)(size_t device_index, oc_rep_t *rep);
  *                 is invoked a second time, then the previously set callback is
  *                 simply replaced.
  */
+OC_API
 void oc_set_con_write_cb(oc_con_write_cb_t callback);
 
 /**
@@ -1383,6 +1435,7 @@ void oc_set_con_write_cb(oc_con_write_cb_t callback);
  * oc_iterate_query() to iterate through query parameter of a URI that are part
  * of an `oc_request_t`
  */
+OC_API
 void oc_init_query_iterator(void);
 
 /**
@@ -1417,6 +1470,7 @@ void oc_init_query_iterator(void);
  *   - The position in the query string of the next key=value string pair
  *   - `-1` if there are no additional query parameters
  */
+OC_API
 int oc_iterate_query(const oc_request_t *request, const char **key,
                      size_t *key_len, const char **value, size_t *value_len);
 
@@ -1456,6 +1510,7 @@ int oc_iterate_query(const oc_request_t *request, const char **key,
  *
  * @return True if there are more query parameters to iterate through
  */
+OC_API
 bool oc_iterate_query_get_values(const oc_request_t *request, const char *key,
                                  const char **value, int *value_len);
 
@@ -1475,6 +1530,7 @@ bool oc_iterate_query_get_values(const oc_request_t *request, const char *key,
  *   - The position in the query string of the next key=value string pair
  *   - `-1` if there are no additional query parameters
  */
+OC_API
 int oc_get_query_value(const oc_request_t *request, const char *key,
                        const char **value);
 
@@ -1488,6 +1544,7 @@ int oc_get_query_value(const oc_request_t *request, const char *key,
  *   - 1 exist
  *   - -1 does not exist
  */
+OC_API
 int oc_query_value_exists(const oc_request_t *request, const char *key);
 
 /**
@@ -1501,12 +1558,63 @@ int oc_query_value_exists(const oc_request_t *request, const char *key);
  *
  * @param[in] request the request being responded to
  * @param[in] response_code the status of the response
+ * @param[in] trigger_cb if true, the send response callback will be triggered
  *
  * @see oc_request_callback_t
  * @see oc_ignore_request
  * @see oc_indicate_separate_response
  */
+OC_API
+void oc_send_response_v1(oc_request_t *request, oc_status_t response_code,
+                         bool trigger_cb);
+
+/**
+ * Called after the response to a GET, PUT, POST or DELETE call has been
+ * prepared completed
+ *
+ * The function oc_send_response is called at the end of a
+ * oc_request_callback_t to inform the caller about the status of the requested
+ * action.
+ *
+ * @note This function just calls oc_send_response_v1 with trigger_cb set to
+ * true.
+ *
+ * @param[in] request the request being responded to
+ * @param[in] response_code the status of the response
+ *
+ * @see oc_request_callback_t
+ * @see oc_ignore_request
+ * @see oc_indicate_separate_response
+ * @see oc_send_response_v1
+ */
+OC_API
 void oc_send_response(oc_request_t *request, oc_status_t response_code);
+
+/**
+ * @brief Callback function is triggered by oc_send_response before the response
+ * is set. In this callback, the application can set/override the response
+ * payload.
+ *
+ * @note For separate message, pong message, and notification, this callback is
+ * not triggered.
+ *
+ * @param request the request being responded to
+ * @param response_code the status of the response
+ */
+typedef void (*oc_send_response_cb_t)(oc_request_t *request,
+                                      oc_status_t response_code);
+
+/**
+ * @brief Set the send response callback function.
+ *
+ * @note This function is not thread safe. It should be called before
+ * oc_main_init().
+ *
+ * @param cb that will be triggered by oc_send_response_v1 when the trigger_cb
+ * is true.
+ */
+OC_API
+void oc_set_send_response_cb(oc_send_response_cb_t cb);
 
 /**
  * @brief retrieve the payload from the request, no processing
@@ -1518,6 +1626,7 @@ void oc_send_response(oc_request_t *request, oc_status_t response_code);
  * @return true
  * @return false
  */
+OC_API
 bool oc_get_request_payload_raw(const oc_request_t *request,
                                 const uint8_t **payload, size_t *size,
                                 oc_content_format_t *content_format);
@@ -1531,6 +1640,7 @@ bool oc_get_request_payload_raw(const oc_request_t *request,
  * @param content_format the content format
  * @param response_code the response code to send
  */
+OC_API
 void oc_send_response_raw(oc_request_t *request, const uint8_t *payload,
                           size_t size, oc_content_format_t content_format,
                           oc_status_t response_code);
@@ -1545,6 +1655,7 @@ void oc_send_response_raw(oc_request_t *request, const uint8_t *payload,
  * @return true - retrieved payload
  * @return false
  */
+OC_API
 bool oc_get_response_payload_raw(const oc_client_response_t *response,
                                  const uint8_t **payload, size_t *size,
                                  oc_content_format_t *content_format);
@@ -1557,6 +1668,7 @@ bool oc_get_response_payload_raw(const oc_client_response_t *response,
  * @param msg_len the lenght of the message
  * @param response_code the coap response code
  */
+OC_API
 void oc_send_diagnostic_message(oc_request_t *request, const char *msg,
                                 size_t msg_len, oc_status_t response_code);
 
@@ -1569,6 +1681,7 @@ void oc_send_diagnostic_message(oc_request_t *request, const char *msg,
  * @return true - retrieved payload
  * @return false
  */
+OC_API
 bool oc_get_diagnostic_message(const oc_client_response_t *response,
                                const char **msg, size_t *size);
 
@@ -1588,6 +1701,7 @@ bool oc_get_diagnostic_message(const oc_client_response_t *response,
  * @see oc_request_callback_t
  * @see oc_send_response
  */
+OC_API
 void oc_ignore_request(oc_request_t *request);
 
 /**
@@ -1633,6 +1747,7 @@ void oc_ignore_request(oc_request_t *request);
  * @see oc_set_separate_response_buffer
  * @see oc_send_separate_response
  */
+OC_API
 void oc_indicate_separate_response(oc_request_t *request,
                                    oc_separate_response_t *response);
 
@@ -1649,6 +1764,7 @@ void oc_indicate_separate_response(oc_request_t *request,
  * @see oc_indicate_separate_response
  * @see oc_send_separate_response
  */
+OC_API
 void oc_set_separate_response_buffer(oc_separate_response_t *handle);
 
 /**
@@ -1666,6 +1782,7 @@ void oc_set_separate_response_buffer(oc_separate_response_t *handle);
  * @see oc_send_response
  * @see oc_ignore_request
  */
+OC_API
 void oc_send_separate_response(oc_separate_response_t *handle,
                                oc_status_t response_code);
 
@@ -1681,6 +1798,7 @@ void oc_send_separate_response(oc_separate_response_t *handle,
  *  - the number observers notified on success
  *  - `0` on failure could also mean no registered observers
  */
+OC_API
 int oc_notify_observers(oc_resource_t *resource);
 
 /**
@@ -1692,6 +1810,7 @@ int oc_notify_observers(oc_resource_t *resource);
  * @param[in] resource the oc_resource_t that has a modified property
  * @param[in] seconds the number of seconds to wait till the callback is invoked
  */
+OC_API
 void oc_notify_observers_delayed(oc_resource_t *resource, uint16_t seconds);
 
 /**
@@ -1704,6 +1823,7 @@ void oc_notify_observers_delayed(oc_resource_t *resource, uint16_t seconds);
  * @param[in] milliseconds the number of milliseconds to wait till the callback
  * is invoked
  */
+OC_API
 void oc_notify_observers_delayed_ms(oc_resource_t *resource,
                                     uint16_t milliseconds);
 
@@ -1740,6 +1860,7 @@ extern "C" {
  *
  * @return true on success
  */
+OC_API
 bool oc_do_site_local_ipv6_discovery(const char *rt,
                                      oc_discovery_handler_t handler,
                                      void *user_data);
@@ -1760,6 +1881,7 @@ bool oc_do_site_local_ipv6_discovery(const char *rt,
  *
  * @return true on success
  */
+OC_API
 bool oc_do_site_local_ipv6_discovery_all(oc_discovery_all_handler_t handler,
                                          void *user_data);
 
@@ -1781,6 +1903,7 @@ bool oc_do_site_local_ipv6_discovery_all(oc_discovery_all_handler_t handler,
  *
  * @return true on success
  */
+OC_API
 bool oc_do_realm_local_ipv6_discovery(const char *rt,
                                       oc_discovery_handler_t handler,
                                       void *user_data);
@@ -1802,6 +1925,7 @@ bool oc_do_realm_local_ipv6_discovery(const char *rt,
  *
  * @return true on success
  */
+OC_API
 bool oc_do_realm_local_ipv6_discovery_all(oc_discovery_all_handler_t handler,
                                           void *user_data);
 
@@ -1824,6 +1948,7 @@ bool oc_do_realm_local_ipv6_discovery_all(oc_discovery_all_handler_t handler,
  *
  * @return true on success
  */
+OC_API
 bool oc_do_ip_discovery(const char *rt, oc_discovery_handler_t handler,
                         void *user_data);
 
@@ -1845,6 +1970,7 @@ bool oc_do_ip_discovery(const char *rt, oc_discovery_handler_t handler,
  *
  * @return true on success
  */
+OC_API
 bool oc_do_ip_discovery_all(oc_discovery_all_handler_t handler,
                             void *user_data);
 
@@ -1858,6 +1984,7 @@ bool oc_do_ip_discovery_all(oc_discovery_all_handler_t handler,
  *
  * @return Returns true if it successfully makes and dispatches a coap packet.
  */
+OC_API
 bool oc_do_ip_discovery_at_endpoint(const char *rt,
                                     oc_discovery_handler_t handler,
                                     const oc_endpoint_t *endpoint,
@@ -1872,6 +1999,7 @@ bool oc_do_ip_discovery_at_endpoint(const char *rt,
  *
  * @return Returns true if it successfully makes and dispatches a coap packet.
  */
+OC_API
 bool oc_do_ip_discovery_all_at_endpoint(oc_discovery_all_handler_t handler,
                                         const oc_endpoint_t *endpoint,
                                         void *user_data);
@@ -2173,6 +2301,7 @@ bool oc_do_post_with_timeout(uint16_t timeout_seconds);
  *
  * @return True if the client successfully dispatched the CaAP observer request
  */
+OC_API
 bool oc_do_observe(const char *uri, const oc_endpoint_t *endpoint,
                    const char *query, oc_response_handler_t handler,
                    oc_qos_t qos, void *user_data);
@@ -2186,6 +2315,7 @@ bool oc_do_observe(const char *uri, const oc_endpoint_t *endpoint,
  * @return True if the client successfully dispatched the CaAP stop observer
  *         request
  */
+OC_API
 bool oc_stop_observe(const char *uri, const oc_endpoint_t *endpoint);
 
 /**
@@ -2201,6 +2331,7 @@ bool oc_stop_observe(const char *uri, const oc_endpoint_t *endpoint);
  * @return True if the client successfully dispatched the multicast discovery
  *         request
  */
+OC_API
 bool oc_do_ip_multicast(const char *uri, const char *query,
                         oc_response_handler_t handler, void *user_data);
 
@@ -2217,6 +2348,7 @@ bool oc_do_ip_multicast(const char *uri, const char *query,
  * @return True if the client successfully dispatched the multicast discovery
  *         request
  */
+OC_API
 bool oc_do_realm_local_ipv6_multicast(const char *uri, const char *query,
                                       oc_response_handler_t handler,
                                       void *user_data);
@@ -2234,6 +2366,7 @@ bool oc_do_realm_local_ipv6_multicast(const char *uri, const char *query,
  * @return True if the client successfully dispatched the multicast discovery
  *         request
  */
+OC_API
 bool oc_do_site_local_ipv6_multicast(const char *uri, const char *query,
                                      oc_response_handler_t handler,
                                      void *user_data);
@@ -2243,6 +2376,7 @@ bool oc_do_site_local_ipv6_multicast(const char *uri, const char *query,
  *
  * @param[in] response the response that should not be handled.
  */
+OC_API
 void oc_stop_multicast(oc_client_response_t *response);
 
 #ifdef OC_OSCORE
@@ -2254,6 +2388,7 @@ void oc_stop_multicast(oc_client_response_t *response);
  * @return true
  * @return false
  */
+OC_API
 bool oc_init_multicast_update(const char *uri, const char *query);
 
 /**
@@ -2262,6 +2397,7 @@ bool oc_init_multicast_update(const char *uri, const char *query);
  * @return true
  * @return false
  */
+OC_API
 bool oc_do_multicast_update(void);
 #endif /* OC_OSCORE */
 
@@ -2274,6 +2410,7 @@ bool oc_do_multicast_update(void);
  *
  * @param[in,out] endpoint the endpoint list to free
  */
+OC_API
 void oc_free_server_endpoints(oc_endpoint_t *endpoint);
 
 /**
@@ -2281,6 +2418,7 @@ void oc_free_server_endpoints(oc_endpoint_t *endpoint);
  *
  * @param endpoint endpoint indicating a session
  */
+OC_API
 void oc_close_session(const oc_endpoint_t *endpoint);
 
 #ifdef OC_TCP
@@ -2295,6 +2433,7 @@ void oc_close_session(const oc_endpoint_t *endpoint);
  * @return true
  * @return false
  */
+OC_API
 bool oc_send_ping(bool custody, const oc_endpoint_t *endpoint,
                   uint16_t timeout_seconds, oc_response_handler_t handler,
                   void *user_data);
@@ -2317,6 +2456,7 @@ bool oc_send_ping(bool custody, const oc_endpoint_t *endpoint,
  * @param[in] device the logical device index
  * @param[in] piid the UUID for the immutable device identifier
  */
+OC_API
 void oc_set_immutable_device_identifier(size_t device, const oc_uuid_t *piid);
 
 /**

--- a/include/oc_api.h
+++ b/include/oc_api.h
@@ -1555,29 +1555,7 @@ int oc_query_value_exists(const oc_request_t *request, const char *key);
  * oc_request_callback_t to inform the caller about the status of the requested
  * action.
  *
- *
- * @param[in] request the request being responded to
- * @param[in] response_code the status of the response
- * @param[in] trigger_cb if true, the send response callback will be triggered
- *
- * @see oc_request_callback_t
- * @see oc_ignore_request
- * @see oc_indicate_separate_response
- */
-OC_API
-void oc_send_response_v1(oc_request_t *request, oc_status_t response_code,
-                         bool trigger_cb);
-
-/**
- * Called after the response to a GET, PUT, POST or DELETE call has been
- * prepared completed
- *
- * The function oc_send_response is called at the end of a
- * oc_request_callback_t to inform the caller about the status of the requested
- * action.
- *
- * @note This function just calls oc_send_response_v1 with trigger_cb set to
- * true.
+ * @note This function does not trigger oc_send_response_cb_t callback function.
  *
  * @param[in] request the request being responded to
  * @param[in] response_code the status of the response
@@ -1585,7 +1563,6 @@ void oc_send_response_v1(oc_request_t *request, oc_status_t response_code,
  * @see oc_request_callback_t
  * @see oc_ignore_request
  * @see oc_indicate_separate_response
- * @see oc_send_response_v1
  */
 OC_API
 void oc_send_response(oc_request_t *request, oc_status_t response_code);
@@ -1610,8 +1587,7 @@ typedef void (*oc_send_response_cb_t)(oc_request_t *request,
  * @note This function is not thread safe. It should be called before
  * oc_main_init().
  *
- * @param cb that will be triggered by oc_send_response_v1 when the trigger_cb
- * is true.
+ * @param cb that will be triggered for each response from the stack.
  */
 OC_API
 void oc_set_send_response_cb(oc_send_response_cb_t cb);

--- a/include/oc_ri.h
+++ b/include/oc_ri.h
@@ -254,7 +254,7 @@ typedef struct oc_request_t
   const oc_endpoint_t *origin; ///< origin of the request
   oc_resource_t *resource;     ///< resource structure
   const char *query;           ///< query (as string)
-  size_t query_len;            ///< query lenght
+  size_t query_len;            ///< query length
   oc_rep_t *request_payload;   ///< request payload structure
   const uint8_t *_payload;     ///< payload of the request
   size_t _payload_len;         ///< payload size
@@ -262,6 +262,7 @@ typedef struct oc_request_t
     content_format; ///< content format (of the payload in the request)
   oc_content_format_t accept; ///< accept header
   oc_response_t *response;    ///< pointer to the response
+  oc_method_t method;         ///< method of the request
 } oc_request_t;
 
 /**
@@ -502,16 +503,27 @@ void oc_ri_remove_timed_event_callback(const void *cb_data,
  * @param key the application level key of the code
  * @return int the CoAP status code
  */
+OC_API
 int oc_status_code(oc_status_t key);
 
 /**
- * @brief convert the status code to string
+ * @brief Convert the status code to string
  *
  * @param[in] key key the application level key of the code
- * @return char* CoAP status code string
+ * @return CoAP status code in const char *
+ * @return Empty string for an invalid log level value
  */
 OC_API
 const char *oc_status_to_str(oc_status_t key);
+
+/**
+ * @brief Convert method to string. It is thread safe.
+ *
+ * @return Method in const char *.
+ * @return Empty string for an invalid log level value
+ */
+OC_API
+const char *oc_method_to_str(oc_method_t method);
 
 #ifdef OC_SERVER
 /**

--- a/messaging/coap/engine.c
+++ b/messaging/coap/engine.c
@@ -261,20 +261,7 @@ coap_receive(oc_message_t *msg)
     if (message->code >= COAP_GET && message->code <= COAP_DELETE) {
 
 #if OC_DBG_IS_ENABLED
-      switch (message->code) {
-      case COAP_GET:
-        OC_DBG("  method: GET");
-        break;
-      case COAP_PUT:
-        OC_DBG("  method: PUT");
-        break;
-      case COAP_POST:
-        OC_DBG("  method: POST");
-        break;
-      case COAP_DELETE:
-        OC_DBG("  method: DELETE");
-        break;
-      }
+      OC_DBG("  method: %s", oc_method_to_str((oc_method_t)message->code));
       OC_DBG("  URL: %.*s", (int)message->uri_path_len, message->uri_path);
       OC_DBG("  QUERY: %.*s", (int)message->uri_query_len, message->uri_query);
       OC_DBG("  Payload: %.*s", (int)message->payload_len, message->payload);

--- a/messaging/coap/observe.c
+++ b/messaging/coap/observe.c
@@ -102,7 +102,7 @@ OC_MEMB(batch_observers_memb, batch_observer_t, COAP_MAX_OBSERVERS);
 
 typedef bool cmp_batch_observer_t(batch_observer_t *o, void *ctx);
 
-#if OC_LOG_LEVEL_IS_ENABLED(OC_LOG_LEVEL_DEBUG_MACRO)
+#if OC_DBG_IS_ENABLED
 static const char *
 batch_observer_get_resource_uri(batch_observer_t *batch_obs)
 {
@@ -638,6 +638,8 @@ coap_notify_collection(oc_collection_t *collection,
   response.response_buffer = &response_buffer;
   request.response = &response;
   request.request_payload = NULL;
+  request.method = OC_GET;
+
 #ifdef OC_DYNAMIC_ALLOCATION
   oc_rep_new_realloc(&response_buffer.buffer, response_buffer.buffer_size,
                      OC_MAX_OBSERVE_SIZE);
@@ -712,6 +714,7 @@ coap_notify_collections(oc_resource_t *resource)
   response.response_buffer = &response_buffer;
   request.response = &response;
   request.request_payload = NULL;
+  request.method = OC_GET;
 
   for (oc_collection_t *collection =
          oc_get_next_collection_with_link(resource, NULL);
@@ -778,6 +781,7 @@ fill_response(oc_resource_t *resource, const oc_endpoint_t *endpoint,
   request.origin = endpoint;
   request.response = response;
   request.request_payload = NULL;
+  request.method = OC_GET;
   if (iface_mask == 0) {
     iface_mask = resource->default_interface;
   }

--- a/security/oc_acl.c
+++ b/security/oc_acl.c
@@ -19,7 +19,6 @@
 #ifdef OC_SECURITY
 
 #include "api/oc_ri_internal.h"
-#include "api/oc_server_api_internal.h"
 #include "oc_acl_internal.h"
 #include "oc_api.h"
 #include "oc_certs_validate_internal.h"
@@ -1340,10 +1339,10 @@ post_acl(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
   (void)data;
   if (oc_sec_decode_acl(request->request_payload, false,
                         request->resource->device, NULL, NULL)) {
-    oc_send_response_v1(request, OC_STATUS_CHANGED, true);
+    oc_send_response_with_callback(request, OC_STATUS_CHANGED, true);
     oc_sec_dump_acl(request->resource->device);
   } else {
-    oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
+    oc_send_response_with_callback(request, OC_STATUS_BAD_REQUEST, true);
   }
 }
 
@@ -1356,7 +1355,7 @@ delete_acl(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
   const oc_sec_pstat_t *ps = oc_sec_get_pstat(request->resource->device);
   if (ps->s == OC_DOS_RFNOP) {
     OC_ERR("oc_acl: Cannot DELETE ACE in RFNOP");
-    oc_send_response_v1(request, OC_STATUS_FORBIDDEN, true);
+    oc_send_response_with_callback(request, OC_STATUS_FORBIDDEN, true);
     return;
   }
 
@@ -1377,10 +1376,10 @@ delete_acl(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
   }
 
   if (success) {
-    oc_send_response_v1(request, OC_STATUS_DELETED, true);
+    oc_send_response_with_callback(request, OC_STATUS_DELETED, true);
     oc_sec_dump_acl(request->resource->device);
   } else {
-    oc_send_response_v1(request, OC_STATUS_NOT_FOUND, true);
+    oc_send_response_with_callback(request, OC_STATUS_NOT_FOUND, true);
   }
 }
 
@@ -1389,9 +1388,10 @@ get_acl(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
 {
   (void)data;
   if (oc_sec_encode_acl(request->resource->device, iface_mask, false)) {
-    oc_send_response_v1(request, OC_STATUS_OK, true);
+    oc_send_response_with_callback(request, OC_STATUS_OK, true);
   } else {
-    oc_send_response_v1(request, OC_STATUS_INTERNAL_SERVER_ERROR, true);
+    oc_send_response_with_callback(request, OC_STATUS_INTERNAL_SERVER_ERROR,
+                                   true);
   }
 }
 

--- a/security/oc_acl.c
+++ b/security/oc_acl.c
@@ -19,6 +19,7 @@
 #ifdef OC_SECURITY
 
 #include "api/oc_ri_internal.h"
+#include "api/oc_server_api_internal.h"
 #include "oc_acl_internal.h"
 #include "oc_api.h"
 #include "oc_certs_validate_internal.h"
@@ -1339,10 +1340,10 @@ post_acl(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
   (void)data;
   if (oc_sec_decode_acl(request->request_payload, false,
                         request->resource->device, NULL, NULL)) {
-    oc_send_response(request, OC_STATUS_CHANGED);
+    oc_send_response_v1(request, OC_STATUS_CHANGED, true);
     oc_sec_dump_acl(request->resource->device);
   } else {
-    oc_send_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
   }
 }
 
@@ -1355,7 +1356,7 @@ delete_acl(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
   const oc_sec_pstat_t *ps = oc_sec_get_pstat(request->resource->device);
   if (ps->s == OC_DOS_RFNOP) {
     OC_ERR("oc_acl: Cannot DELETE ACE in RFNOP");
-    oc_send_response(request, OC_STATUS_FORBIDDEN);
+    oc_send_response_v1(request, OC_STATUS_FORBIDDEN, true);
     return;
   }
 
@@ -1376,10 +1377,10 @@ delete_acl(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
   }
 
   if (success) {
-    oc_send_response(request, OC_STATUS_DELETED);
+    oc_send_response_v1(request, OC_STATUS_DELETED, true);
     oc_sec_dump_acl(request->resource->device);
   } else {
-    oc_send_response(request, OC_STATUS_NOT_FOUND);
+    oc_send_response_v1(request, OC_STATUS_NOT_FOUND, true);
   }
 }
 
@@ -1388,9 +1389,9 @@ get_acl(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
 {
   (void)data;
   if (oc_sec_encode_acl(request->resource->device, iface_mask, false)) {
-    oc_send_response(request, OC_STATUS_OK);
+    oc_send_response_v1(request, OC_STATUS_OK, true);
   } else {
-    oc_send_response(request, OC_STATUS_INTERNAL_SERVER_ERROR);
+    oc_send_response_v1(request, OC_STATUS_INTERNAL_SERVER_ERROR, true);
   }
 }
 

--- a/security/oc_ael.c
+++ b/security/oc_ael.c
@@ -26,7 +26,6 @@
 
 #include "oc_ael.h"
 #include "oc_api.h"
-#include "api/oc_server_api_internal.h"
 #include "oc_clock_util.h"
 #include "oc_core_res.h"
 #include "oc_pstat.h"
@@ -172,9 +171,9 @@ get_ael(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
     case OC_IF_BASELINE:
     case OC_IF_RW:
       if (oc_sec_ael_encode(request->resource->device, iface_mask, false)) {
-        oc_send_response_v1(request, OC_STATUS_OK, true);
+        oc_send_response_with_callback(request, OC_STATUS_OK, true);
       } else {
-        oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
+        oc_send_response_with_callback(request, OC_STATUS_BAD_REQUEST, true);
       }
       break;
     default:
@@ -191,7 +190,7 @@ post_ael(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
     oc_sec_pstat_t *ps = oc_sec_get_pstat(request->resource->device);
     if (ps->s == OC_DOS_RFNOP) {
       OC_ERR("oc_ael: Cannot UPDATE AEL in RFNOP");
-      oc_send_response_v1(request, OC_STATUS_FORBIDDEN, true);
+      oc_send_response_with_callback(request, OC_STATUS_FORBIDDEN, true);
       return;
     }
     switch (iface_mask) {
@@ -199,10 +198,10 @@ post_ael(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
     case OC_IF_RW:
       if (oc_sec_ael_decode(request->resource->device, request->request_payload,
                             false)) {
-        oc_send_response_v1(request, OC_STATUS_CHANGED, true);
+        oc_send_response_with_callback(request, OC_STATUS_CHANGED, true);
         oc_sec_dump_ael(request->resource->device);
       } else {
-        oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
+        oc_send_response_with_callback(request, OC_STATUS_BAD_REQUEST, true);
       }
       break;
     default:

--- a/security/oc_ael.c
+++ b/security/oc_ael.c
@@ -26,6 +26,7 @@
 
 #include "oc_ael.h"
 #include "oc_api.h"
+#include "api/oc_server_api_internal.h"
 #include "oc_clock_util.h"
 #include "oc_core_res.h"
 #include "oc_pstat.h"
@@ -171,9 +172,9 @@ get_ael(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
     case OC_IF_BASELINE:
     case OC_IF_RW:
       if (oc_sec_ael_encode(request->resource->device, iface_mask, false)) {
-        oc_send_response(request, OC_STATUS_OK);
+        oc_send_response_v1(request, OC_STATUS_OK, true);
       } else {
-        oc_send_response(request, OC_STATUS_BAD_REQUEST);
+        oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
       }
       break;
     default:
@@ -190,7 +191,7 @@ post_ael(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
     oc_sec_pstat_t *ps = oc_sec_get_pstat(request->resource->device);
     if (ps->s == OC_DOS_RFNOP) {
       OC_ERR("oc_ael: Cannot UPDATE AEL in RFNOP");
-      oc_send_response(request, OC_STATUS_FORBIDDEN);
+      oc_send_response_v1(request, OC_STATUS_FORBIDDEN, true);
       return;
     }
     switch (iface_mask) {
@@ -198,10 +199,10 @@ post_ael(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
     case OC_IF_RW:
       if (oc_sec_ael_decode(request->resource->device, request->request_payload,
                             false)) {
-        oc_send_response(request, OC_STATUS_CHANGED);
+        oc_send_response_v1(request, OC_STATUS_CHANGED, true);
         oc_sec_dump_ael(request->resource->device);
       } else {
-        oc_send_response(request, OC_STATUS_BAD_REQUEST);
+        oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
       }
       break;
     default:

--- a/security/oc_cred.c
+++ b/security/oc_cred.c
@@ -24,7 +24,6 @@
 #include "oc_config.h"
 #include "oc_core_res.h"
 #include "oc_store.h"
-#include "api/oc_server_api_internal.h"
 #include "port/oc_assert.h"
 #include "port/oc_log_internal.h"
 #include "security/oc_certs_internal.h"
@@ -1618,7 +1617,7 @@ get_cred(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
     oc_sec_encode_roles(client, request->resource->device, iface_mask);
   }
 #endif /* OC_PKI */
-  oc_send_response_v1(request, OC_STATUS_OK, true);
+  oc_send_response_with_callback(request, OC_STATUS_OK, true);
 }
 
 bool
@@ -1664,7 +1663,7 @@ delete_cred(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
     const oc_sec_pstat_t *ps = oc_sec_get_pstat(request->resource->device);
     if (ps->s == OC_DOS_RFNOP) {
       OC_ERR("oc_cred: Cannot DELETE ACE in RFNOP");
-      oc_send_response_v1(request, OC_STATUS_FORBIDDEN, true);
+      oc_send_response_with_callback(request, OC_STATUS_FORBIDDEN, true);
       return;
     }
   }
@@ -1702,10 +1701,10 @@ delete_cred(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
   }
 
   if (success) {
-    oc_send_response_v1(request, OC_STATUS_DELETED, true);
+    oc_send_response_with_callback(request, OC_STATUS_DELETED, true);
     oc_sec_dump_cred(request->resource->device);
   } else {
-    oc_send_response_v1(request, OC_STATUS_NOT_FOUND, true);
+    oc_send_response_with_callback(request, OC_STATUS_NOT_FOUND, true);
   }
 }
 
@@ -1792,9 +1791,9 @@ post_cred(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
                                    /*on_apply_cred_data*/ NULL) == 0;
 
   if (!success) {
-    oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
+    oc_send_response_with_callback(request, OC_STATUS_BAD_REQUEST, true);
   } else {
-    oc_send_response_v1(request, OC_STATUS_CHANGED, true);
+    oc_send_response_with_callback(request, OC_STATUS_CHANGED, true);
     oc_sec_dump_cred(request->resource->device);
   }
 }

--- a/security/oc_cred.c
+++ b/security/oc_cred.c
@@ -24,6 +24,7 @@
 #include "oc_config.h"
 #include "oc_core_res.h"
 #include "oc_store.h"
+#include "api/oc_server_api_internal.h"
 #include "port/oc_assert.h"
 #include "port/oc_log_internal.h"
 #include "security/oc_certs_internal.h"
@@ -1617,7 +1618,7 @@ get_cred(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
     oc_sec_encode_roles(client, request->resource->device, iface_mask);
   }
 #endif /* OC_PKI */
-  oc_send_response(request, OC_STATUS_OK);
+  oc_send_response_v1(request, OC_STATUS_OK, true);
 }
 
 bool
@@ -1663,7 +1664,7 @@ delete_cred(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
     const oc_sec_pstat_t *ps = oc_sec_get_pstat(request->resource->device);
     if (ps->s == OC_DOS_RFNOP) {
       OC_ERR("oc_cred: Cannot DELETE ACE in RFNOP");
-      oc_send_response(request, OC_STATUS_FORBIDDEN);
+      oc_send_response_v1(request, OC_STATUS_FORBIDDEN, true);
       return;
     }
   }
@@ -1701,10 +1702,10 @@ delete_cred(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
   }
 
   if (success) {
-    oc_send_response(request, OC_STATUS_DELETED);
+    oc_send_response_v1(request, OC_STATUS_DELETED, true);
     oc_sec_dump_cred(request->resource->device);
   } else {
-    oc_send_response(request, OC_STATUS_NOT_FOUND);
+    oc_send_response_v1(request, OC_STATUS_NOT_FOUND, true);
   }
 }
 
@@ -1791,9 +1792,9 @@ post_cred(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
                                    /*on_apply_cred_data*/ NULL) == 0;
 
   if (!success) {
-    oc_send_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
   } else {
-    oc_send_response(request, OC_STATUS_CHANGED);
+    oc_send_response_v1(request, OC_STATUS_CHANGED, true);
     oc_sec_dump_cred(request->resource->device);
   }
 }

--- a/security/oc_csr.c
+++ b/security/oc_csr.c
@@ -27,7 +27,6 @@
 #include "oc_certs.h"
 #include "oc_core_res.h"
 #include "oc_uuid.h"
-#include "api/oc_server_api_internal.h"
 #include "security/oc_certs_internal.h"
 #include "security/oc_csr_internal.h"
 #include "security/oc_entropy_internal.h"
@@ -274,7 +273,8 @@ csr_resource_get(oc_request_t *request, oc_interface_mask_t iface_mask,
   int ret = oc_sec_csr_generate(device, oc_sec_certs_md_signature_algorithm(),
                                 csr, sizeof(csr));
   if (ret != 0) {
-    oc_send_response_v1(request, OC_STATUS_INTERNAL_SERVER_ERROR, true);
+    oc_send_response_with_callback(request, OC_STATUS_INTERNAL_SERVER_ERROR,
+                                   true);
     return;
   }
 
@@ -287,7 +287,7 @@ csr_resource_get(oc_request_t *request, oc_interface_mask_t iface_mask,
   oc_rep_set_text_string(root, encoding, OC_ENCODING_PEM_STR);
   oc_rep_end_root_object();
 
-  oc_send_response_v1(request, OC_STATUS_OK, true);
+  oc_send_response_with_callback(request, OC_STATUS_OK, true);
 }
 
 void

--- a/security/oc_csr.c
+++ b/security/oc_csr.c
@@ -27,6 +27,7 @@
 #include "oc_certs.h"
 #include "oc_core_res.h"
 #include "oc_uuid.h"
+#include "api/oc_server_api_internal.h"
 #include "security/oc_certs_internal.h"
 #include "security/oc_csr_internal.h"
 #include "security/oc_entropy_internal.h"
@@ -273,7 +274,7 @@ csr_resource_get(oc_request_t *request, oc_interface_mask_t iface_mask,
   int ret = oc_sec_csr_generate(device, oc_sec_certs_md_signature_algorithm(),
                                 csr, sizeof(csr));
   if (ret != 0) {
-    oc_send_response(request, OC_STATUS_INTERNAL_SERVER_ERROR);
+    oc_send_response_v1(request, OC_STATUS_INTERNAL_SERVER_ERROR, true);
     return;
   }
 
@@ -286,7 +287,7 @@ csr_resource_get(oc_request_t *request, oc_interface_mask_t iface_mask,
   oc_rep_set_text_string(root, encoding, OC_ENCODING_PEM_STR);
   oc_rep_end_root_object();
 
-  oc_send_response(request, OC_STATUS_OK);
+  oc_send_response_v1(request, OC_STATUS_OK, true);
 }
 
 void

--- a/security/oc_doxm.c
+++ b/security/oc_doxm.c
@@ -365,7 +365,7 @@ get_doxm(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
     // respond to unicasts immediately
     oc_sec_encode_doxm(device, iface_mask, false);
     // TODO: shrink buffer
-    oc_send_response_v1(request, OC_STATUS_OK, true);
+    oc_send_response_with_callback(request, OC_STATUS_OK, true);
   } break;
   default:
     break;
@@ -699,11 +699,11 @@ post_doxm(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
   if (!oc_sec_decode_doxm(request->request_payload, false,
                           p != NULL ? p->doc : false,
                           request->resource->device)) {
-    oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
+    oc_send_response_with_callback(request, OC_STATUS_BAD_REQUEST, true);
     return;
   }
 
-  oc_send_response_v1(request, OC_STATUS_CHANGED, true);
+  oc_send_response_with_callback(request, OC_STATUS_CHANGED, true);
   oc_sec_dump_doxm(request->resource->device);
 }
 

--- a/security/oc_doxm.c
+++ b/security/oc_doxm.c
@@ -20,6 +20,7 @@
 
 #include "oc_doxm_internal.h"
 #include "api/oc_rep_internal.h"
+#include "api/oc_server_api_internal.h"
 #include "oc_acl_internal.h"
 #include "oc_api.h"
 #include "oc_core_res.h"
@@ -27,10 +28,6 @@
 #include "oc_store.h"
 #include "oc_tls_internal.h"
 #include "port/oc_assert.h"
-
-#ifdef OC_SERVER
-#include "api/oc_server_api_internal.h"
-#endif
 
 #include <assert.h>
 #include <stdbool.h>
@@ -307,13 +304,10 @@ get_doxm(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
          (g_doxm[device].owned == 0 && strncasecmp(q, "true", 4) == 0))) {
       if (request->origin != NULL &&
           (request->origin->flags & MULTICAST) == 0) {
-        oc_status_t code = OC_STATUS_BAD_REQUEST;
-#ifdef OC_SERVER
-        oc_trigger_send_response_callback(request, code);
-#endif
         // reply with BAD_REQUEST if ownership status does not match query
         // of unicast request
-        request->response->response_buffer->code = oc_status_code(code);
+        oc_send_response_internal(request, OC_STATUS_BAD_REQUEST,
+                                  APPLICATION_VND_OCF_CBOR, 0, true);
         return;
       }
       // ignore if ownership status does not match query of multicast request
@@ -355,11 +349,8 @@ get_doxm(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
       doxm_response_data_t *rd =
         add_doxm_response_for_device(device, iface_mask);
       if (rd == NULL) {
-        oc_status_t code = OC_STATUS_INTERNAL_SERVER_ERROR;
-#ifdef OC_SERVER
-        oc_trigger_send_response_callback(request, code);
-#endif
-        request->response->response_buffer->code = oc_status_code(code);
+        oc_send_response_internal(request, OC_STATUS_INTERNAL_SERVER_ERROR,
+                                  APPLICATION_VND_OCF_CBOR, 0, true);
         return;
       }
 

--- a/security/oc_doxm.c
+++ b/security/oc_doxm.c
@@ -28,6 +28,10 @@
 #include "oc_tls_internal.h"
 #include "port/oc_assert.h"
 
+#ifdef OC_SERVER
+#include "api/oc_server_api_internal.h"
+#endif
+
 #include <assert.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -303,10 +307,13 @@ get_doxm(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
          (g_doxm[device].owned == 0 && strncasecmp(q, "true", 4) == 0))) {
       if (request->origin != NULL &&
           (request->origin->flags & MULTICAST) == 0) {
+        oc_status_t code = OC_STATUS_BAD_REQUEST;
+#ifdef OC_SERVER
+        oc_trigger_send_response_callback(request, code);
+#endif
         // reply with BAD_REQUEST if ownership status does not match query
         // of unicast request
-        request->response->response_buffer->code =
-          oc_status_code(OC_STATUS_BAD_REQUEST);
+        request->response->response_buffer->code = oc_status_code(code);
         return;
       }
       // ignore if ownership status does not match query of multicast request
@@ -348,8 +355,11 @@ get_doxm(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
       doxm_response_data_t *rd =
         add_doxm_response_for_device(device, iface_mask);
       if (rd == NULL) {
-        request->response->response_buffer->code =
-          oc_status_code(OC_STATUS_INTERNAL_SERVER_ERROR);
+        oc_status_t code = OC_STATUS_INTERNAL_SERVER_ERROR;
+#ifdef OC_SERVER
+        oc_trigger_send_response_callback(request, code);
+#endif
+        request->response->response_buffer->code = oc_status_code(code);
         return;
       }
 

--- a/security/oc_doxm.c
+++ b/security/oc_doxm.c
@@ -365,7 +365,7 @@ get_doxm(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
     // respond to unicasts immediately
     oc_sec_encode_doxm(device, iface_mask, false);
     // TODO: shrink buffer
-    oc_send_response(request, OC_STATUS_OK);
+    oc_send_response_v1(request, OC_STATUS_OK, true);
   } break;
   default:
     break;
@@ -699,11 +699,11 @@ post_doxm(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
   if (!oc_sec_decode_doxm(request->request_payload, false,
                           p != NULL ? p->doc : false,
                           request->resource->device)) {
-    oc_send_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
     return;
   }
 
-  oc_send_response(request, OC_STATUS_CHANGED);
+  oc_send_response_v1(request, OC_STATUS_CHANGED, true);
   oc_sec_dump_doxm(request->resource->device);
 }
 

--- a/security/oc_pstat.c
+++ b/security/oc_pstat.c
@@ -21,6 +21,7 @@
 #include "oc_pstat.h"
 #include "api/oc_buffer_internal.h"
 #include "api/oc_main.h"
+#include "api/oc_server_api_internal.h"
 #include "messaging/coap/coap_internal.h"
 #include "messaging/coap/observe.h"
 #include "oc_acl_internal.h"
@@ -613,7 +614,7 @@ get_pstat(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
   case OC_IF_RW:
   case OC_IF_BASELINE: {
     oc_sec_encode_pstat(request->resource->device, iface_mask, false);
-    oc_send_response(request, OC_STATUS_OK);
+    oc_send_response_v1(request, OC_STATUS_OK, true);
   } break;
   default:
     break;
@@ -628,11 +629,11 @@ post_pstat(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
   size_t device = request->resource->device;
   if (oc_sec_decode_pstat(request->request_payload, false, device)) {
     request->response->response_buffer->response_length = 0;
-    oc_send_response(request, OC_STATUS_CHANGED);
+    oc_send_response_v1(request, OC_STATUS_CHANGED, true);
     request->response->response_buffer->response_length = 0;
     oc_sec_dump_pstat(device);
   } else {
-    oc_send_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
   }
 }
 

--- a/security/oc_pstat.c
+++ b/security/oc_pstat.c
@@ -21,7 +21,6 @@
 #include "oc_pstat.h"
 #include "api/oc_buffer_internal.h"
 #include "api/oc_main.h"
-#include "api/oc_server_api_internal.h"
 #include "messaging/coap/coap_internal.h"
 #include "messaging/coap/observe.h"
 #include "oc_acl_internal.h"
@@ -614,7 +613,7 @@ get_pstat(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
   case OC_IF_RW:
   case OC_IF_BASELINE: {
     oc_sec_encode_pstat(request->resource->device, iface_mask, false);
-    oc_send_response_v1(request, OC_STATUS_OK, true);
+    oc_send_response_with_callback(request, OC_STATUS_OK, true);
   } break;
   default:
     break;
@@ -629,11 +628,11 @@ post_pstat(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
   size_t device = request->resource->device;
   if (oc_sec_decode_pstat(request->request_payload, false, device)) {
     request->response->response_buffer->response_length = 0;
-    oc_send_response_v1(request, OC_STATUS_CHANGED, true);
+    oc_send_response_with_callback(request, OC_STATUS_CHANGED, true);
     request->response->response_buffer->response_length = 0;
     oc_sec_dump_pstat(device);
   } else {
-    oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
+    oc_send_response_with_callback(request, OC_STATUS_BAD_REQUEST, true);
   }
 }
 

--- a/security/oc_sdi.c
+++ b/security/oc_sdi.c
@@ -20,7 +20,6 @@
 
 #include "api/oc_core_res_internal.h"
 #include "api/oc_rep_internal.h"
-#include "api/oc_server_api_internal.h"
 #include "oc_sdi_internal.h"
 #include "oc_api.h"
 #include "oc_core_res.h"
@@ -289,10 +288,11 @@ sdi_resource_get(oc_request_t *request, oc_interface_mask_t iface_mask,
   int err = oc_sec_sdi_encode(request->resource->device, iface_mask);
   if (err != CborNoError) {
     OC_ERR("oc_sdi: cannot encode GET request data(error=%d)", err);
-    oc_send_response_v1(request, OC_STATUS_INTERNAL_SERVER_ERROR, true);
+    oc_send_response_with_callback(request, OC_STATUS_INTERNAL_SERVER_ERROR,
+                                   true);
     return;
   }
-  oc_send_response_v1(request, OC_STATUS_OK, true);
+  oc_send_response_with_callback(request, OC_STATUS_OK, true);
 }
 
 static void
@@ -303,10 +303,10 @@ sdi_resource_post(oc_request_t *request, oc_interface_mask_t iface_mask,
   (void)data;
   size_t device = request->resource->device;
   if (!oc_sec_sdi_decode(device, request->request_payload, false)) {
-    oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
+    oc_send_response_with_callback(request, OC_STATUS_BAD_REQUEST, true);
     return;
   }
-  oc_send_response_v1(request, OC_STATUS_CHANGED, true);
+  oc_send_response_with_callback(request, OC_STATUS_CHANGED, true);
   oc_sec_dump_sdi(device);
 }
 

--- a/security/oc_sdi.c
+++ b/security/oc_sdi.c
@@ -20,6 +20,7 @@
 
 #include "api/oc_core_res_internal.h"
 #include "api/oc_rep_internal.h"
+#include "api/oc_server_api_internal.h"
 #include "oc_sdi_internal.h"
 #include "oc_api.h"
 #include "oc_core_res.h"
@@ -288,10 +289,10 @@ sdi_resource_get(oc_request_t *request, oc_interface_mask_t iface_mask,
   int err = oc_sec_sdi_encode(request->resource->device, iface_mask);
   if (err != CborNoError) {
     OC_ERR("oc_sdi: cannot encode GET request data(error=%d)", err);
-    oc_send_response(request, OC_STATUS_INTERNAL_SERVER_ERROR);
+    oc_send_response_v1(request, OC_STATUS_INTERNAL_SERVER_ERROR, true);
     return;
   }
-  oc_send_response(request, OC_STATUS_OK);
+  oc_send_response_v1(request, OC_STATUS_OK, true);
 }
 
 static void
@@ -302,10 +303,10 @@ sdi_resource_post(oc_request_t *request, oc_interface_mask_t iface_mask,
   (void)data;
   size_t device = request->resource->device;
   if (!oc_sec_sdi_decode(device, request->request_payload, false)) {
-    oc_send_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
     return;
   }
-  oc_send_response(request, OC_STATUS_CHANGED);
+  oc_send_response_v1(request, OC_STATUS_CHANGED, true);
   oc_sec_dump_sdi(device);
 }
 

--- a/security/oc_sp.c
+++ b/security/oc_sp.c
@@ -24,6 +24,7 @@
 #include "oc_pki.h"
 #include "oc_pstat.h"
 #include "oc_store.h"
+#include "api/oc_server_api_internal.h"
 #include "port/oc_assert.h"
 #include "util/oc_macros.h"
 
@@ -236,7 +237,7 @@ get_sp(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
   case OC_IF_RW:
   case OC_IF_BASELINE: {
     oc_sec_encode_sp(request->resource->device, iface_mask, false);
-    oc_send_response(request, OC_STATUS_OK);
+    oc_send_response_v1(request, OC_STATUS_OK, true);
   } break;
   default:
     break;
@@ -250,11 +251,11 @@ post_sp(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
   (void)data;
   size_t device = request->resource->device;
   if (oc_sec_decode_sp(request->request_payload, device)) {
-    oc_send_response(request, OC_STATUS_CHANGED);
+    oc_send_response_v1(request, OC_STATUS_CHANGED, true);
     request->response->response_buffer->response_length = 0;
     oc_sec_dump_sp(device);
   } else {
-    oc_send_response(request, OC_STATUS_BAD_REQUEST);
+    oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
   }
 }
 

--- a/security/oc_sp.c
+++ b/security/oc_sp.c
@@ -24,7 +24,6 @@
 #include "oc_pki.h"
 #include "oc_pstat.h"
 #include "oc_store.h"
-#include "api/oc_server_api_internal.h"
 #include "port/oc_assert.h"
 #include "util/oc_macros.h"
 
@@ -237,7 +236,7 @@ get_sp(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
   case OC_IF_RW:
   case OC_IF_BASELINE: {
     oc_sec_encode_sp(request->resource->device, iface_mask, false);
-    oc_send_response_v1(request, OC_STATUS_OK, true);
+    oc_send_response_with_callback(request, OC_STATUS_OK, true);
   } break;
   default:
     break;
@@ -251,11 +250,11 @@ post_sp(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
   (void)data;
   size_t device = request->resource->device;
   if (oc_sec_decode_sp(request->request_payload, device)) {
-    oc_send_response_v1(request, OC_STATUS_CHANGED, true);
+    oc_send_response_with_callback(request, OC_STATUS_CHANGED, true);
     request->response->response_buffer->response_length = 0;
     oc_sec_dump_sp(device);
   } else {
-    oc_send_response_v1(request, OC_STATUS_BAD_REQUEST, true);
+    oc_send_response_with_callback(request, OC_STATUS_BAD_REQUEST, true);
   }
 }
 


### PR DESCRIPTION
In cases of errors, iotivity-lite fails to populate the body. With the implementation of this callback function, you can customize and populate/replace the body as per your requirements.