### PR TITLE
Fix versioning scheme in the Publish docker images job

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -75,9 +75,9 @@ jobs:
             type=ref,event=pr,prefix=vnext-pr,suffix=-{{sha}}
             type=ref,event=pr,prefix=vnext-pr
             type=ref,enable={{is_default_branch}},event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=pep440,pattern={{version}}
+            type=pep440,pattern={{major}}.{{minor}}
+            type=pep440,pattern={{major}}
 
       - name: Build and publish cloud-server docker images
         uses: docker/build-push-action@v4


### PR DESCRIPTION
Switch to pep440 versioning scheme in the helper Github action docker/metadata-action@v4. It seems that the IoTivity versioning format "X.Y.Z.R" (where "X.Y.Z" is the OCF Specification Version and "R" is the version of the C library) is no longer recognized by the action as matching the format of semantic versioning.