### PR TITLE
plgd-time: fix closing of session on fetch

### DIFF
--- a/api/oc_ri.c
+++ b/api/oc_ri.c
@@ -1658,14 +1658,6 @@ oc_ri_remove_client_cb(void *data)
   return OC_EVENT_DONE;
 }
 
-bool
-oc_ri_client_cb_terminated(oc_status_t code)
-{
-  return code == OC_PING_TIMEOUT || code == OC_REQUEST_TIMEOUT ||
-         code == OC_CONNECTION_CLOSED || code == OC_TRANSACTION_TIMEOUT ||
-         code == OC_CANCELLED;
-}
-
 static void
 notify_client_cb_with_code(oc_client_cb_t *cb, oc_status_t code)
 {

--- a/api/plgd/plgd_time.c
+++ b/api/plgd/plgd_time.c
@@ -711,8 +711,7 @@ dev_time_on_fetch(oc_client_response_t *data)
   OC_DBG("plgd-time: on_fetch time=%d time=%u", (int)code, (unsigned)time);
   fp->on_fetch(code, time, fp->on_fetch_data);
 #if defined(OC_TCP) || defined(OC_SECURITY)
-  // session is closed automatically on timeout, close or cancel
-  if (fp->close_peer_after_fetch && !oc_ri_client_cb_terminated(code)) {
+  if (fp->close_peer_after_fetch && (code != OC_CONNECTION_CLOSED)) {
     OC_DBG("plgd-time: close fetch time session");
     oc_close_session(data->endpoint);
   }

--- a/api/unittest/plgdtimetest.cpp
+++ b/api/unittest/plgdtimetest.cpp
@@ -601,7 +601,7 @@ TEST_F(TestPlgdTimeWithServer, FetchTimeFail)
 
   auto fetch_handler = [](oc_status_t code, oc_clock_time_t, void *data) {
     OC_DBG("fetch time handler timeout");
-    EXPECT_TRUE(oc_ri_client_cb_terminated(code));
+    EXPECT_TRUE(code == OC_CONNECTION_CLOSED || code == OC_REQUEST_TIMEOUT);
     *(static_cast<bool *>(data)) = true;
     oc::TestDevice::Terminate();
   };


### PR DESCRIPTION
Only OC_CONNECTION_CLOSED closes the session and invokes the session handler. Timeout status code just invoke and remove the client cb, the session is kept intact.