### PR TITLE
Linux: configure listening ports of a device

### DIFF
--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -151,6 +151,7 @@ jobs:
               -D OC_CLOUD_ENABLED=ON
               -D OC_COLLECTIONS_IF_CREATE_ENABLED=ON
               -D OC_RESOURCE_ACCESS_IN_RFOTM_ENABLED=ON
+              -D OC_DEBUG_ENABLED=ON
               -G Ninja
               -D CMAKE_MAKE_PROGRAM=${ninja_program}
             RESULT_VARIABLE result

--- a/.github/workflows/plgd-hub-test-with-cfg.yml
+++ b/.github/workflows/plgd-hub-test-with-cfg.yml
@@ -96,7 +96,7 @@ jobs:
         if: ${{ inputs.coverage }}
         id: coverage
         run: |
-          SUFFIX=`echo "-DCMAKE_BUILD_TYPE=${{ inputs.build_type }} ${{ inputs.build_args }} ${{ inputs.docker_args }} ${{ inputs.hub_args }} ${{ inputs.name }} -DBUILD_TESTING=ON" | sha1sum | cut -f 1 -d ' '`
+          SUFFIX=`echo "-DCMAKE_BUILD_TYPE=${{ inputs.build_type }} ${{ inputs.build_args }} ${{ inputs.args }} ${{ inputs.docker_args }} ${{ inputs.hub_args }} ${{ inputs.name }} -DBUILD_TESTING=ON" | sha1sum | cut -f 1 -d ' '`
           echo "filename=coverage-plgd-hub-${SUFFIX}.json" >> $GITHUB_OUTPUT
 
       - name: Gather coverage data

--- a/.github/workflows/plgd-hub-tests.yml
+++ b/.github/workflows/plgd-hub-tests.yml
@@ -47,7 +47,7 @@ jobs:
           - name: cloud-server-simulate-tpm-asan
             build_args: "-DOC_ASAN_ENABLED=ON"
             args: "--simulate-tpm"
-            
+
           - name: cloud-server-time-2000-01-01
             build_args: ""
             docker_args: '-e FAKETIME="@2000-01-01 11:12:13"'
@@ -119,6 +119,12 @@ jobs:
             build_args: "-DOC_DISCOVERY_RESOURCE_OBSERVABLE_ENABLED=ON -DOC_REPRESENTATION_REALLOC_ENCODING_ENABLED=ON -DOC_ASAN_ENABLED=ON"
           - name: cloud-server-discovery-resource-observable-rep-realloc-tsan
             build_args: "-DOC_DISCOVERY_RESOURCE_OBSERVABLE_ENABLED=ON -DOC_REPRESENTATION_REALLOC_ENCODING_ENABLED=ON -DOC_TSAN_ENABLED=ON"
+
+          # ports
+          - name: cloud-server-tcp-disabled
+            args: "--udp-port 61234 --udp-port4 61234 --dtls-port 61235 --dtls-port4 61235 --tcp-port -1 --tcp-port4 -1 --tls-port -1 --tls-port4 -1"
+          - name: cloud-server-ipv6-disabled
+            args: "--udp-port -1 --udp-port4 61234 --dtls-port -1 --dtls-port4 61235 --tcp-port -1 --tcp-port4 61234 --tls-port -1 --tls-port4 61235"
 
           - name: dtls-cloud-server
             build_args: ""

--- a/.github/workflows/sonar-cloud-analysis.yml
+++ b/.github/workflows/sonar-cloud-analysis.yml
@@ -60,6 +60,7 @@ jobs:
       build_type: Debug
       coverage: true
       hub_args: ${{ matrix.hub_args }}
+      args: ${{ matrix.args }}
 
   sonar-cloud-scan:
     name: Sonar Cloud scan

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,6 +376,10 @@ if(MINGW)
     if(BUILD_MBEDTLS)
         list(APPEND MBEDTLS_COMPILE_DEFINITIONS "WINVER=0x0600" "_WIN32_WINNT=0x0600")
     endif()
+
+    # force the use mingw_printf because the default doesn't support '%zu'
+    list(APPEND PRIVATE_COMPILE_DEFINITIONS "__USE_MINGW_ANSI_STDIO=1")
+    list(APPEND TEST_COMPILE_DEFINITIONS "__USE_MINGW_ANSI_STDIO=1")
 endif()
 
 if(MSVC)

--- a/api/oc_core_res_internal.h
+++ b/api/oc_core_res_internal.h
@@ -19,9 +19,11 @@
 #ifndef OC_CORE_RES_INTERNAL_H
 #define OC_CORE_RES_INTERNAL_H
 
+#include "oc_api.h"
 #include "oc_core_res.h"
 #include "oc_helpers.h"
 #include "oc_ri.h"
+#include "port/oc_connectivity_internal.h"
 #include "util/oc_compiler.h"
 
 #include <cbor.h>
@@ -52,25 +54,13 @@ void oc_core_shutdown(void);
 oc_platform_info_t *oc_core_init_platform(const char *mfg_name,
                                           oc_core_init_platform_cb_t init_cb,
                                           void *data) OC_NONNULL(1);
-
 /**
- * @brief Add new devide to the platform
+ * @brief Add new device to the platform
  *
- * @param uri the uri of the device (cannot be NULL)
- * @param rt the device type of the device (cannot be NULL)
- * @param name the friendly name (cannot be NULL)
- * @param spec_version specification version (cannot be NULL)
- * @param data_model_version  data model version (cannot be NULL)
- * @param add_device_cb callback
- * @param data supplied user data
+ * @param cfg device configuration
  * @return oc_device_info_t* the device information
  */
-oc_device_info_t *oc_core_add_new_device(const char *uri, const char *rt,
-                                         const char *name,
-                                         const char *spec_version,
-                                         const char *data_model_version,
-                                         oc_core_add_device_cb_t add_device_cb,
-                                         void *data) OC_NONNULL(1, 2, 3, 4, 5);
+oc_device_info_t *oc_core_add_new_device(oc_add_new_device_t cfg);
 
 /**
  * @brief encode the interfaces with the cbor (payload) encoder

--- a/api/oc_server_api.c
+++ b/api/oc_server_api.c
@@ -53,11 +53,23 @@ oc_add_device(const char *uri, const char *rt, const char *name,
               const char *spec_version, const char *data_model_version,
               oc_add_device_cb_t add_device_cb, void *data)
 {
-  if (!oc_core_add_new_device(uri, rt, name, spec_version, data_model_version,
-                              add_device_cb, data)) {
-    return -1;
-  }
-  return 0;
+  oc_add_new_device_t cfg = {
+    .uri = uri,
+    .rt = rt,
+    .name = name,
+    .spec_version = spec_version,
+    .data_model_version = data_model_version,
+    .add_device_cb = add_device_cb,
+    .add_device_cb_data = data,
+  };
+  memset(&cfg.ports, 0, sizeof(cfg.ports));
+  return oc_add_device_v1(cfg);
+}
+
+int
+oc_add_device_v1(oc_add_new_device_t cfg)
+{
+  return oc_core_add_new_device(cfg) == NULL ? -1 : 0;
 }
 
 int

--- a/api/unittest/coreresourcetest.cpp
+++ b/api/unittest/coreresourcetest.cpp
@@ -78,9 +78,13 @@ TEST_F(TestCoreResource, CoreInitPlatform_P)
 
 TEST_F(TestCoreResource, CoreDevice_P)
 {
-  oc_device_info_t *addcoredevice = oc_core_add_new_device(
-    kDeviceURI.c_str(), kDeviceType.c_str(), kDeviceName.c_str(),
-    kOCFSpecVersion.c_str(), kOCFDataModelVersion.c_str(), nullptr, nullptr);
+  oc_add_new_device_t cfg{};
+  cfg.name = kDeviceName.c_str();
+  cfg.uri = kDeviceURI.c_str();
+  cfg.rt = kDeviceType.c_str();
+  cfg.spec_version = kOCFSpecVersion.c_str();
+  cfg.data_model_version = kOCFDataModelVersion.c_str();
+  oc_device_info_t *addcoredevice = oc_core_add_new_device(cfg);
   ASSERT_NE(addcoredevice, nullptr);
   size_t numcoredevice = oc_core_get_num_devices();
   EXPECT_EQ(1, numcoredevice);

--- a/port/android/ipadapter.c
+++ b/port/android/ipadapter.c
@@ -1337,8 +1337,10 @@ connectivity_ipv4_init(ip_context_t *dev)
 #endif
 
 int
-oc_connectivity_init(size_t device)
+oc_connectivity_init(size_t device, oc_connectivity_ports_t ports)
 {
+  // TODO set ports
+  (void)ports;
   OC_DBG("Initializing connectivity for device %zd", device);
 
   ip_context_t *dev = (ip_context_t *)oc_memb_alloc(&ip_context_s);

--- a/port/arduino/adapter/ipadapter.c
+++ b/port/arduino/adapter/ipadapter.c
@@ -179,8 +179,10 @@ oc_send_discovery_request(oc_message_t *message)
 #endif /* OC_CLIENT */
 
 int
-oc_connectivity_init(size_t device)
+oc_connectivity_init(size_t device, oc_connectivity_ports_t ports)
 {
+  // TODO set ports
+  (void)ports;
   OC_DBG("Initializing IPv4 connectivity for device %d", device);
   ip_context_t *dev = (ip_context_t *)oc_memb_alloc(&ip_context_s);
   if (!dev) {

--- a/port/esp32/adapter/src/ipadapter.c
+++ b/port/esp32/adapter/src/ipadapter.c
@@ -1333,8 +1333,10 @@ got_ip6_event_handler(void *arg, esp_event_base_t event_base, int32_t event_id,
 }
 
 int
-oc_connectivity_init(size_t device)
+oc_connectivity_init(size_t device, oc_connectivity_ports_t ports)
 {
+  // TODO set ports
+  (void)ports;
   OC_DBG("Initializing connectivity for device %zd", device);
 
   ip_context_t *dev = (ip_context_t *)oc_memb_alloc(&ip_context_s);

--- a/port/linux/ipcontext.h
+++ b/port/linux/ipcontext.h
@@ -20,6 +20,7 @@
 #define IPCONTEXT_H
 
 #include "oc_endpoint.h"
+#include "socklistener.h"
 #include "util/oc_atomic.h"
 #ifdef OC_TCP
 #include "tcpcontext.h"
@@ -49,26 +50,16 @@ typedef struct ip_context_t
 {
   struct ip_context_t *next;
   OC_LIST_STRUCT(eps); /// < not thread-safe, must be used only from main thread
-  struct sockaddr_storage mcast;
-  struct sockaddr_storage server;
   int mcast_sock;
-  int server_sock;
-  uint16_t port;
+  oc_sock_listener_t server;
 #ifdef OC_SECURITY
-  struct sockaddr_storage secure;
-  int secure_sock;
-  uint16_t dtls_port;
+  oc_sock_listener_t secure;
 #endif /* OC_SECURITY */
 #ifdef OC_IPV4
-  struct sockaddr_storage mcast4;
-  struct sockaddr_storage server4;
   int mcast4_sock;
-  int server4_sock;
-  uint16_t port4;
+  oc_sock_listener_t server4;
 #ifdef OC_SECURITY
-  struct sockaddr_storage secure4;
-  int secure4_sock;
-  uint16_t dtls4_port;
+  oc_sock_listener_t secure4;
 #endif /* OC_SECURITY */
 #endif /* OC_IPV4 */
 #ifdef OC_TCP

--- a/port/linux/socklistener.c
+++ b/port/linux/socklistener.c
@@ -1,0 +1,72 @@
+/****************************************************************************
+ *
+ * Copyright (c) 2023 plgd.dev s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"),
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************/
+
+#include "port/oc_log_internal.h"
+#include "socklistener.h"
+
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <errno.h>
+
+void
+oc_sock_listener_close(oc_sock_listener_t *server)
+{
+  if (server->sock >= 0) {
+    close(server->sock);
+  }
+  server->sock = -1;
+}
+
+void
+oc_sock_listener_fd_set(const oc_sock_listener_t *server, fd_set *rfds)
+{
+  if (server->sock >= 0) {
+    FD_SET(server->sock, rfds);
+  }
+}
+
+bool
+oc_sock_listener_fd_isset(const oc_sock_listener_t *server, const fd_set *rfds)
+{
+  return (server->sock >= 0 && FD_ISSET(server->sock, rfds));
+}
+
+int
+oc_sock_listener_get_port(const oc_sock_listener_t *server)
+{
+  if (server->sock < 0) {
+    return -1;
+  }
+  struct sockaddr_storage sockaddr;
+  socklen_t socklen = sizeof(sockaddr);
+  if (getsockname(server->sock, (struct sockaddr *)&sockaddr, &socklen) == -1) {
+    OC_ERR("obtaining socket information %d", errno);
+    return -1;
+  }
+
+  switch (sockaddr.ss_family) {
+#ifdef OC_IPV4
+  case AF_INET:
+    return (int)ntohs(((struct sockaddr_in *)&sockaddr)->sin_port);
+#endif /* OC_IPV4 */
+  case AF_INET6:
+    return (int)ntohs(((struct sockaddr_in6 *)&sockaddr)->sin6_port);
+  default:
+    return -1;
+  }
+}

--- a/port/linux/socklistener.h
+++ b/port/linux/socklistener.h
@@ -1,0 +1,69 @@
+/****************************************************************************
+ *
+ * Copyright (c) 2023 plgd.dev s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"),
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifndef SOCKLISTENER_H
+#define SOCKLISTENER_H
+
+#include "util/oc_compiler.h"
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include <sys/socket.h>
+#include <sys/select.h>
+
+typedef struct oc_sock_listener_t
+{
+  int sock;
+} oc_sock_listener_t;
+
+/**
+ * @brief Close socket listener
+ *
+ * @param server socket listener
+ */
+void oc_sock_listener_close(oc_sock_listener_t *server) OC_NONNULL();
+
+/**
+ * @brief Set socket listener to fd_set
+ *
+ * @param server socket listener
+ * @param rfds set of file descriptors
+ */
+void oc_sock_listener_fd_set(const oc_sock_listener_t *server, fd_set *rfds)
+  OC_NONNULL();
+
+/**
+ * @brief Check if socket listener is set in fd_set
+ *
+ * @param server socket listener
+ * @param rfds set of file descriptors
+ * @return true if socket listener is set in fd_set
+ */
+bool oc_sock_listener_fd_isset(const oc_sock_listener_t *server,
+                               const fd_set *rfds) OC_NONNULL();
+
+/**
+ * @brief Get port of socket listener
+ *
+ * @param server socket listener
+ * @return port of socket listener
+ */
+int oc_sock_listener_get_port(const oc_sock_listener_t *server) OC_NONNULL();
+
+#endif /* SOCKLISTENER_H */

--- a/port/linux/tcpadapter.h
+++ b/port/linux/tcpadapter.h
@@ -19,6 +19,7 @@
 #ifndef TCP_ADAPTER_H
 #define TCP_ADAPTER_H
 
+#include "oc_api.h"
 #include "ipcontext.h"
 #include "tcpcontext.h"
 
@@ -35,7 +36,7 @@ extern "C" {
  * @return 0 on success
  * @return -1 on error
  */
-int tcp_connectivity_init(ip_context_t *dev);
+int tcp_connectivity_init(ip_context_t *dev, oc_connectivity_ports_t ports);
 
 /**
  * @brief Deinitialize all TCP members of the device network context.

--- a/port/linux/tcpcontext.h
+++ b/port/linux/tcpcontext.h
@@ -19,6 +19,8 @@
 #ifndef TCPCONTEXT_H
 #define TCPCONTEXT_H
 
+#include "socklistener.h"
+
 #include <pthread.h>
 #include <sys/select.h>
 #include <sys/socket.h>
@@ -32,22 +34,14 @@ extern "C" {
 
 typedef struct tcp_context_t
 {
-  struct sockaddr_storage server;
-  int server_sock;
-  uint16_t port;
+  oc_sock_listener_t server;
 #ifdef OC_SECURITY
-  struct sockaddr_storage secure;
-  int secure_sock;
-  uint16_t tls_port;
+  oc_sock_listener_t secure;
 #endif /* OC_SECURITY */
 #ifdef OC_IPV4
-  struct sockaddr_storage server4;
-  int server4_sock;
-  uint16_t port4;
+  oc_sock_listener_t server4;
 #ifdef OC_SECURITY
-  struct sockaddr_storage secure4;
-  int secure4_sock;
-  uint16_t tls4_port;
+  oc_sock_listener_t secure4;
 #endif /* OC_SECURITY */
 #endif /* OC_IPV4 */
   int connect_pipe[2];

--- a/port/linux/tcpsession.c
+++ b/port/linux/tcpsession.c
@@ -320,11 +320,11 @@ static adapter_receive_state_t
 tcp_receive_server_message_locked(ip_context_t *dev, fd_set *fds,
                                   oc_message_t *message)
 {
-  if (FD_ISSET(dev->tcp.server_sock, fds)) {
-    OC_DBG("tcp receive server_sock(fd=%d)", dev->tcp.server_sock);
-    FD_CLR(dev->tcp.server_sock, fds);
+  if (oc_sock_listener_fd_isset(&dev->tcp.server, fds)) {
+    OC_DBG("tcp receive server_sock(fd=%d)", dev->tcp.server.sock);
+    FD_CLR(dev->tcp.server.sock, fds);
     message->endpoint.flags = IPV6 | TCP | ACCEPTED;
-    if (accept_new_session_locked(dev, dev->tcp.server_sock, fds,
+    if (accept_new_session_locked(dev, dev->tcp.server.sock, fds,
                                   &message->endpoint) < 0) {
       OC_ERR("accept new session fail");
       return ADAPTER_STATUS_ERROR;
@@ -332,11 +332,11 @@ tcp_receive_server_message_locked(ip_context_t *dev, fd_set *fds,
     return ADAPTER_STATUS_ACCEPT;
   }
 #ifdef OC_SECURITY
-  if (FD_ISSET(dev->tcp.secure_sock, fds)) {
-    OC_DBG("tcp receive secure_sock(fd=%d)", dev->tcp.secure_sock);
-    FD_CLR(dev->tcp.secure_sock, fds);
+  if (oc_sock_listener_fd_isset(&dev->tcp.secure, fds)) {
+    OC_DBG("tcp receive secure_sock(fd=%d)", dev->tcp.secure.sock);
+    FD_CLR(dev->tcp.secure.sock, fds);
     message->endpoint.flags = IPV6 | SECURED | TCP | ACCEPTED;
-    if (accept_new_session_locked(dev, dev->tcp.secure_sock, fds,
+    if (accept_new_session_locked(dev, dev->tcp.secure.sock, fds,
                                   &message->endpoint) < 0) {
       OC_ERR("accept new session fail");
       return ADAPTER_STATUS_ERROR;
@@ -345,11 +345,11 @@ tcp_receive_server_message_locked(ip_context_t *dev, fd_set *fds,
   }
 #endif /* OC_SECURITY */
 #ifdef OC_IPV4
-  if (FD_ISSET(dev->tcp.server4_sock, fds)) {
-    OC_DBG("tcp receive server4_sock(fd=%d)", dev->tcp.server4_sock);
-    FD_CLR(dev->tcp.server4_sock, fds);
+  if (oc_sock_listener_fd_isset(&dev->tcp.server4, fds)) {
+    OC_DBG("tcp receive server4_sock(fd=%d)", dev->tcp.server4.sock);
+    FD_CLR(dev->tcp.server4.sock, fds);
     message->endpoint.flags = IPV4 | TCP | ACCEPTED;
-    if (accept_new_session_locked(dev, dev->tcp.server4_sock, fds,
+    if (accept_new_session_locked(dev, dev->tcp.server4.sock, fds,
                                   &message->endpoint) < 0) {
       OC_ERR("accept new session fail");
       return ADAPTER_STATUS_ERROR;
@@ -357,11 +357,11 @@ tcp_receive_server_message_locked(ip_context_t *dev, fd_set *fds,
     return ADAPTER_STATUS_ACCEPT;
   }
 #ifdef OC_SECURITY
-  if (FD_ISSET(dev->tcp.secure4_sock, fds)) {
-    OC_DBG("tcp receive secure4_sock(fd=%d)", dev->tcp.secure4_sock);
-    FD_CLR(dev->tcp.secure4_sock, fds);
+  if (oc_sock_listener_fd_isset(&dev->tcp.secure4, fds)) {
+    OC_DBG("tcp receive secure4_sock(fd=%d)", dev->tcp.secure4.sock);
+    FD_CLR(dev->tcp.secure4.sock, fds);
     message->endpoint.flags = IPV4 | SECURED | TCP | ACCEPTED;
-    if (accept_new_session_locked(dev, dev->tcp.secure4_sock, fds,
+    if (accept_new_session_locked(dev, dev->tcp.secure4.sock, fds,
                                   &message->endpoint) < 0) {
       OC_ERR("accept new session fail");
       return ADAPTER_STATUS_ERROR;

--- a/port/oc_connectivity.h
+++ b/port/oc_connectivity.h
@@ -145,21 +145,6 @@ typedef struct oc_message_s
 int oc_send_buffer(oc_message_t *message);
 
 /**
- * @brief initialize the connectivity (e.g. open sockets) for the device
- *
- * @param device the device index
- * @return int 0 = success
- */
-int oc_connectivity_init(size_t device);
-
-/**
- * @brief shut down the connectivity for device at device index
- *
- * @param device the device index
- */
-void oc_connectivity_shutdown(size_t device);
-
-/**
  * @brief send discovery request
  *
  * @param message the message

--- a/port/oc_connectivity_internal.h
+++ b/port/oc_connectivity_internal.h
@@ -20,6 +20,7 @@
 #define OC_PORT_CONNECTIVITY_INTERNAL_H
 
 #include "oc_config.h"
+#include "oc_api.h"
 #include "oc_endpoint.h"
 #include "oc_network_events.h"
 #include "oc_session_events.h"
@@ -27,12 +28,29 @@
 #include "util/oc_features.h"
 #include <limits.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 #define OC_SEND_MESSAGE_QUEUED INT_MAX
+
+/**
+ * @brief initialize the connectivity (e.g. open sockets) for the device
+ *
+ * @param device the device index
+ * @param ports the ports to listen on
+ * @return int 0 = success
+ */
+int oc_connectivity_init(size_t device, oc_connectivity_ports_t ports);
+
+/**
+ * @brief shut down the connectivity for device at device index
+ *
+ * @param device the device index
+ */
+void oc_connectivity_shutdown(size_t device);
 
 /**
  * @brief Send message to endpoint.

--- a/port/openthread/ipadapter.c
+++ b/port/openthread/ipadapter.c
@@ -161,8 +161,10 @@ oc_send_buffer2(oc_message_t *message, bool queue)
 }
 
 int
-oc_connectivity_init(size_t device)
+oc_connectivity_init(size_t device, oc_connectivity_ports_t ports)
 {
+  // TODO set ports
+  (void)ports;
   (void)device;
 
   OC_DBG("Connectivity init");

--- a/port/unittest/connectivitytest.cpp
+++ b/port/unittest/connectivitytest.cpp
@@ -56,9 +56,70 @@ public:
 
 std::atomic<bool> TestConnectivity::is_callback_received{ false };
 
-TEST(TestConnectivity_init, oc_connectivity_init)
+TEST(TestConnectivity_init, oc_connectivity_initDefault)
 {
-  int ret = oc_connectivity_init(g_device);
+  oc_connectivity_ports_t ports;
+  memset(&ports, 0, sizeof(oc_connectivity_ports_t));
+  int ret = oc_connectivity_init(g_device, ports);
+  EXPECT_EQ(0, ret);
+  oc_connectivity_shutdown(g_device);
+}
+
+TEST(TestConnectivity_init, oc_connectivity_initTCPDisabled)
+{
+  oc_connectivity_ports_t ports;
+  memset(&ports, 0, sizeof(oc_connectivity_ports_t));
+#ifdef OC_TCP
+  ports.tcp.flags = OC_CONNECTIVITY_DISABLE_ALL_PORTS;
+#endif /* OC_TCP */
+#if defined(OC_IPV4)
+  ports.udp.port4 = 5683;
+#if defined(OC_SECURITY)
+  ports.udp.secure_port4 = 5684;
+#endif /* OC_SECURITY */
+#endif /* OC_IPV4 */
+  // ipv6
+  ports.udp.port = 15683;
+#if defined(OC_SECURITY)
+  ports.udp.secure_port = 5684;
+#endif /* OC_SECURITY */
+  int ret = oc_connectivity_init(g_device, ports);
+  EXPECT_EQ(0, ret);
+  oc_connectivity_shutdown(g_device);
+}
+
+TEST(TestConnectivity_init, oc_connectivity_initUDPDisabled)
+{
+  oc_connectivity_ports_t ports;
+  memset(&ports, 0, sizeof(oc_connectivity_ports_t));
+  ports.udp.flags = OC_CONNECTIVITY_DISABLE_ALL_PORTS;
+#ifdef OC_TCP
+#if defined(OC_IPV4)
+  ports.tcp.port4 = 5683;
+#if defined(OC_SECURITY)
+  ports.tcp.secure_port4 = 5684;
+#endif /* OC_SECURITY */
+#endif /* OC_IPV4 */
+  // ipv6
+  ports.tcp.port = 5683;
+#if defined(OC_SECURITY)
+  ports.tcp.secure_port = 5684;
+#endif /* OC_SECURITY */
+#endif /* OC_TCP */
+  int ret = oc_connectivity_init(g_device, ports);
+  EXPECT_EQ(0, ret);
+  oc_connectivity_shutdown(g_device);
+}
+
+TEST(TestConnectivity_init, oc_connectivity_initAllDisabled)
+{
+  oc_connectivity_ports_t ports;
+  memset(&ports, 0, sizeof(oc_connectivity_ports_t));
+  ports.udp.flags = OC_CONNECTIVITY_DISABLE_ALL_PORTS;
+#ifdef OC_TCP
+  ports.tcp.flags = OC_CONNECTIVITY_DISABLE_ALL_PORTS;
+#endif /* OC_TCP */
+  int ret = oc_connectivity_init(g_device, ports);
   EXPECT_EQ(0, ret);
   oc_connectivity_shutdown(g_device);
 }

--- a/port/windows/ipadapter.c
+++ b/port/windows/ipadapter.c
@@ -1411,8 +1411,10 @@ handle_network_interface_event_callback(oc_interface_event_t event)
 #endif /* OC_NETWORK_MONITOR */
 
 int
-oc_connectivity_init(size_t device)
+oc_connectivity_init(size_t device, oc_connectivity_ports_t ports)
 {
+  // TODO set ports
+  (void)ports;
   if (!ifchange_initialized) {
     WSADATA wsadata;
     WSAStartup(MAKEWORD(2, 2), &wsadata);

--- a/port/zephyr/src/ipadapter.c
+++ b/port/zephyr/src/ipadapter.c
@@ -244,8 +244,10 @@ oc_connectivity_get_endpoints(size_t device)
 }
 
 int
-oc_connectivity_init(size_t device)
+oc_connectivity_init(size_t device, oc_connectivity_ports_t ports)
 {
+  // TODO set ports
+  (void)ports;
   (void)device;
   int ret;
 

--- a/security/unittest/tls_cert_test.cpp
+++ b/security/unittest/tls_cert_test.cpp
@@ -54,9 +54,13 @@ public:
     oc_random_init();
     oc_network_event_handler_mutex_init();
     oc_tls_init_context();
-    oc_device_info_t *info =
-      oc_core_add_new_device("/oic/d", "oic.d.light", "Lamp", "ocf.1.0.0",
-                             "ocf.res.1.0.0", nullptr, nullptr);
+    oc_add_new_device_t cfg{};
+    cfg.name = "Lamp";
+    cfg.uri = "/oic/d";
+    cfg.rt = "oic.d.light";
+    cfg.spec_version = "ocf.1.0.0";
+    cfg.data_model_version = "ocf.res.1.0.0";
+    oc_device_info_t *info = oc_core_add_new_device(cfg);
     EXPECT_NE(nullptr, info);
     oc_sec_svr_create();
 

--- a/swig/swig_interfaces/oc_api.i
+++ b/swig/swig_interfaces/oc_api.i
@@ -343,6 +343,9 @@ void jni_oc_add_device_callback(void *user_data)
   $2 = user_data;
 }
 %ignore oc_add_device;
+%ignore oc_add_new_device_s;
+%ignore oc_connectivity_ports_s;
+%ignore oc_add_device_v1;
 %rename(addDevice) jni_oc_add_device;
 %inline %{
 int jni_oc_add_device(const char *uri, const char *rt, const char *name,

--- a/tests/gtest/Device.cpp
+++ b/tests/gtest/Device.cpp
@@ -102,6 +102,14 @@ Device::Device()
 #endif /* _WIN32 */
 }
 
+Device::~Device()
+{
+#ifndef _WIN32
+  pthread_cond_destroy(&cv_);
+  pthread_mutex_destroy(&mutex_);
+#endif /* _WIN32 */
+}
+
 void
 Device::SignalEventLoop()
 {
@@ -109,7 +117,7 @@ Device::SignalEventLoop()
   WakeConditionVariable(&cv_);
 #else
   pthread_cond_signal(&cv_);
-#endif
+#endif /* _WIN32 */
 }
 
 void
@@ -119,7 +127,7 @@ Device::Lock()
   EnterCriticalSection(&mutex_);
 #else
   pthread_mutex_lock(&mutex_);
-#endif
+#endif /* _WIN32 */
 }
 
 void
@@ -129,7 +137,7 @@ Device::Unlock()
   LeaveCriticalSection(&mutex_);
 #else
   pthread_mutex_unlock(&mutex_);
-#endif
+#endif /* _WIN32 */
 }
 
 void
@@ -155,13 +163,14 @@ Device::WaitForEvent(oc_clock_time_t next_event)
   ts.tv_nsec =
     static_cast<long>((next_event % OC_CLOCK_SECOND) * 1.e09 / OC_CLOCK_SECOND);
   pthread_cond_timedwait(&cv_, &mutex_, &ts);
-#endif
+#endif /* _WIN32 */
 }
 
 void
 Device::Terminate()
 {
   OC_ATOMIC_STORE8(terminate_, 1);
+  SignalEventLoop();
 }
 
 void

--- a/tests/gtest/Device.h
+++ b/tests/gtest/Device.h
@@ -55,7 +55,7 @@ struct DeviceToAdd
 class Device {
 public:
   Device();
-  ~Device() = default;
+  ~Device();
 
   void SignalEventLoop();
   void PoolEvents(uint64_t seconds);
@@ -74,7 +74,7 @@ private:
     return OC_EVENT_DONE;
   }
 
-#if defined(_WIN32)
+#ifdef _WIN32
   CRITICAL_SECTION mutex_;
   CONDITION_VARIABLE cv_;
 #else  /* !_WIN32 */

--- a/util/oc_compiler.h
+++ b/util/oc_compiler.h
@@ -68,7 +68,12 @@
 #endif
 
 #if defined(__clang__) || defined(__GNUC__)
+#if defined(__MINGW32__) && defined(__USE_MINGW_ANSI_STDIO) &&                 \
+  __USE_MINGW_ANSI_STDIO == 1
+#define OC_PRINTF_FORMAT(...) __attribute__((format(gnu_printf, __VA_ARGS__)))
+#else
 #define OC_PRINTF_FORMAT(...) __attribute__((format(printf, __VA_ARGS__)))
+#endif
 #else
 #define OC_PRINTF_FORMAT(...)
 #endif


### PR DESCRIPTION
This repository provides a configuration option to specify port numbers or disable ports for each IP protocol. The following are the effects of disallowing specific protocols:

- Disabling UDP4 or UDP: The device will no longer be discoverable via multicast for certain protocol, and the connection will not work as both rely on the same socket.
- Disabling DTLS4 or DTLS: DTLS will be disabled for both the server and the client.
- Disabling TCP4 or TCP or TLS(TCP)4 or TLS(TCP): Only the TCP listener will be disabled, while the client side will continue to function.

Example: apps/cloud_server.c