### PR TITLE
Fix issues reported by clang-tidy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -381,8 +381,8 @@ if(MINGW)
     endif()
 
     # force the use mingw_printf because the default doesn't support '%zu'
-    list(APPEND PRIVATE_COMPILE_DEFINITIONS "__USE_MINGW_ANSI_STDIO=1")
-    list(APPEND TEST_COMPILE_DEFINITIONS "__USE_MINGW_ANSI_STDIO=1")
+    list(APPEND PRIVATE_COMPILE_DEFINITIONS "__USE_MINGW_ANSI_STDIO=(1)")
+    list(APPEND TEST_COMPILE_DEFINITIONS "__USE_MINGW_ANSI_STDIO=(1)")
 endif()
 
 if(MSVC)

--- a/api/c-timestamp/timestamp_format.c
+++ b/api/c-timestamp/timestamp_format.c
@@ -27,7 +27,9 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
 #include "timestamp.h"
+#include "util/oc_compiler.h"
 #include <assert.h>
 #include <stddef.h>
 
@@ -64,12 +66,6 @@ static const uint32_t Pow10[10] = { 1,         10,        100,     1000,
                                     10000,     100000,    1000000, 10000000,
                                     100000000, 1000000000 };
 
-#if defined(__clang__) || defined(__GNUC__)
-#define FALLTHROUGH __attribute__((fallthrough))
-#else
-#define FALLTHROUGH
-#endif
-
 static size_t
 timestamp_format_internal(char *dst, size_t len, const timestamp_t *tsp,
                           const int precision)
@@ -87,8 +83,8 @@ timestamp_format_internal(char *dst, size_t len, const timestamp_t *tsp,
     return 0;
   }
 
-  uint64_t sec = tsp->sec + tsp->offset * 60 + EPOCH;
-  uint64_t rdn = sec / 86400;
+  int64_t sec = tsp->sec + tsp->offset * 60L + EPOCH;
+  int64_t rdn = sec / 86400;
   assert(rdn < UINT32_MAX);
   uint16_t y;
   uint16_t m;
@@ -139,38 +135,38 @@ timestamp_format_internal(char *dst, size_t len, const timestamp_t *tsp,
     case 9:
       p[9] = '0' + (v % 10);
       v /= 10;
-      FALLTHROUGH;
+      OC_FALLTHROUGH;
     case 8:
       p[8] = '0' + (v % 10);
       v /= 10;
-      FALLTHROUGH;
+      OC_FALLTHROUGH;
     case 7:
       p[7] = '0' + (v % 10);
       v /= 10;
-      FALLTHROUGH;
+      OC_FALLTHROUGH;
     case 6:
       p[6] = '0' + (v % 10);
       v /= 10;
-      FALLTHROUGH;
+      OC_FALLTHROUGH;
     case 5:
       p[5] = '0' + (v % 10);
       v /= 10;
-      FALLTHROUGH;
+      OC_FALLTHROUGH;
     case 4:
       p[4] = '0' + (v % 10);
       v /= 10;
-      FALLTHROUGH;
+      OC_FALLTHROUGH;
     case 3:
       p[3] = '0' + (v % 10);
       v /= 10;
-      FALLTHROUGH;
+      OC_FALLTHROUGH;
     case 2:
       p[2] = '0' + (v % 10);
       v /= 10;
-      FALLTHROUGH;
+      OC_FALLTHROUGH;
     case 1:
       p[1] = '0' + (v % 10);
-      FALLTHROUGH;
+      OC_FALLTHROUGH;
     default:
       break;
     }

--- a/api/c-timestamp/timestamp_parse.c
+++ b/api/c-timestamp/timestamp_parse.c
@@ -151,18 +151,18 @@ parse_time(const unsigned char *str, uint16_t *hour, uint16_t *min,
 static bool
 parse_offset(const unsigned char *str, bool minus, int16_t *offset)
 {
-  uint16_t hour;
-  uint16_t min;
   if (str[2] != ':') {
     return false;
   }
 
+  uint16_t hour;
+  uint16_t min;
   if (parse_2d(str, 0, &hour) || hour > 23 || parse_2d(str, 3, &min) ||
       min > 59) {
     return false;
   }
 
-  int16_t o = hour * 60 + min;
+  int16_t o = (int16_t)(hour * 60 + min);
   if (minus) {
     o *= -1;
   }
@@ -243,8 +243,8 @@ timestamp_parse(const char *str, size_t len, timestamp_t *tsp)
     return 1;
   }
 
-  tsp->sec = ((int64_t)rdn - 719163) * 86400 + sod - offset * 60;
-  tsp->nsec = nsec;
+  tsp->sec = ((int64_t)rdn - 719163) * 86400 + sod - (offset * 60L);
+  tsp->nsec = (int32_t)nsec;
   tsp->offset = offset;
   return 0;
 }

--- a/api/c-timestamp/timestamp_tm.c
+++ b/api/c-timestamp/timestamp_tm.c
@@ -74,7 +74,7 @@ timestamp_to_tm(const timestamp_t *tsp, struct tm *tmp, const bool local)
 
   uint64_t sec = tsp->sec + RDN_OFFSET;
   if (local) {
-    sec += tsp->offset * 60;
+    sec += tsp->offset * 60L;
   }
   assert((sec / 86400) <= UINT32_MAX);
   uint32_t rdn = (uint32_t)(sec / 86400);

--- a/api/c-timestamp/timestamp_valid.c
+++ b/api/c-timestamp/timestamp_valid.c
@@ -35,9 +35,10 @@
 bool
 timestamp_valid(const timestamp_t *tsp)
 {
-  const int64_t sec = tsp->sec + tsp->offset * 60;
+  const int64_t sec = tsp->sec + tsp->offset * 60L;
   if (sec < MIN_SEC || sec > MAX_SEC || tsp->nsec < 0 ||
-      tsp->nsec > 999999999 || tsp->offset < -1439 || tsp->offset > 1439)
+      tsp->nsec > 999999999 || tsp->offset < -1439 || tsp->offset > 1439) {
     return false;
+  }
   return true;
 }

--- a/api/client/oc_client_cb.c
+++ b/api/client/oc_client_cb.c
@@ -81,7 +81,7 @@ oc_ri_alloc_client_cb(const char *uri, const oc_endpoint_t *endpoint,
   oc_random_buffer(cb->token, cb->token_len);
   cb->discovery = false;
   cb->timestamp = oc_clock_time();
-  cb->observe_seq = OC_COAP_OBSERVE_NOT_SET;
+  cb->observe_seq = OC_COAP_OPTION_OBSERVE_NOT_SET;
   if (endpoint != NULL) {
     oc_endpoint_copy(&cb->endpoint, endpoint);
   }
@@ -237,7 +237,7 @@ client_cb_notify_with_code(oc_client_cb_t *cb, oc_status_t code)
   memset(&client_response, 0, sizeof(oc_client_response_t));
   client_response.client_cb = cb;
   client_response.endpoint = &cb->endpoint;
-  client_response.observe_option = OC_COAP_OBSERVE_NOT_SET;
+  client_response.observe_option = OC_COAP_OPTION_OBSERVE_NOT_SET;
   client_response.user_data = cb->user_data;
   client_response.code = code;
 
@@ -332,7 +332,7 @@ ri_prepare_client_response(const coap_packet_t *packet,
   memset(&client_response, 0, sizeof(oc_client_response_t));
   client_response.client_cb = cb;
   client_response.endpoint = endpoint;
-  client_response.observe_option = OC_COAP_OBSERVE_NOT_SET;
+  client_response.observe_option = OC_COAP_OPTION_OBSERVE_NOT_SET;
   client_response.content_format = cf;
   client_response.user_data = cb->user_data;
 
@@ -364,10 +364,11 @@ ri_client_cb_set_observe_seq(oc_client_cb_t *cb, int observe_seq,
   cb->observe_seq = observe_seq;
 
   // Drop old observe callback and keep the last one.
-  if (cb->observe_seq == OC_COAP_OBSERVE_REGISTER) {
+  if (cb->observe_seq == OC_COAP_OPTION_OBSERVE_REGISTER) {
     oc_client_cb_t *dup_cb = (oc_client_cb_t *)oc_list_head(g_client_cbs);
     while (dup_cb != NULL) {
-      if (dup_cb != cb && dup_cb->observe_seq != OC_COAP_OBSERVE_NOT_SET &&
+      if (dup_cb != cb &&
+          dup_cb->observe_seq != OC_COAP_OPTION_OBSERVE_NOT_SET &&
           dup_cb->token_len == cb->token_len &&
           memcmp(dup_cb->token, cb->token, cb->token_len) == 0 &&
           oc_string_is_equal(&dup_cb->uri, &cb->uri) &&
@@ -408,7 +409,8 @@ oc_client_cb_invoke(const coap_packet_t *response, oc_client_cb_t *cb,
 #endif /* OC_BLOCK_WISE */
 
 #if defined(OC_OSCORE) && defined(OC_SECURITY)
-  if (client_response.observe_option > OC_COAP_OBSERVE_UNREGISTER) {
+  if (client_response.observe_option >=
+      OC_COAP_OPTION_OBSERVE_SEQUENCE_START_VALUE) {
     uint64_t notification_num = 0;
     oscore_read_piv(endpoint->piv, endpoint->piv_len, &notification_num);
     if (notification_num < cb->notification_num) {
@@ -491,8 +493,8 @@ oc_client_cb_invoke(const coap_packet_t *response, oc_client_cb_t *cb,
 
   cb->ref_count = 0;
 
-  if (client_response.observe_option == OC_COAP_OBSERVE_NOT_SET && !separate &&
-      !cb->discovery) {
+  if (client_response.observe_option == OC_COAP_OPTION_OBSERVE_NOT_SET &&
+      !separate && !cb->discovery) {
     if (cb->multicast) {
       if (cb->stop_multicast_receive) {
         uint16_t mid = cb->mid;

--- a/api/client/oc_client_cb.c
+++ b/api/client/oc_client_cb.c
@@ -81,7 +81,7 @@ oc_ri_alloc_client_cb(const char *uri, const oc_endpoint_t *endpoint,
   oc_random_buffer(cb->token, cb->token_len);
   cb->discovery = false;
   cb->timestamp = oc_clock_time();
-  cb->observe_seq = -1;
+  cb->observe_seq = OC_COAP_OBSERVE_NOT_SET;
   if (endpoint != NULL) {
     oc_endpoint_copy(&cb->endpoint, endpoint);
   }
@@ -237,7 +237,7 @@ client_cb_notify_with_code(oc_client_cb_t *cb, oc_status_t code)
   memset(&client_response, 0, sizeof(oc_client_response_t));
   client_response.client_cb = cb;
   client_response.endpoint = &cb->endpoint;
-  client_response.observe_option = -1;
+  client_response.observe_option = OC_COAP_OBSERVE_NOT_SET;
   client_response.user_data = cb->user_data;
   client_response.code = code;
 
@@ -332,7 +332,7 @@ ri_prepare_client_response(const coap_packet_t *packet,
   memset(&client_response, 0, sizeof(oc_client_response_t));
   client_response.client_cb = cb;
   client_response.endpoint = endpoint;
-  client_response.observe_option = -1;
+  client_response.observe_option = OC_COAP_OBSERVE_NOT_SET;
   client_response.content_format = cf;
   client_response.user_data = cb->user_data;
 
@@ -364,10 +364,10 @@ ri_client_cb_set_observe_seq(oc_client_cb_t *cb, int observe_seq,
   cb->observe_seq = observe_seq;
 
   // Drop old observe callback and keep the last one.
-  if (cb->observe_seq == 0) {
+  if (cb->observe_seq == OC_COAP_OBSERVE_REGISTER) {
     oc_client_cb_t *dup_cb = (oc_client_cb_t *)oc_list_head(g_client_cbs);
     while (dup_cb != NULL) {
-      if (dup_cb != cb && dup_cb->observe_seq != -1 &&
+      if (dup_cb != cb && dup_cb->observe_seq != OC_COAP_OBSERVE_NOT_SET &&
           dup_cb->token_len == cb->token_len &&
           memcmp(dup_cb->token, cb->token, cb->token_len) == 0 &&
           oc_string_is_equal(&dup_cb->uri, &cb->uri) &&
@@ -408,7 +408,7 @@ oc_client_cb_invoke(const coap_packet_t *response, oc_client_cb_t *cb,
 #endif /* OC_BLOCK_WISE */
 
 #if defined(OC_OSCORE) && defined(OC_SECURITY)
-  if (client_response.observe_option > 1) {
+  if (client_response.observe_option > OC_COAP_OBSERVE_UNREGISTER) {
     uint64_t notification_num = 0;
     oscore_read_piv(endpoint->piv, endpoint->piv_len, &notification_num);
     if (notification_num < cb->notification_num) {
@@ -491,7 +491,8 @@ oc_client_cb_invoke(const coap_packet_t *response, oc_client_cb_t *cb,
 
   cb->ref_count = 0;
 
-  if (client_response.observe_option == -1 && !separate && !cb->discovery) {
+  if (client_response.observe_option == OC_COAP_OBSERVE_NOT_SET && !separate &&
+      !cb->discovery) {
     if (cb->multicast) {
       if (cb->stop_multicast_receive) {
         uint16_t mid = cb->mid;

--- a/api/client/oc_client_cb.c
+++ b/api/client/oc_client_cb.c
@@ -351,7 +351,7 @@ ri_prepare_client_response(const coap_packet_t *packet,
   }
 #else  /* !OC_BLOCK_WISE */
   (void)response_state;
-  coap_get_header_observe(packet, (uint32_t *)&client_response.observe_option);
+  coap_get_header_observe(packet, &client_response.observe_option);
 #endif /* OC_BLOCK_WISE */
 
   return client_response;

--- a/api/client/oc_client_cb.c
+++ b/api/client/oc_client_cb.c
@@ -419,17 +419,17 @@ oc_client_cb_invoke(const coap_packet_t *response, oc_client_cb_t *cb,
 #endif /* OC_OSCORE && OC_SECURITY */
 
   const uint8_t *payload = NULL;
-  int payload_len = 0;
+  size_t payload_len = 0;
 #ifdef OC_BLOCK_WISE
   if (*response_state != NULL) {
     payload = (*response_state)->buffer;
-    payload_len = (int)(*response_state)->payload_size;
+    payload_len = (*response_state)->payload_size;
   }
 #else  /* OC_BLOCK_WISE */
   payload_len = coap_get_payload(response, (const uint8_t **)&payload);
 #endif /* !OC_BLOCK_WISE */
   client_response._payload = payload;
-  client_response._payload_len = (size_t)payload_len;
+  client_response._payload_len = payload_len;
 
   bool separate = false;
   if (payload_len) {

--- a/api/cloud/oc_cloud_manager.c
+++ b/api/cloud/oc_cloud_manager.c
@@ -537,14 +537,14 @@ on_keepalive_response_default(oc_cloud_context_t *ctx, bool response_received,
                               uint64_t *next_ping)
 {
   if (response_received) {
-    *next_ping = 20UL * 1000UL;
+    *next_ping = 20UL * MILLISECONDS_PER_SECOND;
     ctx->retry_count = 0;
   } else {
-    *next_ping = 4UL * 1000UL;
+    *next_ping = 4UL * MILLISECONDS_PER_SECOND;
     uint64_t keepalive_ping_timeout_ms =
-      ((uint64_t)(ctx->keepalive.ping_timeout)) * 1000;
+      ((uint64_t)(ctx->keepalive.ping_timeout)) * MILLISECONDS_PER_SECOND;
     // we don't want to ping more often than once per second
-    if (keepalive_ping_timeout_ms >= (*next_ping + 1000)) {
+    if (keepalive_ping_timeout_ms >= (*next_ping + MILLISECONDS_PER_SECOND)) {
       *next_ping = (keepalive_ping_timeout_ms - *next_ping);
     }
     ++ctx->retry_count;

--- a/api/cloud/oc_cloud_manager.c
+++ b/api/cloud/oc_cloud_manager.c
@@ -197,17 +197,17 @@ refresh_token_expires_in_ms(int64_t expires_in_ms)
     return 0;
   }
 
-  if (expires_in_ms > MILLISECONDS_PER_HOUR) {
+  if (expires_in_ms > (int64_t)MILLISECONDS_PER_HOUR) {
     // if time is more than 1h then set expires to (expires_in_ms - 10min).
-    return (uint64_t)(expires_in_ms - 10 * MILLISECONDS_PER_MINUTE);
+    return (uint64_t)(expires_in_ms - (int64_t)(10 * MILLISECONDS_PER_MINUTE));
   }
-  if (expires_in_ms > 4 * MILLISECONDS_PER_MINUTE) {
+  if (expires_in_ms > (int64_t)(4 * MILLISECONDS_PER_MINUTE)) {
     // if time is more than 240sec then set expires to (expires_in_ms - 2min).
-    return (uint64_t)(expires_in_ms - 2 * MILLISECONDS_PER_MINUTE);
+    return (uint64_t)(expires_in_ms - (int64_t)(2 * MILLISECONDS_PER_MINUTE));
   }
-  if (expires_in_ms > 20 * MILLISECONDS_PER_SECOND) {
+  if (expires_in_ms > (int64_t)(20 * MILLISECONDS_PER_SECOND)) {
     // if time is more than 20sec then set expires to (expires_in_ms - 10sec).
-    return (uint64_t)(expires_in_ms - 10 * MILLISECONDS_PER_SECOND);
+    return (uint64_t)(expires_in_ms - (int64_t)(10 * MILLISECONDS_PER_SECOND));
   }
   return (uint64_t)expires_in_ms;
 }
@@ -537,10 +537,10 @@ on_keepalive_response_default(oc_cloud_context_t *ctx, bool response_received,
                               uint64_t *next_ping)
 {
   if (response_received) {
-    *next_ping = 20 * 1000;
+    *next_ping = 20UL * 1000UL;
     ctx->retry_count = 0;
   } else {
-    *next_ping = 4 * 1000;
+    *next_ping = 4UL * 1000UL;
     uint64_t keepalive_ping_timeout_ms =
       ((uint64_t)(ctx->keepalive.ping_timeout)) * 1000;
     // we don't want to ping more often than once per second

--- a/api/cloud/oc_cloud_manager.c
+++ b/api/cloud/oc_cloud_manager.c
@@ -559,12 +559,12 @@ on_keepalive_response(oc_cloud_context_t *ctx, bool response_received,
   }
   if (!ok) {
     OC_ERR("[CM] keepalive failed");
-  } else {
-    OC_DBG("[CM] keepalive sends the next ping in %llu milliseconds with %u "
-           "seconds timeout",
-           (long long unsigned)*next_ping, ctx->keepalive.ping_timeout);
+    return false;
   }
-  return ok;
+  OC_DBG("[CM] keepalive sends the next ping in %llu milliseconds with %u "
+         "seconds timeout",
+         (long long unsigned)*next_ping, ctx->keepalive.ping_timeout);
+  return true;
 }
 
 static void

--- a/api/cloud/oc_cloud_manager.c
+++ b/api/cloud/oc_cloud_manager.c
@@ -43,6 +43,10 @@
 #include <assert.h>
 #include <stdint.h>
 
+#define MILLISECONDS_PER_SECOND (1000)
+#define MILLISECONDS_PER_MINUTE (60 * MILLISECONDS_PER_SECOND)
+#define MILLISECONDS_PER_HOUR (60 * MILLISECONDS_PER_MINUTE)
+
 static void cloud_start_process(oc_cloud_context_t *ctx);
 static oc_event_callback_retval_t cloud_manager_reconnect_async(void *data);
 static oc_event_callback_retval_t cloud_manager_register_async(void *data);
@@ -186,23 +190,26 @@ finish:
   _oc_signal_event_loop();
 }
 
-static uint16_t
-check_expires_in(int64_t expires_in)
+static uint64_t
+refresh_token_expires_in_ms(int64_t expires_in_ms)
 {
-  if (expires_in <= 0) {
+  if (expires_in_ms <= 0) {
     return 0;
   }
-  if (expires_in > 60 * 60) {
-    // if time is more than 1h then set expires to (expires_in - 10min).
-    expires_in = expires_in - 10 * 60;
-  } else if (expires_in > 4 * 60) {
-    // if time is more than 240sec then set expires to (expires_in - 2min).
-    expires_in = expires_in - 2 * 60;
-  } else if (expires_in > 20) {
-    // if time is more than 20sec then set expires to (expires_in - 10sec).
-    expires_in = expires_in - 10;
+
+  if (expires_in_ms > MILLISECONDS_PER_HOUR) {
+    // if time is more than 1h then set expires to (expires_in_ms - 10min).
+    return (uint64_t)(expires_in_ms - 10 * MILLISECONDS_PER_MINUTE);
   }
-  return expires_in > UINT16_MAX ? UINT16_MAX : (uint16_t)expires_in;
+  if (expires_in_ms > 4 * MILLISECONDS_PER_MINUTE) {
+    // if time is more than 240sec then set expires to (expires_in_ms - 2min).
+    return (uint64_t)(expires_in_ms - 2 * MILLISECONDS_PER_MINUTE);
+  }
+  if (expires_in_ms > 20 * MILLISECONDS_PER_SECOND) {
+    // if time is more than 20sec then set expires to (expires_in_ms - 10sec).
+    return (uint64_t)(expires_in_ms - 10 * MILLISECONDS_PER_SECOND);
+  }
+  return (uint64_t)expires_in_ms;
 }
 
 static bool
@@ -583,8 +590,10 @@ cloud_manager_login_handler(oc_client_response_t *data)
     on_keepalive_response(ctx, true, &next_ping);
     oc_reset_delayed_callback_ms(ctx, cloud_manager_send_ping_async, next_ping);
     if (ctx->store.expires_in > 0) {
-      oc_reset_delayed_callback(ctx, cloud_manager_refresh_token_async,
-                                check_expires_in(ctx->store.expires_in));
+      oc_reset_delayed_callback_ms(
+        ctx, cloud_manager_refresh_token_async,
+        refresh_token_expires_in_ms(ctx->store.expires_in *
+                                    MILLISECONDS_PER_SECOND));
     }
     goto finish;
   }

--- a/api/cloud/oc_cloud_store.c
+++ b/api/cloud/oc_cloud_store.c
@@ -133,10 +133,10 @@ cloud_store_dump_internal(const char *store_name, const oc_cloud_store_t *store)
   uint8_t *buf = malloc(OC_MIN_APP_DATA_SIZE);
   if (!buf)
     return -1;
-  oc_rep_new_realloc(&buf, OC_MIN_APP_DATA_SIZE, OC_MAX_APP_DATA_SIZE);
+  oc_rep_new_realloc_v1(&buf, OC_MIN_APP_DATA_SIZE, OC_MAX_APP_DATA_SIZE);
 #else  /* OC_DYNAMIC_ALLOCATION */
   uint8_t buf[OC_MIN_APP_DATA_SIZE];
-  oc_rep_new(buf, OC_MIN_APP_DATA_SIZE);
+  oc_rep_new_v1(buf, sizeof(buf));
 #endif /* !OC_DYNAMIC_ALLOCATION */
 
   // Dumping cloud and accesspoint information.

--- a/api/cloud/unittest/cloud_rd_test.cpp
+++ b/api/cloud/unittest/cloud_rd_test.cpp
@@ -26,6 +26,9 @@
 
 static constexpr size_t kDeviceID{ 0 };
 
+#include <gtest/gtest.h>
+#include <pthread.h>
+
 class TestCloudRD : public testing::Test {
 public:
   static void SetUpTestCase() { ASSERT_TRUE(oc::TestDevice::StartServer()); }

--- a/api/cloud/unittest/cloud_rd_test.cpp
+++ b/api/cloud/unittest/cloud_rd_test.cpp
@@ -26,9 +26,6 @@
 
 static constexpr size_t kDeviceID{ 0 };
 
-#include <gtest/gtest.h>
-#include <pthread.h>
-
 class TestCloudRD : public testing::Test {
 public:
   static void SetUpTestCase() { ASSERT_TRUE(oc::TestDevice::StartServer()); }

--- a/api/cloud/unittest/cloud_resource_test.cpp
+++ b/api/cloud/unittest/cloud_resource_test.cpp
@@ -1,0 +1,90 @@
+/******************************************************************
+ *
+ * Copyright 2019 Jozef Kralik All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"),
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************/
+
+#include "oc_api.h"
+#include "oc_clock_util.h"
+#include "oc_cloud_internal.h"
+#include "oc_collection.h"
+
+#include <gtest/gtest.h>
+#include <pthread.h>
+
+class TestCloudResource : public testing::Test {
+public:
+  static oc_handler_t s_handler;
+  static pthread_mutex_t s_mutex;
+  static pthread_cond_t s_cv;
+  static oc_cloud_context_t s_context;
+
+  static int appInit(void)
+  {
+    int result = oc_init_platform("OCFCloud", nullptr, nullptr);
+    result |= oc_add_device("/oic/d", "oic.d.light", "Lamp", "ocf.1.0.0",
+                            "ocf.res.1.0.0", nullptr, nullptr);
+    return result;
+  }
+
+  static void signalEventLoop(void) { pthread_cond_signal(&s_cv); }
+
+  static oc_event_callback_retval_t quitEvent(void *data)
+  {
+    auto *quit = static_cast<bool *>(data);
+    *quit = true;
+    return OC_EVENT_DONE;
+  }
+
+  static void poolEvents(uint16_t seconds)
+  {
+    bool quit = false;
+    oc_set_delayed_callback(&quit, quitEvent, seconds);
+
+    while (true) {
+      pthread_mutex_lock(&s_mutex);
+      oc_clock_time_t next_event = oc_main_poll();
+      if (quit) {
+        pthread_mutex_unlock(&s_mutex);
+        break;
+      }
+      if (next_event == 0) {
+        pthread_cond_wait(&s_cv, &s_mutex);
+      } else {
+        timespec ts = oc_clock_time_to_timespec(next_event);
+        pthread_cond_timedwait(&s_cv, &s_mutex, &ts);
+      }
+      pthread_mutex_unlock(&s_mutex);
+    }
+  }
+
+protected:
+  static void SetUpTestCase()
+  {
+    s_handler.init = &appInit;
+    s_handler.signal_event_loop = &signalEventLoop;
+    int ret = oc_main_init(&s_handler);
+    ASSERT_EQ(0, ret);
+
+    memset(&s_context, 0, sizeof(s_context));
+  }
+
+  static void TearDownTestCase() { oc_main_shutdown(); }
+};
+
+oc_handler_t TestCloudResource::s_handler;
+pthread_mutex_t TestCloudResource::s_mutex;
+pthread_cond_t TestCloudResource::s_cv;
+oc_cloud_context_t TestCloudResource::s_context;

--- a/api/cloud/unittest/cloud_resource_test.cpp
+++ b/api/cloud/unittest/cloud_resource_test.cpp
@@ -16,75 +16,44 @@
  *
  ******************************************************************/
 
-#include "oc_api.h"
-#include "oc_clock_util.h"
-#include "oc_cloud_internal.h"
-#include "oc_collection.h"
+#include "oc_core_res.h"
+#include "oc_ri.h"
+#include "tests/gtest/Device.h"
 
 #include <gtest/gtest.h>
-#include <pthread.h>
+#include <cstddef>
 
-class TestCloudResource : public testing::Test {
+static constexpr size_t kDeviceID{ 0 };
+
+class TestCloudResourceWithServer : public testing::Test {
 public:
-  static oc_handler_t s_handler;
-  static pthread_mutex_t s_mutex;
-  static pthread_cond_t s_cv;
-  static oc_cloud_context_t s_context;
+  static void SetUpTestCase() { ASSERT_TRUE(oc::TestDevice::StartServer()); }
 
-  static int appInit(void)
-  {
-    int result = oc_init_platform("OCFCloud", nullptr, nullptr);
-    result |= oc_add_device("/oic/d", "oic.d.light", "Lamp", "ocf.1.0.0",
-                            "ocf.res.1.0.0", nullptr, nullptr);
-    return result;
-  }
-
-  static void signalEventLoop(void) { pthread_cond_signal(&s_cv); }
-
-  static oc_event_callback_retval_t quitEvent(void *data)
-  {
-    auto *quit = static_cast<bool *>(data);
-    *quit = true;
-    return OC_EVENT_DONE;
-  }
-
-  static void poolEvents(uint16_t seconds)
-  {
-    bool quit = false;
-    oc_set_delayed_callback(&quit, quitEvent, seconds);
-
-    while (true) {
-      pthread_mutex_lock(&s_mutex);
-      oc_clock_time_t next_event = oc_main_poll();
-      if (quit) {
-        pthread_mutex_unlock(&s_mutex);
-        break;
-      }
-      if (next_event == 0) {
-        pthread_cond_wait(&s_cv, &s_mutex);
-      } else {
-        timespec ts = oc_clock_time_to_timespec(next_event);
-        pthread_cond_timedwait(&s_cv, &s_mutex, &ts);
-      }
-      pthread_mutex_unlock(&s_mutex);
-    }
-  }
-
-protected:
-  static void SetUpTestCase()
-  {
-    s_handler.init = &appInit;
-    s_handler.signal_event_loop = &signalEventLoop;
-    int ret = oc_main_init(&s_handler);
-    ASSERT_EQ(0, ret);
-
-    memset(&s_context, 0, sizeof(s_context));
-  }
-
-  static void TearDownTestCase() { oc_main_shutdown(); }
+  static void TearDownTestCase() { oc::TestDevice::StopServer(); }
 };
 
-oc_handler_t TestCloudResource::s_handler;
-pthread_mutex_t TestCloudResource::s_mutex;
-pthread_cond_t TestCloudResource::s_cv;
-oc_cloud_context_t TestCloudResource::s_context;
+TEST_F(TestCloudResourceWithServer, GetResource)
+{
+  EXPECT_NE(nullptr,
+            oc_core_get_resource_by_index(OCF_COAPCLOUDCONF, kDeviceID));
+}
+
+TEST_F(TestCloudResourceWithServer, GetRequest)
+{
+  // TODO
+}
+
+TEST_F(TestCloudResourceWithServer, PostRequest)
+{
+  // TODO
+}
+
+TEST_F(TestCloudResourceWithServer, PutRequest_FailMethodNotSupported)
+{
+  // TODO
+}
+
+TEST_F(TestCloudResourceWithServer, DeleteRequest_FailMethodNotSupported)
+{
+  // TODO
+}

--- a/api/cloud/unittest/cloud_test.cpp
+++ b/api/cloud/unittest/cloud_test.cpp
@@ -24,6 +24,9 @@
 
 static constexpr size_t kDeviceID{ 0 };
 
+#include <gtest/gtest.h>
+#include <pthread.h>
+
 class TestCloud : public testing::Test {
 public:
   static void SetUpTestCase() { ASSERT_TRUE(oc::TestDevice::StartServer()); }

--- a/api/cloud/unittest/cloud_test.cpp
+++ b/api/cloud/unittest/cloud_test.cpp
@@ -24,9 +24,6 @@
 
 static constexpr size_t kDeviceID{ 0 };
 
-#include <gtest/gtest.h>
-#include <pthread.h>
-
 class TestCloud : public testing::Test {
 public:
   static void SetUpTestCase() { ASSERT_TRUE(oc::TestDevice::StartServer()); }

--- a/api/oc_blockwise.c
+++ b/api/oc_blockwise.c
@@ -27,6 +27,7 @@
 #include "port/oc_connectivity.h"
 #include "port/oc_log_internal.h"
 #include "util/oc_list.h"
+#include "util/oc_macros_internal.h"
 #include "util/oc_memb.h"
 #include <inttypes.h>
 
@@ -190,7 +191,7 @@ oc_blockwise_alloc_response_buffer(const char *href, size_t href_len,
   if (buffer) {
     oc_random_buffer(buffer->etag, sizeof(buffer->etag));
 #ifdef OC_CLIENT
-    buffer->observe_seq = -1;
+    buffer->observe_seq = OC_COAP_OBSERVE_NOT_SET;
 #endif /* OC_CLIENT */
     oc_ri_add_timed_event_callback_seconds(
       buffer, oc_blockwise_response_timeout, OC_EXCHANGE_LIFETIME);

--- a/api/oc_blockwise.c
+++ b/api/oc_blockwise.c
@@ -191,7 +191,7 @@ oc_blockwise_alloc_response_buffer(const char *href, size_t href_len,
   if (buffer) {
     oc_random_buffer(buffer->etag, sizeof(buffer->etag));
 #ifdef OC_CLIENT
-    buffer->observe_seq = OC_COAP_OBSERVE_NOT_SET;
+    buffer->observe_seq = OC_COAP_OPTION_OBSERVE_NOT_SET;
 #endif /* OC_CLIENT */
     oc_ri_add_timed_event_callback_seconds(
       buffer, oc_blockwise_response_timeout, OC_EXCHANGE_LIFETIME);

--- a/api/oc_buffer.c
+++ b/api/oc_buffer.c
@@ -24,7 +24,7 @@
 #include "oc_signal_event_loop.h"
 #include "port/oc_network_event_handler_internal.h"
 #include "util/oc_features.h"
-#include "util/oc_macros.h"
+#include "util/oc_macros_internal.h"
 #include "util/oc_memb.h"
 
 #ifdef OC_SECURITY

--- a/api/oc_client_api.c
+++ b/api/oc_client_api.c
@@ -113,14 +113,15 @@ dispatch_coap_request(void)
   if (g_dispatch.transaction->message->length > 0) {
     coap_send_transaction(g_dispatch.transaction);
 
-    if (g_dispatch.client_cb->observe_seq == -1) {
-      if (g_dispatch.client_cb->qos == LOW_QOS)
+    if (g_dispatch.client_cb->observe_seq == OC_COAP_OBSERVE_NOT_SET) {
+      if (g_dispatch.client_cb->qos == LOW_QOS) {
         oc_set_delayed_callback(g_dispatch.client_cb,
                                 &oc_client_cb_remove_async, OC_NON_LIFETIME);
-      else
+      } else {
         oc_set_delayed_callback(g_dispatch.client_cb,
                                 &oc_client_cb_remove_async,
                                 OC_EXCHANGE_LIFETIME);
+      }
     }
 
     success = true;
@@ -213,8 +214,9 @@ prepare_coap_request(oc_client_cb_t *cb)
   coap_set_header_uri_path(g_request, oc_string(cb->uri),
                            oc_string_len(cb->uri));
 
-  if (cb->observe_seq != -1)
+  if (cb->observe_seq != OC_COAP_OBSERVE_NOT_SET) {
     coap_set_header_observe(g_request, cb->observe_seq);
+  }
 
   if (oc_string_len(cb->query) > 0) {
     coap_set_header_uri_query(g_request, oc_string(cb->query));
@@ -548,7 +550,7 @@ oc_do_observe(const char *uri, const oc_endpoint_t *endpoint, const char *query,
   if (!cb)
     return false;
 
-  cb->observe_seq = 0;
+  cb->observe_seq = OC_COAP_OBSERVE_REGISTER;
 
   bool status = false;
 
@@ -569,7 +571,7 @@ oc_stop_observe(const char *uri, const oc_endpoint_t *endpoint)
     return false;
 
   cb->mid = coap_get_mid();
-  cb->observe_seq = 1;
+  cb->observe_seq = OC_COAP_OBSERVE_UNREGISTER;
 
   bool status = false;
 

--- a/api/oc_client_api.c
+++ b/api/oc_client_api.c
@@ -85,13 +85,14 @@ dispatch_coap_request(void)
         g_dispatch.client_cb->qos = HIGH_QOS;
       }
     } else {
-      coap_set_payload(g_request, g_request_buffer->buffer, payload_size);
+      coap_set_payload(g_request, g_request_buffer->buffer,
+                       (uint32_t)payload_size);
       g_request_buffer->ref_count = 0;
     }
 #else  /* OC_BLOCK_WISE */
     coap_set_payload(
       g_request, g_dispatch.transaction->message->data + COAP_MAX_HEADER_SIZE,
-      payload_size);
+      (uint32_t)payload_size);
 #endif /* !OC_BLOCK_WISE */
   }
 
@@ -158,8 +159,8 @@ prepare_coap_request(oc_client_cb_t *cb)
   }
 
   g_dispatch.transaction = transaction;
-  oc_rep_new(g_dispatch.transaction->message->data + COAP_MAX_HEADER_SIZE,
-             OC_BLOCK_SIZE);
+  oc_rep_new_v1(g_dispatch.transaction->message->data + COAP_MAX_HEADER_SIZE,
+                OC_BLOCK_SIZE);
 
 #ifdef OC_BLOCK_WISE
   if (cb->method == OC_PUT || cb->method == OC_POST) {
@@ -173,15 +174,16 @@ prepare_coap_request(oc_client_cb_t *cb)
 #ifdef OC_DYNAMIC_ALLOCATION
 #ifdef OC_APP_DATA_BUFFER_POOL
     if (g_request_buffer->block) {
-      oc_rep_new(g_request_buffer->buffer, g_request_buffer->buffer_size);
+      oc_rep_new_v1(g_request_buffer->buffer, g_request_buffer->buffer_size);
     } else
 #endif
     {
-      oc_rep_new_realloc(&g_request_buffer->buffer,
-                         g_request_buffer->buffer_size, OC_MAX_APP_DATA_SIZE);
+      oc_rep_new_realloc_v1(&g_request_buffer->buffer,
+                            g_request_buffer->buffer_size,
+                            OC_MAX_APP_DATA_SIZE);
     }
 #else  /* OC_DYNAMIC_ALLOCATION */
-    oc_rep_new(g_request_buffer->buffer, OC_MIN_APP_DATA_SIZE);
+    oc_rep_new_v1(g_request_buffer->buffer, OC_MIN_APP_DATA_SIZE);
 #endif /* !OC_DYNAMIC_ALLOCATION */
     g_request_buffer->mid = cb->mid;
     g_request_buffer->client_cb = cb;
@@ -252,7 +254,7 @@ oc_do_multicast_update(void)
 
   if (payload_size > 0) {
     coap_set_payload(g_request, g_multicast_update->data + COAP_MAX_HEADER_SIZE,
-                     payload_size);
+                     (uint32_t)payload_size);
   } else {
     goto do_multicast_update_error;
   }
@@ -298,7 +300,7 @@ oc_init_multicast_update(const char *uri, const char *query)
 
   memcpy(&g_multicast_update->endpoint, &mcast, sizeof(oc_endpoint_t));
 
-  oc_rep_new(g_multicast_update->data + COAP_MAX_HEADER_SIZE, OC_BLOCK_SIZE);
+  oc_rep_new_v1(g_multicast_update->data + COAP_MAX_HEADER_SIZE, OC_BLOCK_SIZE);
 
   coap_udp_init_message(g_request, type, OC_POST, coap_get_mid());
 

--- a/api/oc_client_api.c
+++ b/api/oc_client_api.c
@@ -113,7 +113,7 @@ dispatch_coap_request(void)
   if (g_dispatch.transaction->message->length > 0) {
     coap_send_transaction(g_dispatch.transaction);
 
-    if (g_dispatch.client_cb->observe_seq == OC_COAP_OBSERVE_NOT_SET) {
+    if (g_dispatch.client_cb->observe_seq == OC_COAP_OPTION_OBSERVE_NOT_SET) {
       if (g_dispatch.client_cb->qos == LOW_QOS) {
         oc_set_delayed_callback(g_dispatch.client_cb,
                                 &oc_client_cb_remove_async, OC_NON_LIFETIME);
@@ -214,7 +214,7 @@ prepare_coap_request(oc_client_cb_t *cb)
   coap_set_header_uri_path(g_request, oc_string(cb->uri),
                            oc_string_len(cb->uri));
 
-  if (cb->observe_seq != OC_COAP_OBSERVE_NOT_SET) {
+  if (cb->observe_seq != OC_COAP_OPTION_OBSERVE_NOT_SET) {
     coap_set_header_observe(g_request, cb->observe_seq);
   }
 
@@ -550,7 +550,7 @@ oc_do_observe(const char *uri, const oc_endpoint_t *endpoint, const char *query,
   if (!cb)
     return false;
 
-  cb->observe_seq = OC_COAP_OBSERVE_REGISTER;
+  cb->observe_seq = OC_COAP_OPTION_OBSERVE_REGISTER;
 
   bool status = false;
 
@@ -571,7 +571,7 @@ oc_stop_observe(const char *uri, const oc_endpoint_t *endpoint)
     return false;
 
   cb->mid = coap_get_mid();
-  cb->observe_seq = OC_COAP_OBSERVE_UNREGISTER;
+  cb->observe_seq = OC_COAP_OPTION_OBSERVE_UNREGISTER;
 
   bool status = false;
 

--- a/api/oc_core_res.c
+++ b/api/oc_core_res.c
@@ -32,7 +32,7 @@
 #include "util/oc_atomic.h"
 #include "util/oc_compiler.h"
 #include "util/oc_features.h"
-#include "util/oc_macros.h"
+#include "util/oc_macros_internal.h"
 
 #ifdef OC_CLOUD
 #include "api/cloud/oc_cloud_resource_internal.h"

--- a/api/oc_discovery.c
+++ b/api/oc_discovery.c
@@ -1186,7 +1186,7 @@ oc_discovery_process_payload(const uint8_t *payload, size_t len,
       link = link->next;
     }
 
-    if (eps_list &&
+    if (eps_list && anchor != NULL && uri != NULL && types != NULL &&
         (all ? all_handler(oc_string(*anchor), oc_string(*uri), *types,
                            iface_mask, eps_list, bm,
                            (links->next ? true : false), user_data)

--- a/api/oc_discovery.c
+++ b/api/oc_discovery.c
@@ -1027,7 +1027,7 @@ oc_create_discovery_resource(int resource_idx, size_t device)
 
 #ifdef OC_CLIENT
 oc_discovery_flags_t
-oc_discovery_process_payload(const uint8_t *payload, int len,
+oc_discovery_process_payload(const uint8_t *payload, size_t len,
                              oc_client_handler_t client_handler,
                              const oc_endpoint_t *endpoint, void *user_data)
 {

--- a/api/oc_discovery_internal.h
+++ b/api/oc_discovery_internal.h
@@ -42,7 +42,7 @@ extern "C" {
  * @return oc_discovery_flags_t the discovery flags (e.g. more to come)
  */
 oc_discovery_flags_t oc_discovery_process_payload(const uint8_t *payload,
-                                                  int len,
+                                                  size_t len,
                                                   oc_client_handler_t handler,
                                                   const oc_endpoint_t *endpoint,
                                                   void *user_data);

--- a/api/oc_endpoint.c
+++ b/api/oc_endpoint.c
@@ -23,7 +23,7 @@
 #include "port/oc_connectivity.h"
 #include "port/oc_log_internal.h"
 #include "port/oc_network_event_handler_internal.h"
-#include "util/oc_macros.h"
+#include "util/oc_macros_internal.h"
 #include "util/oc_memb.h"
 
 #include <stdio.h>
@@ -288,17 +288,12 @@ oc_parse_ipv6_address(const char *address, size_t len, oc_endpoint_t *endpoint)
     long i = (long)(addr_idx - 1);
     addr_idx = OC_IPV6_ADDRLEN - 1;
     while (i >= split) {
-#if defined(__GNUC__) && !defined(__clang__)
-// GCC thinks that addr has size=4 instead of size=16 and complains about
-// overflow
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstringop-overflow"
-#endif // __GNUC__ && !__clang__
+      // clang-format off
+      GCC_IGNORE_WARNING_START
+      GCC_IGNORE_WARNING("-Wstringop-overflow")
       addr[addr_idx] = addr[i];
       addr[i] = 0;
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif // __GNUC__ && !__clang__
+      GCC_IGNORE_WARNING_END
       i--;
       addr_idx--;
     }

--- a/api/oc_helpers.c
+++ b/api/oc_helpers.c
@@ -147,7 +147,7 @@ oc_string_is_cstr_equal(const oc_string_t *str1, const char *str2,
                         size_t str2_len)
 {
   return oc_string_len(*str1) == str2_len &&
-         strncmp(oc_string(*str1), str2, str2_len) == 0;
+         memcmp(oc_string(*str1), str2, str2_len) == 0;
 }
 
 void

--- a/api/oc_helpers.c
+++ b/api/oc_helpers.c
@@ -22,6 +22,7 @@
 #include "port/oc_assert.h"
 #include "port/oc_log_internal.h"
 #include "port/oc_random.h"
+#include "util/oc_macros_internal.h"
 #include <assert.h>
 #include <inttypes.h>
 #include <stdbool.h>

--- a/api/oc_mnt.c
+++ b/api/oc_mnt.c
@@ -70,12 +70,12 @@ post_mnt(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
 
   if (success) {
 #ifdef OC_DYNAMIC_ALLOCATION
-    oc_rep_new_realloc(&request->response->response_buffer->buffer,
-                       request->response->response_buffer->buffer_size,
-                       OC_MAX_APP_DATA_SIZE);
+    oc_rep_new_realloc_v1(&request->response->response_buffer->buffer,
+                          request->response->response_buffer->buffer_size,
+                          OC_MAX_APP_DATA_SIZE);
 #else  /* OC_DYNAMIC_ALLOCATION */
-    oc_rep_new(request->response->response_buffer->buffer,
-               request->response->response_buffer->buffer_size);
+    oc_rep_new_v1(request->response->response_buffer->buffer,
+                  request->response->response_buffer->buffer_size);
 #endif /* !OC_DYNAMIC_ALLOCATION */
     oc_rep_start_root_object();
     oc_rep_set_boolean(root, fr, false);

--- a/api/oc_push.c
+++ b/api/oc_push.c
@@ -1302,7 +1302,7 @@ oc_print_pushd_resource(const oc_rep_t *payload)
   const oc_rep_t *rep = payload;
 
   /* check buffer overflow */
-  if ((size_t)(prefix_width * (depth + 1) + 1) > sizeof(depth_prefix)) {
+  if ((prefix_width * (depth + 1) + 1) > sizeof(depth_prefix)) {
     return;
   }
 
@@ -2031,30 +2031,29 @@ exit:
 static bool
 _replace_recv_obj_array(oc_recvs_t *recvs_instance, oc_rep_t *rep)
 {
-  bool result = false;
 
-  if (rep && (rep->type == OC_REP_OBJECT_ARRAY)) {
-    /* check if received new receiver object array is ok */
-    if (!_validate_recv_obj_list(rep->value.object_array))
-      goto exit;
-
-    /* if received new receiver object array is ok, do the job... */
-    /* remove existing receivers object array */
-    _purge_recv_obj_list(recvs_instance);
-
-    /* replace `receivers` obj array with new one */
-    for (oc_rep_t *rep_obj = rep->value.object_array; rep_obj != NULL;
-         rep_obj = rep_obj->next) {
-      _create_recv_obj(recvs_instance, rep_obj->value.object);
-    }
-
-    result = true;
-  } else {
-    OC_PUSH_ERR("something wrong, unexpected Property type: %d", rep->type);
+  if (rep == NULL || rep->type != OC_REP_OBJECT_ARRAY) {
+    OC_PUSH_ERR("something wrong, unexpected Property type: %d",
+                rep != NULL ? (int)rep->type : -1);
+    return false;
   }
 
-exit:
-  return result;
+  /* check if received new receiver object array is ok */
+  if (!_validate_recv_obj_list(rep->value.object_array)) {
+    return false;
+  }
+
+  /* if received new receiver object array is ok, do the job... */
+  /* remove existing receivers object array */
+  _purge_recv_obj_list(recvs_instance);
+
+  /* replace `receivers` obj array with new one */
+  for (oc_rep_t *rep_obj = rep->value.object_array; rep_obj != NULL;
+       rep_obj = rep_obj->next) {
+    _create_recv_obj(recvs_instance, rep_obj->value.object);
+  }
+
+  return true;
 }
 
 /**

--- a/api/oc_push.c
+++ b/api/oc_push.c
@@ -40,7 +40,7 @@
 #include "port/oc_log_internal.h"
 #include "util/oc_compiler.h"
 #include "util/oc_list.h"
-#include "util/oc_macros.h"
+#include "util/oc_macros_internal.h"
 #include "util/oc_mmem.h"
 #include "util/oc_process.h"
 
@@ -2531,9 +2531,8 @@ OC_PROCESS_THREAD(oc_push_process, ev, data)
 
         oc_rep_end_root_object();
 
-        if (oc_do_post()) {
-          OC_PUSH_DBG("Sent POST request");
-        } else {
+        OC_PUSH_DBG("Sending POST request");
+        if (!oc_do_post()) {
           OC_PUSH_ERR("Could not send POST");
         }
       } else {

--- a/api/oc_push.c
+++ b/api/oc_push.c
@@ -377,15 +377,17 @@ set_ns_properties(oc_resource_t *resource, oc_rep_t *rep, void *data)
                              OC_CHAR_ARRAY_LEN(OC_PUSH_PROP_STATE))) {
         /* state can be modified only if Push Proxy is in "tout" or "err" state
          */
-        if (strcmp(oc_string(ns_instance->state), pp_statestr(OC_PP_ERR)) &&
-            strcmp(oc_string(ns_instance->state), pp_statestr(OC_PP_TOUT))) {
+        if (strcmp(oc_string(ns_instance->state), pp_statestr(OC_PP_ERR)) !=
+              0 &&
+            strcmp(oc_string(ns_instance->state), pp_statestr(OC_PP_TOUT)) !=
+              0) {
           OC_PUSH_ERR("state can be modified only if Push Proxy is in \"tout\" "
                       "or \"err\" state");
           return false;
         }
 
         /* "waitingforupdate" is only acceptable value */
-        if (strcmp(oc_string(rep->value.string), pp_statestr(OC_PP_WFU))) {
+        if (strcmp(oc_string(rep->value.string), pp_statestr(OC_PP_WFU)) != 0) {
           OC_PUSH_ERR(
             "only \"waitingforupdate\" is allowed to reset \"state\"");
           return false;
@@ -487,9 +489,9 @@ set_ns_properties(oc_resource_t *resource, oc_rep_t *rep, void *data)
    * - only configurator can change "state" when it is in "err"/"tout" state
    */
   if (pushtarget_is_updated &&
-      strcmp(oc_string(ns_instance->state), pp_statestr(OC_PP_ERR)) &&
-      strcmp(oc_string(ns_instance->state), pp_statestr(OC_PP_TOUT)) &&
-      strcmp(oc_string(ns_instance->state), pp_statestr(OC_PP_WFU))) {
+      strcmp(oc_string(ns_instance->state), pp_statestr(OC_PP_ERR)) != 0 &&
+      strcmp(oc_string(ns_instance->state), pp_statestr(OC_PP_TOUT)) != 0 &&
+      strcmp(oc_string(ns_instance->state), pp_statestr(OC_PP_WFU)) != 0) {
     OC_PUSH_DBG("state of Push Proxy (\"%s\") is changed (%s => %s)",
                 oc_string(ns_instance->resource->uri),
                 oc_string(ns_instance->state), pp_statestr(OC_PP_WFU));
@@ -508,7 +510,7 @@ set_ns_properties(oc_resource_t *resource, oc_rep_t *rep, void *data)
  * @brief callback to be called to fill the contents of `notification
  * selector` from existing data structure (`oc_ns_t`)
  *
- * @param resource
+ * @param resource not used
  * @param iface_mask interface to be used to send response
  * @param data internal structure for storing `notification selector`
  * resource (oc_memb struct for ["oic.r.notificationselector",
@@ -1066,7 +1068,7 @@ _find_pushd_rsc_rep_by_uri(oc_string_t *uri, size_t device_index)
     (oc_pushd_resource_rep_t *)(oc_list_head(g_pushd_rsc_rep_list));
 
   while (pushd_rsc_rep) {
-    if (!strcmp(oc_string(pushd_rsc_rep->resource->uri), oc_string(*uri)) &&
+    if (strcmp(oc_string(pushd_rsc_rep->resource->uri), oc_string(*uri)) == 0 &&
         (pushd_rsc_rep->resource->device == device_index)) {
       break;
     } else {
@@ -1149,17 +1151,18 @@ _check_pushd_rsc_rt(oc_recv_t *recv_obj, oc_rep_t *rep)
   rts_len = oc_string_array_get_allocated_size(recv_obj->rts);
 
   /* if "rts" is not configured (""), any pushed resource can be accepted... */
-  if ((rts_len == 1) && !strcmp(oc_string_array_get_item(recv_obj->rts, 0), ""))
+  if ((rts_len == 1) &&
+      strcmp(oc_string_array_get_item(recv_obj->rts, 0), "") == 0)
     return 1;
 
   while (rep) {
     if ((rep->type == OC_REP_STRING_ARRAY) &&
-        !strcmp(oc_string(rep->name), "rt")) {
+        strcmp(oc_string(rep->name), "rt") == 0) {
       rt_len = oc_string_array_get_allocated_size(rep->value.array);
       for (i = 0; i < rt_len; i++) {
         for (j = 0; j < rts_len; j++) {
-          if (!strcmp(oc_string_array_get_item(rep->value.array, i),
-                      oc_string_array_get_item(recv_obj->rts, j)))
+          if (strcmp(oc_string_array_get_item(rep->value.array, i),
+                     oc_string_array_get_item(recv_obj->rts, j)) == 0)
             break;
         }
         if (j == rts_len) {
@@ -1292,19 +1295,18 @@ _create_pushd_rsc_rep(oc_rep_t *org_rep)
 void
 oc_print_pushd_resource(const oc_rep_t *payload)
 {
-  static int depth = 0;
+  static unsigned depth = 0;
   char prefix_width = 3;
   const char *prefix_str = "   ";
-  char depth_prefix[1024];
+  char depth_prefix[1024] = { 0 };
   const oc_rep_t *rep = payload;
-  const oc_rep_t *obj;
-  int i;
 
   /* check buffer overflow */
   if ((size_t)(prefix_width * (depth + 1) + 1) > sizeof(depth_prefix)) {
     return;
   }
 
+  size_t i;
 #if 0
   depth_prefix[sizeof(depth_prefix) - 1] = '\0';
   depth++;
@@ -1319,7 +1321,6 @@ oc_print_pushd_resource(const oc_rep_t *payload)
   for (i = 0; i < depth; i++) {
     strcpy(depth_prefix + (i * prefix_width), prefix_str);
   }
-
   depth_prefix[i * prefix_width] = '\0';
 
   if (!rep) {
@@ -1341,7 +1342,7 @@ oc_print_pushd_resource(const oc_rep_t *payload)
     case OC_REP_BOOL_ARRAY:
       OC_PUSH_PRINT("%s%s: \n%s[\n", depth_prefix, oc_string(rep->name),
                     depth_prefix);
-      for (i = 0; i < (int)oc_bool_array_size(rep->value.array); i++) {
+      for (i = 0; i < oc_bool_array_size(rep->value.array); i++) {
         OC_PUSH_PRINT("%s%s\"%d\"\n", depth_prefix, prefix_str,
                       oc_bool_array(rep->value.array)[i]);
       }
@@ -1356,7 +1357,7 @@ oc_print_pushd_resource(const oc_rep_t *payload)
     case OC_REP_INT_ARRAY:
       OC_PUSH_PRINT("%s%s: \n%s[\n", depth_prefix, oc_string(rep->name),
                     depth_prefix);
-      for (i = 0; i < (int)oc_int_array_size(rep->value.array); i++) {
+      for (i = 0; i < oc_int_array_size(rep->value.array); i++) {
         OC_PUSH_PRINT("%s%s\"%" PRId64 "\"\n", depth_prefix, prefix_str,
                       oc_int_array(rep->value.array)[i]);
       }
@@ -1371,7 +1372,7 @@ oc_print_pushd_resource(const oc_rep_t *payload)
     case OC_REP_DOUBLE_ARRAY:
       OC_PUSH_PRINT("%s%s: \n%s[\n", depth_prefix, oc_string(rep->name),
                     depth_prefix);
-      for (i = 0; i < (int)oc_double_array_size(rep->value.array); i++) {
+      for (i = 0; i < oc_double_array_size(rep->value.array); i++) {
         OC_PUSH_PRINT("%s%s\"%f\"\n", depth_prefix, prefix_str,
                       oc_double_array(rep->value.array)[i]);
       }
@@ -1386,7 +1387,7 @@ oc_print_pushd_resource(const oc_rep_t *payload)
     case OC_REP_STRING_ARRAY:
       OC_PUSH_PRINT("%s%s: \n%s[\n", depth_prefix, oc_string(rep->name),
                     depth_prefix);
-      for (i = 0; i < (int)oc_string_array_get_allocated_size(rep->value.array);
+      for (i = 0; i < oc_string_array_get_allocated_size(rep->value.array);
            i++) {
         OC_PUSH_PRINT("%s%s\"%s\"\n", depth_prefix, prefix_str,
                       oc_string_array_get_item(rep->value.array, i));
@@ -1406,7 +1407,7 @@ oc_print_pushd_resource(const oc_rep_t *payload)
       OC_PUSH_PRINT("%s%s: \n%s[\n", depth_prefix, oc_string(rep->name),
                     depth_prefix);
       depth++;
-      obj = rep->value.object_array;
+      const oc_rep_t *obj = rep->value.object_array;
       while (obj) {
         OC_PUSH_PRINT("%s%s{\n", depth_prefix, prefix_str);
         oc_print_pushd_resource(obj->value.object);
@@ -1533,7 +1534,7 @@ post_pushd_rsc(oc_request_t *request, oc_interface_mask_t iface_mask,
        */
       switch (rep->type) {
       case OC_REP_STRING_ARRAY:
-        if (!strcmp(oc_string(rep->name), "rt")) {
+        if (strcmp(oc_string(rep->name), "rt") == 0) {
           /* update rt */
           oc_free_string_array(&request->resource->types);
           oc_new_string_array(
@@ -1556,7 +1557,7 @@ post_pushd_rsc(oc_request_t *request, oc_interface_mask_t iface_mask,
           oc_free_rep(common_property);
           continue;
 
-        } else if (!strcmp(oc_string(rep->name), "if")) {
+        } else if (strcmp(oc_string(rep->name), "if") == 0) {
           /* update if */
           request->resource->interfaces = 0;
           for (int i = 0;
@@ -1573,7 +1574,7 @@ post_pushd_rsc(oc_request_t *request, oc_interface_mask_t iface_mask,
         }
         break;
       case OC_REP_STRING:
-        if (!strcmp(oc_string(rep->name), "n")) {
+        if (strcmp(oc_string(rep->name), "n") == 0) {
           /* update name */
           oc_set_string(&request->resource->name, oc_string(rep->value.string),
                         oc_string_len(rep->value.string));
@@ -1601,8 +1602,8 @@ post_pushd_rsc(oc_request_t *request, oc_interface_mask_t iface_mask,
       oc_rep_set_pool(&g_rep_instance_memb);
       oc_free_rep(pushd_rsc_rep->rep);
 
-      if (!(pushd_rsc_rep->rep =
-              _create_pushd_rsc_rep(request->request_payload))) {
+      pushd_rsc_rep->rep = _create_pushd_rsc_rep(request->request_payload);
+      if (pushd_rsc_rep->rep == NULL) {
         OC_PUSH_ERR("something wrong!, creating corresponding pushed resource "
                     "representation faild (%s) ! ",
                     oc_string(request->resource->uri));
@@ -1838,7 +1839,7 @@ _purge_recv_obj_list(oc_recvs_t *recvs_instance)
  * @brief update existing receiver object with new contents
  *
  * @param recv_obj existing receiver object
- * @param resource app Resource pointed by `recv_obj->receiveruri`
+ * @param recvs_instance app Resource pointed by `recv_obj->receiveruri`
  * @param rep payload representation of new receiver object
  */
 static void
@@ -1850,14 +1851,14 @@ _update_recv_obj(oc_recv_t *recv_obj, const oc_recvs_t *recvs_instance,
   while (rep) {
     switch (rep->type) {
     case OC_REP_STRING:
-      if (!strcmp(oc_string(rep->name), "receiveruri")) {
+      if (strcmp(oc_string(rep->name), "receiveruri") == 0) {
         OC_PUSH_DBG("target receiveruri: \"%s\", new receiveruri: \"%s\"",
                     oc_string(recv_obj->receiveruri),
                     oc_string(rep->value.string));
         /* if `receiveruri' is different from existing `receiveruri`,
          * update URI of Resource pointed by previous `receiveruri` */
         if (strcmp(oc_string(recv_obj->receiveruri),
-                   oc_string(rep->value.string))) {
+                   oc_string(rep->value.string)) != 0) {
           pushd_rsc_rep = _find_pushd_rsc_rep_by_uri(
             &recv_obj->receiveruri, recvs_instance->resource->device);
 
@@ -1877,7 +1878,7 @@ _update_recv_obj(oc_recv_t *recv_obj, const oc_recvs_t *recvs_instance,
       break;
 
     case OC_REP_STRING_ARRAY:
-      if (!strcmp(oc_string(rep->name), "rts")) {
+      if (strcmp(oc_string(rep->name), "rts") == 0) {
         oc_free_string_array(&recv_obj->rts);
         size_t len = oc_string_array_get_allocated_size(rep->value.array);
         oc_new_string_array(&recv_obj->rts, len);
@@ -1919,7 +1920,7 @@ _create_recv_obj(oc_recvs_t *recvs_instance, oc_rep_t *rep)
   while (rep) {
     switch (rep->type) {
     case OC_REP_STRING:
-      if (!strcmp(oc_string(rep->name), "receiveruri")) {
+      if (strcmp(oc_string(rep->name), "receiveruri") == 0) {
         oc_new_string(&recv_obj->receiveruri, oc_string(rep->value.string),
                       oc_string_len(rep->value.string));
         mandatory_property_check |= 0x1;
@@ -1927,7 +1928,7 @@ _create_recv_obj(oc_recvs_t *recvs_instance, oc_rep_t *rep)
       break;
 
     case OC_REP_STRING_ARRAY:
-      if (!strcmp(oc_string(rep->name), "rts")) {
+      if (strcmp(oc_string(rep->name), "rts") == 0) {
         size_t len = oc_string_array_get_allocated_size(rep->value.array);
         oc_new_string_array(&recv_obj->rts, len);
 
@@ -1990,13 +1991,13 @@ _validate_recv_obj_list(oc_rep_t *obj_list)
     for (; rep != NULL; rep = rep->next) {
       switch (rep->type) {
       case OC_REP_STRING:
-        if (!strcmp(oc_string(rep->name), "receiveruri")) {
+        if (strcmp(oc_string(rep->name), "receiveruri") == 0) {
           mandatory_property_check |= 0x1;
         }
         break;
 
       case OC_REP_STRING_ARRAY:
-        if (!strcmp(oc_string(rep->name), "rts")) {
+        if (strcmp(oc_string(rep->name), "rts") == 0) {
           mandatory_property_check |= 0x2;
         }
         break;
@@ -2400,7 +2401,7 @@ push_update(oc_ns_t *ns_instance)
 
   /* href (optional) */
   if (oc_string(ns_instance->phref) &&
-      strcmp(oc_string(ns_instance->phref), "")) {
+      strcmp(oc_string(ns_instance->phref), "") != 0) {
     oc_rep_set_text_string(root, href, oc_string(ns_instance->phref));
   }
 
@@ -2510,7 +2511,7 @@ OC_PROCESS_THREAD(oc_push_process, ev, data)
          * - option
          */
         if (oc_string(ns_instance->phref) &&
-            strcmp(oc_string(ns_instance->phref), "")) {
+            strcmp(oc_string(ns_instance->phref), "") != 0) {
           oc_rep_set_text_string(root, href, oc_string(ns_instance->phref));
         }
 
@@ -2546,8 +2547,6 @@ OC_PROCESS_THREAD(oc_push_process, ev, data)
 
 /**
  * @brief check if any of source array is part of target array
- * @param target
- * @param source
  * @return
  * 			false: any of source is not part of target
  * 			true: any of source is part of target
@@ -2566,8 +2565,8 @@ _check_string_array_inclusion(oc_string_array_t *target,
 
   for (size_t i = 0; i < src_len; i++) {
     for (size_t j = 0; j < tgt_len; j++) {
-      if (!strcmp(oc_string_array_get_item(*source, i),
-                  oc_string_array_get_item(*target, j))) {
+      if (strcmp(oc_string_array_get_item(*source, i),
+                 oc_string_array_get_item(*target, j)) == 0) {
         return true;
       }
     }
@@ -2608,11 +2607,11 @@ oc_resource_state_changed(const char *uri, size_t uri_len, size_t device_index)
       continue;
 
     /* if push proxy is not in "wait for update" state, just skip it... */
-    if (strcmp(oc_string(ns_instance->state), pp_statestr(OC_PP_WFU)))
+    if (strcmp(oc_string(ns_instance->state), pp_statestr(OC_PP_WFU)) != 0)
       continue;
 
     if (oc_string(ns_instance->phref)) {
-      if (strcmp(oc_string(ns_instance->phref), uri)) {
+      if (strcmp(oc_string(ns_instance->phref), uri) != 0) {
         OC_PUSH_DBG("%s:phref exists, but mismatches (phref:%s - uri:%s)",
                     oc_string(ns_instance->resource->uri),
                     oc_string(ns_instance->phref), uri);
@@ -2669,8 +2668,8 @@ oc_resource_state_changed(const char *uri, size_t uri_len, size_t device_index)
 
     if (oc_string_array_get_allocated_size(ns_instance->pif) > 0) {
       oc_interface_mask_t pif = 0;
-      for (int i = 0;
-           i < (int)oc_string_array_get_allocated_size(ns_instance->pif); i++) {
+      for (size_t i = 0;
+           i < oc_string_array_get_allocated_size(ns_instance->pif); i++) {
         pif |= oc_ri_get_interface_mask(
           oc_string_array_get_item(ns_instance->pif, i),
           oc_byte_string_array_get_item_size(ns_instance->pif, i));

--- a/api/oc_rep.c
+++ b/api/oc_rep.c
@@ -24,7 +24,7 @@
 #include "oc_config.h"
 #include "port/oc_assert.h"
 #include "port/oc_log_internal.h"
-#include "util/oc_macros.h"
+#include "util/oc_macros_internal.h"
 #include "util/oc_memb.h"
 #include "util/oc_features.h"
 
@@ -47,18 +47,31 @@ oc_rep_set_pool(struct oc_memb *rep_objects_pool)
 }
 
 void
-oc_rep_new(uint8_t *out_payload, int size)
+oc_rep_new_v1(uint8_t *payload, size_t size)
 {
   g_err = CborNoError;
-  oc_rep_encoder_init(out_payload, size);
+  oc_rep_encoder_init(payload, size);
+}
+
+void
+oc_rep_new(uint8_t *payload, int size)
+{
+  oc_rep_new_v1(payload, (size_t)size);
 }
 
 #ifdef OC_DYNAMIC_ALLOCATION
+
 void
-oc_rep_new_realloc(uint8_t **out_payload, int size, int max_size)
+oc_rep_new_realloc_v1(uint8_t **payload, size_t size, size_t max_size)
 {
   g_err = CborNoError;
-  oc_rep_encoder_realloc_init(out_payload, size, max_size);
+  oc_rep_encoder_realloc_init(payload, size, max_size);
+}
+
+void
+oc_rep_new_realloc(uint8_t **payload, int size, int max_size)
+{
+  oc_rep_new_realloc_v1(payload, (size_t)size, (size_t)max_size);
 }
 #endif /* OC_DYNAMIC_ALLOCATION */
 

--- a/api/oc_rep.c
+++ b/api/oc_rep.c
@@ -28,6 +28,8 @@
 #include "util/oc_memb.h"
 #include "util/oc_features.h"
 
+#include <assert.h>
+
 static struct oc_memb *g_rep_objects;
 CborEncoder root_map;
 CborEncoder links_array;
@@ -71,6 +73,8 @@ oc_rep_new_realloc_v1(uint8_t **payload, size_t size, size_t max_size)
 void
 oc_rep_new_realloc(uint8_t **payload, int size, int max_size)
 {
+  assert(size >= 0);
+  assert(max_size >= 0);
   oc_rep_new_realloc_v1(payload, (size_t)size, (size_t)max_size);
 }
 #endif /* OC_DYNAMIC_ALLOCATION */

--- a/api/oc_rep_to_json.c
+++ b/api/oc_rep_to_json.c
@@ -20,6 +20,7 @@
 #include "oc_base64.h"
 #include "oc_rep.h"
 #include "port/oc_log_internal.h"
+#include "util/oc_compiler.h"
 #include <inttypes.h>
 #include <stdarg.h>
 #include <stdbool.h>
@@ -34,14 +35,8 @@ typedef struct
   size_t total;       // running total of characters printed to buf
 } write_buffer_t;
 
-#if defined(__clang__) || defined(__GNUC__)
-#define PRINTFLIKE(a, b) __attribute__((format(printf, a, b)))
-#else
-#define PRINTFLIKE(a, b)
-#endif
-
 static long write_to_buffer(write_buffer_t *wb, const char *fmt, ...)
-  PRINTFLIKE(2, 3);
+  OC_PRINTF_FORMAT(2, 3);
 
 static long
 write_to_buffer(write_buffer_t *wb, const char *fmt, ...)
@@ -55,7 +50,7 @@ write_to_buffer(write_buffer_t *wb, const char *fmt, ...)
   }
   wb->total += num_char_printed;
   if (wb->buffer == NULL) {
-    return wb->total;
+    return (long)wb->total;
   }
   if ((size_t)num_char_printed < wb->buffer_size) {
     wb->buffer += num_char_printed;
@@ -64,7 +59,7 @@ write_to_buffer(write_buffer_t *wb, const char *fmt, ...)
     wb->buffer += wb->buffer_size;
     wb->buffer_size = 0;
   }
-  return wb->total;
+  return (long)wb->total;
 }
 
 /*

--- a/api/oc_ri.c
+++ b/api/oc_ri.c
@@ -1047,7 +1047,7 @@ ri_handle_observation(const coap_packet_t *request, coap_packet_t *response,
   /* If a GET request was successfully processed, then check if the resource is
    * OBSERVABLE and check its observe option.
    */
-  uint32_t observe = 2;
+  int32_t observe = 2;
   if ((resource->properties & OC_OBSERVABLE) == 0 ||
       !coap_get_header_observe(request, &observe)) {
     return 2;

--- a/api/oc_ri.c
+++ b/api/oc_ri.c
@@ -1059,7 +1059,7 @@ ri_handle_observation(const coap_packet_t *request, coap_packet_t *response,
   if (observe == 0) {
     if (ri_add_observation(request, response, resource, resource_is_collection,
                            block2_size, endpoint, iface_query)) {
-      coap_set_header_observe(response, 0);
+      coap_set_header_observe(response, OC_COAP_OBSERVE_REGISTER);
     } else {
       coap_remove_observer_by_token(endpoint, request->token,
                                     request->token_len);

--- a/api/oc_ri.c
+++ b/api/oc_ri.c
@@ -36,7 +36,7 @@
 #include "util/oc_etimer_internal.h"
 #include "util/oc_features.h"
 #include "util/oc_list.h"
-#include "util/oc_macros.h"
+#include "util/oc_macros_internal.h"
 #include "util/oc_memb.h"
 #include "util/oc_process_internal.h"
 
@@ -1279,7 +1279,7 @@ oc_ri_invoke_coap_entity_handler(const coap_packet_t *request,
 
   /* Obtain handle to buffer containing the serialized payload */
   const uint8_t *payload = NULL;
-  int payload_len = 0;
+  size_t payload_len = 0;
 #ifdef OC_BLOCK_WISE
   if (*ctx.request_state) {
     payload = (*ctx.request_state)->buffer;
@@ -1289,7 +1289,7 @@ oc_ri_invoke_coap_entity_handler(const coap_packet_t *request,
   payload_len = coap_get_payload(request, &payload);
 #endif /* !OC_BLOCK_WISE */
   request_obj._payload = payload;
-  request_obj._payload_len = (size_t)payload_len;
+  request_obj._payload_len = payload_len;
   request_obj.content_format = cf;
   request_obj.accept = accept;
   OC_MEMB_LOCAL(rep_objects, oc_rep_t, OC_MAX_NUM_REP_OBJECTS);
@@ -1431,14 +1431,14 @@ oc_ri_invoke_coap_entity_handler(const coap_packet_t *request,
      */
 #ifdef OC_DYNAMIC_ALLOCATION
     if (response_state_allocated) {
-      oc_rep_new_realloc(&response_buffer.buffer, response_buffer.buffer_size,
-                         OC_MAX_APP_DATA_SIZE);
+      oc_rep_new_realloc_v1(&response_buffer.buffer,
+                            response_buffer.buffer_size, OC_MAX_APP_DATA_SIZE);
       enable_realloc_rep = true;
     } else {
-      oc_rep_new(response_buffer.buffer, response_buffer.buffer_size);
+      oc_rep_new_v1(response_buffer.buffer, response_buffer.buffer_size);
     }
 #else  /* OC_DYNAMIC_ALLOCATION */
-    oc_rep_new(response_buffer.buffer, response_buffer.buffer_size);
+    oc_rep_new_v1(response_buffer.buffer, response_buffer.buffer_size);
 #endif /* !OC_DYNAMIC_ALLOCATION */
 
     oc_status_t ret =

--- a/api/oc_server_api.c
+++ b/api/oc_server_api.c
@@ -768,7 +768,7 @@ handle_separate_response_request(coap_separate_t *request,
 #endif /* OC_BLOCK_WISE */
   if (response_buffer->response_length > 0) {
     coap_set_payload(&response, response_buffer->buffer,
-                     response_buffer->response_length);
+                     (uint32_t)response_buffer->response_length);
   }
   handle_separate_response_transaction(t, &response,
                                        (uint8_t)response_buffer->code);

--- a/api/oc_server_api.c
+++ b/api/oc_server_api.c
@@ -26,7 +26,7 @@
 #include "oc_core_res_internal.h"
 #include "port/oc_log_internal.h"
 #include "util/oc_features.h"
-#include "util/oc_macros.h"
+#include "util/oc_macros_internal.h"
 
 #ifdef OC_SERVER
 #include "api/oc_ri_server_internal.h"
@@ -684,9 +684,9 @@ void
 oc_set_separate_response_buffer(oc_separate_response_t *handle)
 {
 #ifdef OC_BLOCK_WISE
-  oc_rep_new(handle->buffer, OC_MAX_APP_DATA_SIZE);
+  oc_rep_new_v1(handle->buffer, OC_MAX_APP_DATA_SIZE);
 #else  /* OC_BLOCK_WISE */
-  oc_rep_new(handle->buffer, OC_BLOCK_SIZE);
+  oc_rep_new_v1(handle->buffer, OC_BLOCK_SIZE);
 #endif /* !OC_BLOCK_WISE */
 }
 

--- a/api/oc_server_api.c
+++ b/api/oc_server_api.c
@@ -20,6 +20,7 @@
 #include "api/oc_ri_internal.h"
 #include "messaging/coap/engine.h"
 #include "messaging/coap/oc_coap.h"
+#include "messaging/coap/observe.h"
 #include "messaging/coap/separate.h"
 #include "oc_api.h"
 #include "oc_core_res.h"
@@ -792,7 +793,7 @@ oc_send_separate_response(oc_separate_response_t *handle,
   coap_separate_t *cur = oc_list_head(handle->requests);
   while (cur != NULL) {
     coap_separate_t *next = cur->next;
-    if (cur->observe < 3) {
+    if (cur->observe < OC_COAP_OPTION_OBSERVE_SEQUENCE_START_VALUE) {
       handle_separate_response_request(cur, &response_buffer);
     } else {
       oc_resource_t *resource = oc_ri_get_app_resource_by_uri(

--- a/api/oc_storage.c
+++ b/api/oc_storage.c
@@ -155,9 +155,9 @@ oc_storage_save_resource(const char *name, size_t device,
     OC_ERR("cannot dump %s to storage: cannot allocate buffer", name);
     return -1;
   }
-  oc_rep_new_realloc(&sb.buffer, OC_MIN_APP_DATA_SIZE, OC_MAX_APP_DATA_SIZE);
+  oc_rep_new_realloc_v1(&sb.buffer, OC_MIN_APP_DATA_SIZE, OC_MAX_APP_DATA_SIZE);
 #else  /* !OC_APP_DATA_STORAGE_BUFFER */
-  oc_rep_new(sb.buffer, OC_MIN_APP_DATA_SIZE);
+  oc_rep_new_v1(sb.buffer, OC_MIN_APP_DATA_SIZE);
 #endif /* OC_APP_DATA_STORAGE_BUFFER */
 
   if (encode(device, encode_data) != 0 ||

--- a/api/oc_swupdate.c
+++ b/api/oc_swupdate.c
@@ -35,7 +35,7 @@
 #include "security/oc_pstat.h"
 #endif /* OC_SECURITY  */
 #include "util/oc_compiler.h"
-#include "util/oc_macros.h"
+#include "util/oc_macros_internal.h"
 
 #ifdef OC_DYNAMIC_ALLOCATION
 #include "port/oc_assert.h"

--- a/api/oc_uuid.c
+++ b/api/oc_uuid.c
@@ -18,7 +18,7 @@
 
 #include "oc_uuid.h"
 #include "port/oc_random.h"
-#include "util/oc_macros.h"
+#include "util/oc_macros_internal.h"
 #include <ctype.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/api/oc_uuid.c
+++ b/api/oc_uuid.c
@@ -19,6 +19,7 @@
 #include "oc_uuid.h"
 #include "port/oc_random.h"
 #include "util/oc_macros_internal.h"
+#include "util/oc_secure_string_internal.h"
 #include <ctype.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -35,17 +36,19 @@ oc_str_to_uuid(const char *str, oc_uuid_t *uuid)
   if (str == NULL) {
     return;
   }
+  size_t str_len = oc_strnlen(str, OC_UUID_LEN);
   memset(uuid, 0, sizeof(*uuid));
-  if (str[0] == '*' && strlen(str) == 1) {
+  if (str[0] == '*' && str_len == 1) {
     uuid->id[0] = '*';
     return;
   }
-  int i, j = 0, k = 1;
+  size_t k = 1;
   uint8_t c = 0;
-  for (i = 0; i < 36 && i < (int)strlen(str); i++) {
-    if (str[i] == '-')
+  for (size_t i = 0, j = 0; i < (OC_UUID_LEN - 1) && i < str_len; ++i) {
+    if (str[i] == '-') {
       continue;
-    else if (isalpha((int)str[i])) {
+    }
+    if (isalpha((int)str[i])) {
       switch (str[i]) {
       case 65:
       case 97:

--- a/api/plgd/plgd_time.c
+++ b/api/plgd/plgd_time.c
@@ -34,7 +34,7 @@
 #include "port/oc_clock.h"
 #include "port/oc_log_internal.h"
 #include "util/oc_compiler.h"
-#include "util/oc_macros.h"
+#include "util/oc_macros_internal.h"
 #include "util/oc_memb.h"
 
 #ifdef OC_SECURITY
@@ -197,7 +197,7 @@ dev_plgd_time(plgd_time_t pt)
     return -1;
   }
 
-  long elapsed = cur - pt.update_time;
+  long elapsed = (long)(cur - pt.update_time);
   assert(elapsed >= 0);
   oc_clock_time_t ptime = (pt.store.last_synced_time + elapsed);
 

--- a/api/plgd/plgd_time.c
+++ b/api/plgd/plgd_time.c
@@ -151,7 +151,7 @@ dev_time_set_time(oc_clock_time_t lst, bool dump, bool notify)
 #if OC_DBG_IS_ENABLED
   char lst_ts[64] = { 0 };
   oc_clock_encode_time_rfc3339(lst, lst_ts, sizeof(lst_ts));
-  uint64_t ut_s = (uint64_t)(updateTime / (double)OC_CLOCK_SECOND);
+  uint64_t ut_s = (uint64_t)((double)updateTime / (double)OC_CLOCK_SECOND);
   OC_DBG("plgd-time: %s (update: %" PRIu64 "s)", lst_ts, ut_s);
 #endif /* OC_DBG_IS_ENABLED */
 
@@ -218,7 +218,7 @@ dev_plgd_time(plgd_time_t pt)
   oc_clock_time_t time = oc_clock_time();
   char ts[RFC3339_BUFFER_SIZE] = { 0 };
   oc_clock_encode_time_rfc3339(time, ts, sizeof(ts));
-  long diff = (long)((time - ptime) / (double)OC_CLOCK_SECOND);
+  long diff = (long)((double)(time - ptime) / (double)OC_CLOCK_SECOND);
   OC_DBG("calculated plgd-time: %s, system time: %s, diff: %lds", pt_ts, ts,
          diff);
 #endif /* OC_DBG_IS_ENABLED */

--- a/api/unittest/buffertest.cpp
+++ b/api/unittest/buffertest.cpp
@@ -28,8 +28,11 @@
 #include <gtest/gtest.h>
 #include <memory>
 
-constexpr size_t kTestMessagesPoolSize = 1;
 OC_MEMB(oc_test_messages, oc_message_t, kTestMessagesPoolSize);
+
+#ifndef OC_DYNAMIC_ALLOCATION
+constexpr size_t kTestMessagesPoolSize = 1;
+#endif /* OC_DYNAMIC_ALLOCATION */
 
 using oc_message_unique_ptr =
   std::unique_ptr<oc_message_t, void (*)(oc_message_t *)>;

--- a/api/unittest/buffertest.cpp
+++ b/api/unittest/buffertest.cpp
@@ -28,11 +28,8 @@
 #include <gtest/gtest.h>
 #include <memory>
 
-OC_MEMB(oc_test_messages, oc_message_t, kTestMessagesPoolSize);
-
-#ifndef OC_DYNAMIC_ALLOCATION
 constexpr size_t kTestMessagesPoolSize = 1;
-#endif /* OC_DYNAMIC_ALLOCATION */
+OC_MEMB(oc_test_messages, oc_message_t, kTestMessagesPoolSize);
 
 using oc_message_unique_ptr =
   std::unique_ptr<oc_message_t, void (*)(oc_message_t *)>;
@@ -41,6 +38,7 @@ class TestMessage : public testing::Test {
 public:
   static void SetUpTestCase()
   {
+    (void)kTestMessagesPoolSize;
     oc_memb_init(&oc_test_messages);
     oc_set_buffers_avail_cb(onIncomingBufferAvailable);
     oc_memb_set_buffers_avail_cb(&oc_test_messages, onTestBufferAvailable);

--- a/api/unittest/ocapitest.cpp
+++ b/api/unittest/ocapitest.cpp
@@ -19,6 +19,7 @@
 #include "api/client/oc_client_cb_internal.h"
 #include "api/oc_ri_internal.h"
 #include "oc_api.h"
+#include "oc_clock_util.h"
 #include "oc_core_res.h"
 #include "oc_obt.h"
 #include "oc_uuid.h"

--- a/api/unittest/plgdtimetest.cpp
+++ b/api/unittest/plgdtimetest.cpp
@@ -37,7 +37,7 @@
 #include "tests/gtest/Endpoint.h"
 #include "tests/gtest/PKI.h"
 #include "tests/gtest/RepPool.h"
-#include "util/oc_macros.h"
+#include "util/oc_macros_internal.h"
 
 #ifdef OC_SECURITY
 #include "security/oc_security_internal.h"

--- a/api/unittest/repencodetest.cpp
+++ b/api/unittest/repencodetest.cpp
@@ -45,11 +45,11 @@ public:
     if (size > 0) {
       buffer_ = static_cast<uint8_t *>(malloc(size));
     }
-    oc_rep_new_realloc(&buffer_, size, max_size);
+    oc_rep_new_realloc_v1(&buffer_, size, max_size);
 #else  /* OC_DYNAMIC_ALLOCATION */
     (void)size;
     buffer_.reserve(max_size);
-    oc_rep_new(buffer_.data(), buffer_.capacity());
+    oc_rep_new_v1(buffer_.data(), buffer_.capacity());
 #endif /* OC_DYNAMIC_ALLOCATION */
   }
 

--- a/api/unittest/reptest.cpp
+++ b/api/unittest/reptest.cpp
@@ -48,7 +48,7 @@ TEST(TestRep, OCRepEncodedPayloadSizeTooSmall)
 {
   /* buffer for oc_rep_t */
   std::array<uint8_t, 10> buf{}; // Purposely small buffer
-  oc_rep_new(buf.data(), buf.size());
+  oc_rep_new_v1(buf.data(), buf.size());
 
   oc_rep_start_root_object();
   EXPECT_EQ(CborNoError, oc_rep_get_cbor_errno());

--- a/api/unittest/storagetest.cpp
+++ b/api/unittest/storagetest.cpp
@@ -25,7 +25,7 @@
 #include "oc_api.h"
 #include "port/oc_storage.h"
 #include "port/oc_storage_internal.h"
-#include "util/oc_macros.h"
+#include "util/oc_macros_internal.h"
 
 #include <array>
 #include <filesystem>

--- a/apps/client_arduino.cpp
+++ b/apps/client_arduino.cpp
@@ -193,10 +193,9 @@ discovery(const char *anchor, const char *uri, oc_string_array_t types,
   (void)user_data;
   (void)interfaces;
   (void)bm;
-  int i;
-  int uri_len = strlen(uri);
+  size_t uri_len = strlen(uri);
   uri_len = (uri_len >= MAX_URI_LENGTH) ? MAX_URI_LENGTH - 1 : uri_len;
-  for (i = 0; i < (int)oc_string_array_get_allocated_size(types); i++) {
+  for (size_t i = 0; i < oc_string_array_get_allocated_size(types); i++) {
     char *t = oc_string_array_get_item(types, i);
     if (strlen(t) == 10 && strncmp(t, "core.light", 10) == 0) {
 #ifdef OC_IPV4

--- a/apps/client_block_linux.c
+++ b/apps/client_block_linux.c
@@ -61,9 +61,8 @@ stop_observe(void *data)
   OC_PRINTF("Stopping OBSERVE\n");
   oc_stop_observe(array_1, array_server);
 
-  int i;
   if (oc_init_post(array_1, array_server, NULL, &post_array, LOW_QOS, NULL)) {
-    for (i = 0; i < 100; i++) {
+    for (int i = 0; i < 100; i++) {
       large_array[i] = oc_random_value();
       OC_PRINTF("(%d %d) ", i, large_array[i]);
     }
@@ -71,12 +70,14 @@ stop_observe(void *data)
     oc_rep_start_root_object();
     oc_rep_set_int_array(root, array, large_array, 100);
     oc_rep_end_root_object();
-    if (oc_do_post())
+    if (oc_do_post()) {
       OC_PRINTF("Sent POST request\n");
-    else
+    } else {
       OC_PRINTF("Could not send POST\n");
-  } else
+    }
+  } else {
     OC_PRINTF("Could not init POST\n");
+  }
 
   return OC_EVENT_DONE;
 }

--- a/apps/client_block_linux.c
+++ b/apps/client_block_linux.c
@@ -113,11 +113,9 @@ discovery(const char *anchor, const char *uri, oc_string_array_t types,
   (void)iface_mask;
   (void)user_data;
   (void)bm;
-  int i;
-  int uri_len = strlen(uri);
+  size_t uri_len = strlen(uri);
   uri_len = (uri_len >= MAX_URI_LENGTH) ? MAX_URI_LENGTH - 1 : uri_len;
-
-  for (i = 0; i < (int)oc_string_array_get_allocated_size(types); i++) {
+  for (size_t i = 0; i < oc_string_array_get_allocated_size(types); i++) {
     char *t = oc_string_array_get_item(types, i);
     if (strlen(t) == 11 && strncmp(t, "oic.r.array", 11) == 0) {
       oc_endpoint_list_copy(&array_server, endpoint);

--- a/apps/client_collections_linux.c
+++ b/apps/client_collections_linux.c
@@ -361,11 +361,9 @@ discovery(const char *anchor, const char *uri, oc_string_array_t types,
   (void)iface_mask;
   (void)user_data;
   (void)bm;
-  int i;
-  int uri_len = strlen(uri);
+  size_t uri_len = strlen(uri);
   uri_len = (uri_len >= MAX_URI_LENGTH) ? MAX_URI_LENGTH - 1 : uri_len;
-
-  for (i = 0; i < (int)oc_string_array_get_allocated_size(types); i++) {
+  for (size_t i = 0; i < oc_string_array_get_allocated_size(types); i++) {
     char *t = oc_string_array_get_item(types, i);
     if (strlen(t) == 10 && strncmp(t, "oic.wk.col", 10) == 0) {
       oc_endpoint_list_copy(&lights_server, endpoint);

--- a/apps/client_linux.c
+++ b/apps/client_linux.c
@@ -100,11 +100,9 @@ discovery(const char *di, const char *uri, oc_string_array_t types,
   (void)iface_mask;
   (void)user_data;
   (void)bm;
-  int i;
-  int uri_len = strlen(uri);
+  size_t uri_len = strlen(uri);
   uri_len = (uri_len >= MAX_URI_LENGTH) ? MAX_URI_LENGTH - 1 : uri_len;
-
-  for (i = 0; i < (int)oc_string_array_get_allocated_size(types); i++) {
+  for (size_t i = 0; i < oc_string_array_get_allocated_size(types); i++) {
     char *t = oc_string_array_get_item(types, i);
     if (strlen(t) == 11 && strncmp(t, "oic.r.light", 11) == 0) {
       strncpy(light_1, uri, uri_len);

--- a/apps/client_multithread_linux.c
+++ b/apps/client_multithread_linux.c
@@ -248,10 +248,9 @@ discovery_handler(const char *anchor, const char *uri, oc_string_array_t types,
   (void)anchor;
   (void)iface_mask;
   (void)bm;
-  int i;
-  int uri_len = strlen(uri);
+  size_t uri_len = strlen(uri);
   uri_len = (uri_len >= MAX_URI_LENGTH) ? MAX_URI_LENGTH - 1 : uri_len;
-  for (i = 0; i < (int)oc_string_array_get_allocated_size(types); i++) {
+  for (size_t i = 0; i < oc_string_array_get_allocated_size(types); i++) {
     char *t = oc_string_array_get_item(types, i);
     if (strlen(t) == 10 && strncmp(t, "core.light", 10) == 0) {
       strncpy(a_light, uri, uri_len);
@@ -459,7 +458,8 @@ main(void)
   int ret = oc_main_init(&handler);
   if (ret < 0) {
     OC_PRINTF("oc_main_init failed!(%d)\n", ret);
-    goto exit;
+    deinit();
+    return -1;
   }
 
   pthread_t thread;

--- a/apps/client_openthread.c
+++ b/apps/client_openthread.c
@@ -106,11 +106,9 @@ discovery(const char *di, const char *uri, oc_string_array_t types,
   (void)iface_mask;
   (void)user_data;
   (void)bm;
-  int i;
-  int uri_len = strlen(uri);
+  size_t uri_len = strlen(uri);
   uri_len = (uri_len >= MAX_URI_LENGTH) ? MAX_URI_LENGTH - 1 : uri_len;
-
-  for (i = 0; i < (int)oc_string_array_get_allocated_size(types); i++) {
+  for (size_t i = 0; i < oc_string_array_get_allocated_size(types); i++) {
     char *t = oc_string_array_get_item(types, i);
     if (strlen(t) == 11 && strncmp(t, "oic.r.light", 11) == 0) {
       strncpy(light_1, uri, uri_len);

--- a/apps/client_zephyr.c
+++ b/apps/client_zephyr.c
@@ -103,11 +103,9 @@ discovery(const char *anchor, const char *uri, oc_string_array_t types,
   (void)iface_mask;
   (void)user_data;
   (void)bm;
-  int i;
-  int uri_len = strlen(uri);
+  size_t uri_len = strlen(uri);
   uri_len = (uri_len >= MAX_URI_LENGTH) ? MAX_URI_LENGTH - 1 : uri_len;
-
-  for (i = 0; i < (int)oc_string_array_get_allocated_size(types); i++) {
+  for (size_t i = 0; i < (int)oc_string_array_get_allocated_size(types); i++) {
     char *t = oc_string_array_get_item(types, i);
     if (strlen(t) == 11 && strncmp(t, "oic.r.light", 11) == 0) {
       light_server = endpoint;

--- a/apps/cloud_client.c
+++ b/apps/cloud_client.c
@@ -22,6 +22,7 @@
 #include "oc_log.h"
 #include "oc_pki.h"
 #include "util/oc_atomic.h"
+
 #include <inttypes.h>
 #include <signal.h>
 #if defined(_WIN32)

--- a/apps/cloud_proxy.c
+++ b/apps/cloud_proxy.c
@@ -147,7 +147,6 @@
 #include "oc_log.h"
 #include "oc_pki.h"
 #include "port/oc_clock.h"
-#include <signal.h>
 
 #ifdef OC_CLOUD
 #include "oc_cloud.h"
@@ -156,6 +155,8 @@
 #ifdef OC_IDD_API
 #include "oc_introspection.h"
 #endif /* OC_IDD_API */
+
+#include <signal.h>
 
 #ifndef DOXYGEN
 // Force doxygen to document static inline
@@ -1595,11 +1596,14 @@ cloud_status_handler(oc_cloud_context_t *ctx, oc_cloud_status_t status,
     OC_PRINTF("\t\t-Refreshed Token\n");
   }
 
-  OC_PRINTF("   AC   = %s\n", oc_string(ctx->store.access_token));
-  OC_PRINTF("   AP   = %s\n", oc_string(ctx->store.auth_provider));
-  OC_PRINTF("   CI   = %s\n", oc_string(ctx->store.ci_server));
-
-  OC_PRINTF("   UUID = %s\n", oc_string(ctx->store.uid));
+  const char *at = oc_string(ctx->store.access_token);
+  OC_PRINTF("   AC   = %s\n", at != NULL ? at : "");
+  const char *ap = oc_string(ctx->store.auth_provider);
+  OC_PRINTF("   AP   = %s\n", ap != NULL ? ap : "");
+  const char *ci = oc_string(ctx->store.ci_server);
+  OC_PRINTF("   CI   = %s\n", ci != NULL ? ci : "");
+  const char *uid = oc_string(ctx->store.uid);
+  OC_PRINTF("   UUID = %s\n", uid != NULL ? uid : "");
 }
 #endif // OC_CLOUD
 

--- a/apps/cloud_proxy.c
+++ b/apps/cloud_proxy.c
@@ -1572,7 +1572,7 @@ cloud_status_handler(oc_cloud_context_t *ctx, oc_cloud_status_t status,
   }
   if (status & OC_CLOUD_TOKEN_EXPIRY) {
     OC_PRINTF("\t\t-Token Expiry: ");
-    if (ctx) {
+    if (ctx != NULL) {
       OC_PRINTF("%d\n", oc_cloud_get_token_expiry(ctx));
     } else {
       OC_PRINTF("\n");
@@ -1596,14 +1596,16 @@ cloud_status_handler(oc_cloud_context_t *ctx, oc_cloud_status_t status,
     OC_PRINTF("\t\t-Refreshed Token\n");
   }
 
-  const char *at = oc_string(ctx->store.access_token);
-  OC_PRINTF("   AC   = %s\n", at != NULL ? at : "");
-  const char *ap = oc_string(ctx->store.auth_provider);
-  OC_PRINTF("   AP   = %s\n", ap != NULL ? ap : "");
-  const char *ci = oc_string(ctx->store.ci_server);
-  OC_PRINTF("   CI   = %s\n", ci != NULL ? ci : "");
-  const char *uid = oc_string(ctx->store.uid);
-  OC_PRINTF("   UUID = %s\n", uid != NULL ? uid : "");
+  if (ctx != NULL) {
+    const char *at = oc_string(ctx->store.access_token);
+    OC_PRINTF("   AC   = %s\n", at != NULL ? at : "");
+    const char *ap = oc_string(ctx->store.auth_provider);
+    OC_PRINTF("   AP   = %s\n", ap != NULL ? ap : "");
+    const char *ci = oc_string(ctx->store.ci_server);
+    OC_PRINTF("   CI   = %s\n", ci != NULL ? ci : "");
+    const char *uid = oc_string(ctx->store.uid);
+    OC_PRINTF("   UUID = %s\n", uid != NULL ? uid : "");
+  }
 }
 #endif // OC_CLOUD
 

--- a/apps/cloud_server.c
+++ b/apps/cloud_server.c
@@ -20,7 +20,6 @@
 #include "oc_acl.h"
 #include "oc_api.h"
 #include "oc_certs.h"
-#include "oc_clock_util.h"
 #include "oc_core_res.h"
 #include "oc_log.h"
 #include "oc_pki.h"

--- a/apps/push_configurator_multithread_linux.c
+++ b/apps/push_configurator_multithread_linux.c
@@ -268,11 +268,9 @@ cb_discovery(const char *anchor, const char *uri, oc_string_array_t types,
 
   (void)anchor;
   (void)iface_mask;
-  int i;
-  int uri_len = strlen(uri);
+  size_t uri_len = strlen(uri);
   uri_len = (uri_len >= MAX_URI_LENGTH) ? MAX_URI_LENGTH - 1 : uri_len;
-
-  for (i = 0; i < (int)oc_string_array_get_allocated_size(types); i++) {
+  for (size_t i = 0; i < oc_string_array_get_allocated_size(types); i++) {
     char *t = oc_string_array_get_item(types, i);
     if (strlen(t) == strlen(resource_rt) &&
         strncmp(t, resource_rt, strlen(t)) == 0) {
@@ -522,7 +520,8 @@ main(void)
   int ret = oc_main_init(&handler);
   if (ret < 0) {
     OC_PRINTF("oc_main_init failed!(%d)\n", ret);
-    goto exit;
+    deinit();
+    return ret;
   }
 
   pthread_t thread;

--- a/apps/push_originserver_multithread_linux.c
+++ b/apps/push_originserver_multithread_linux.c
@@ -343,7 +343,8 @@ main(void)
   int ret = oc_main_init(&handler);
   if (ret < 0) {
     printf("oc_main_init failed!(%d)\n", ret);
-    goto exit;
+    deinit();
+    return ret;
   }
 
   size_t device_num = oc_core_get_num_devices();

--- a/apps/push_targetserver_multithread_linux.c
+++ b/apps/push_targetserver_multithread_linux.c
@@ -198,7 +198,8 @@ main(void)
   int ret = oc_main_init(&handler);
   if (ret < 0) {
     printf("oc_main_init failed!(%d)\n", ret);
-    goto exit;
+    deinit();
+    return ret;
   }
 
   size_t device_num = oc_core_get_num_devices();

--- a/apps/secure_mcast_server1.c
+++ b/apps/secure_mcast_server1.c
@@ -88,7 +88,9 @@ update_light_switch(oc_request_t *request, oc_interface_mask_t iface_mask,
       break;
     default:
       code = OC_STATUS_BAD_REQUEST;
-      return;
+      break;
+    }
+    if (code == OC_STATUS_BAD_REQUEST) {
       break;
     }
     rep = rep->next;

--- a/apps/secure_mcast_server2.c
+++ b/apps/secure_mcast_server2.c
@@ -88,7 +88,9 @@ update_light_switch(oc_request_t *request, oc_interface_mask_t iface_mask,
       break;
     default:
       code = OC_STATUS_BAD_REQUEST;
-      return;
+      break;
+    }
+    if (code == OC_STATUS_BAD_REQUEST) {
       break;
     }
     rep = rep->next;

--- a/apps/server_block_linux.c
+++ b/apps/server_block_linux.c
@@ -20,6 +20,7 @@
 #include "port/oc_clock.h"
 #include "oc_log.h"
 #include "port/oc_random.h"
+
 #include <inttypes.h>
 #include <pthread.h>
 #include <signal.h>
@@ -50,8 +51,7 @@ handle_array_response(void *data)
   if (array_response.active) {
     oc_set_separate_response_buffer(&array_response);
     OC_PRINTF("GET_array:\n");
-    int i;
-    for (i = 0; i < 100; i++) {
+    for (int i = 0; i < 100; i++) {
       large_array[i] = oc_random_value();
       OC_PRINTF("(%d %d) ", i, large_array[i]);
     }

--- a/apps/server_block_linux.c
+++ b/apps/server_block_linux.c
@@ -52,7 +52,7 @@ handle_array_response(void *data)
     oc_set_separate_response_buffer(&array_response);
     OC_PRINTF("GET_array:\n");
     for (int i = 0; i < 100; i++) {
-      large_array[i] = oc_random_value();
+      large_array[i] = (int)oc_random_value();
       OC_PRINTF("(%d %d) ", i, large_array[i]);
     }
     OC_PRINTF("\n");

--- a/apps/server_certification_tests.c
+++ b/apps/server_certification_tests.c
@@ -23,6 +23,7 @@
 #include "oc_swupdate.h"
 #include "port/oc_clock.h"
 #include "util/oc_atomic.h"
+
 #include <inttypes.h>
 #include <pthread.h>
 #include <signal.h>
@@ -1161,9 +1162,9 @@ post_dali(oc_request_t *request, oc_interface_mask_t interfaces,
                                    &g_dali_tbus_array_size);
             /* copy over the data of the retrieved (byte) array to the global
              * variable */
-            for (int j = 0; j < (int)g_dali_tbus_array_size; j++) {
+            for (size_t j = 0; j < g_dali_tbus_array_size; j++) {
               OC_PRINTF(" byte %d ", temp_array[j]);
-              g_dali_tbus[j] = temp_array[j];
+              g_dali_tbus[j] = (int)temp_array[j];
             }
           } else {
             int64_t *temp_integer = 0;
@@ -1171,9 +1172,9 @@ post_dali(oc_request_t *request, oc_interface_mask_t interfaces,
                                  &g_dali_tbus_array_size);
             /* copy over the data of the retrieved (integer) array to the global
              * variable */
-            for (int j = 0; j < (int)g_dali_tbus_array_size; j++) {
+            for (size_t j = 0; j < g_dali_tbus_array_size; j++) {
               OC_PRINTF(" integer %" PRId64 " ", temp_integer[j]);
-              g_dali_tbus[j] = temp_integer[j];
+              g_dali_tbus[j] = (int)temp_integer[j];
             }
           }
         }
@@ -2011,10 +2012,10 @@ initialize_variables(void)
   oc_storage_read("g_switch_storage_status",
                   (uint8_t *)&g_switch_storage_status,
                   sizeof(g_switch_storage_status));
-  int ret_size = oc_storage_read("g_switch_value", (uint8_t *)&g_switch_value,
-                                 sizeof(g_switch_value));
+  long ret_size = oc_storage_read("g_switch_value", (uint8_t *)&g_switch_value,
+                                  sizeof(g_switch_value));
   if (ret_size != sizeof(g_switch_value)) {
-    OC_PRINTF(" could not read store g_switch_value : %d\n", ret_size);
+    OC_PRINTF(" could not read store g_switch_value : %ld\n", ret_size);
   }
 #endif /* OC_STORAGE */
 }

--- a/apps/server_certification_tests.c
+++ b/apps/server_certification_tests.c
@@ -678,7 +678,7 @@ post_temp(oc_request_t *request, oc_interface_mask_t iface_mask,
   bool out_of_range = false;
   double t = -1;
   units_t units = C;
-  oc_rep_t *rep = request->request_payload;
+  const oc_rep_t *rep = request->request_payload;
   while (rep != NULL) {
     switch (rep->type) {
     case OC_REP_DOUBLE:
@@ -827,7 +827,7 @@ post_switch(oc_request_t *request, oc_interface_mask_t iface_mask,
   bool state = false;
   bool bad_request = false;
   bool var_in_request = false;
-  oc_rep_t *rep = request->request_payload;
+  const oc_rep_t *rep = request->request_payload;
   while (rep != NULL) {
     switch (rep->type) {
     case OC_REP_BOOL:
@@ -984,12 +984,11 @@ post_dali(oc_request_t *request, oc_interface_mask_t interfaces,
   (void)user_data;
   bool error_state = false;
   OC_PRINTF("-- Begin post_dali:\n");
-  oc_rep_t *rep = request->request_payload;
 
   /* loop over the request document for each required input field to check if
    * all required input fields are present */
   bool var_in_request = false;
-  rep = request->request_payload;
+  const oc_rep_t *rep = request->request_payload;
   while (rep != NULL) {
     if (strcmp(oc_string(rep->name), g_dali_RESOURCE_PROPERTY_NAME_pld) == 0) {
       var_in_request = true;
@@ -1095,7 +1094,7 @@ post_dali(oc_request_t *request, oc_interface_mask_t interfaces,
     switch (interfaces) {
     default: {
       /* loop over all the properties in the input document */
-      oc_rep_t *rep = request->request_payload;
+      const oc_rep_t *rep = request->request_payload;
       while (rep != NULL) {
         OC_PRINTF("key: (assign) %s \n", oc_string(rep->name));
         /* no error: assign the variables */
@@ -1322,12 +1321,11 @@ post_dali_config(oc_request_t *request, oc_interface_mask_t interfaces,
   (void)user_data;
   bool error_state = false;
   OC_PRINTF("-- Begin post_config:\n");
-  oc_rep_t *rep = request->request_payload;
 
   /* loop over the request document for each required input field to check if
    * all required input fields are present */
   /* loop over the request document to check if all inputs are ok */
-  rep = request->request_payload;
+  const oc_rep_t *rep = request->request_payload;
   while (rep != NULL) {
     OC_PRINTF("key: (check) %s \n", oc_string(rep->name));
 
@@ -1361,7 +1359,7 @@ post_dali_config(oc_request_t *request, oc_interface_mask_t interfaces,
     switch (interfaces) {
     default: {
       /* loop over all the properties in the input document */
-      oc_rep_t *rep = request->request_payload;
+      const oc_rep_t *rep = request->request_payload;
       while (rep != NULL) {
         OC_PRINTF("key: (assign) %s \n", oc_string(rep->name));
         /* no error: assign the variables */
@@ -1463,7 +1461,7 @@ post_cswitch(oc_request_t *request, oc_interface_mask_t iface_mask,
 {
   (void)iface_mask;
   oc_switch_t *cswitch = (oc_switch_t *)user_data;
-  oc_rep_t *rep = request->request_payload;
+  const oc_rep_t *rep = request->request_payload;
   bool bad_request = false;
   while (rep) {
     switch (rep->type) {

--- a/apps/server_multithread_linux.c
+++ b/apps/server_multithread_linux.c
@@ -329,7 +329,8 @@ main(void)
   int ret = oc_main_init(&handler);
   if (ret < 0) {
     printf("oc_main_init failed!(%d)\n", ret);
-    goto exit;
+    deinit();
+    return ret;
   }
 
   size_t device_num = oc_core_get_num_devices();

--- a/apps/server_rules.c
+++ b/apps/server_rules.c
@@ -281,7 +281,6 @@ POST method.
 * The input values (as a set) are checked if all supplied values are correct.
 * If the input values are correct, they will be assigned to the global  property
 values.
-* Resource Description:
 */
 static void
 post_binaryswitch(oc_request_t *request, oc_interface_mask_t interfaces,
@@ -374,7 +373,6 @@ POST method.
 * The input values (as a set) are checked if all supplied values are correct.
 * If the input values are correct, they will be assigned to the global  property
 values.
-* Resource Description:
 */
 static void
 post_audio(oc_request_t *request, oc_interface_mask_t interfaces,
@@ -541,7 +539,6 @@ POST method.
 * The input values (as a set) are checked if all supplied values are correct.
 * If the input values are correct, they will be assigned to the global  property
 values.
-* Resource Description:
 */
 static void
 post_ruleexpression(oc_request_t *request, oc_interface_mask_t interfaces,
@@ -637,7 +634,6 @@ POST method.
 * The input values (as a set) are checked if all supplied values are correct.
 * If the input values are correct, they will be assigned to the global  property
 values.
-* Resource Description:
 */
 static void
 post_ruleaction(oc_request_t *request, oc_interface_mask_t interfaces,

--- a/apps/server_rules.c
+++ b/apps/server_rules.c
@@ -219,7 +219,7 @@ toggle_switch_resource(void *data)
 {
   (void)data;
   while (OC_ATOMIC_LOAD8(quit) != 1) {
-    char c = getchar();
+    int c = getchar();
     if (OC_ATOMIC_LOAD8(quit) != 1) {
       getchar();
       if (c == 48) {

--- a/apps/simpleclient.c
+++ b/apps/simpleclient.c
@@ -198,10 +198,9 @@ discovery(const char *anchor, const char *uri, oc_string_array_t types,
   (void)user_data;
   (void)iface_mask;
   (void)bm;
-  int i;
-  int uri_len = strlen(uri);
+  size_t uri_len = strlen(uri);
   uri_len = (uri_len >= MAX_URI_LENGTH) ? MAX_URI_LENGTH - 1 : uri_len;
-  for (i = 0; i < (int)oc_string_array_get_allocated_size(types); i++) {
+  for (size_t i = 0; i < oc_string_array_get_allocated_size(types); i++) {
     char *t = oc_string_array_get_item(types, i);
     if (strlen(t) == 10 && strncmp(t, "core.light", 10) == 0) {
       oc_endpoint_list_copy(&light_server, endpoint);

--- a/apps/simpleserver-TVAppAndAction.c
+++ b/apps/simpleserver-TVAppAndAction.c
@@ -161,7 +161,6 @@ POST method.
 * The input values (as a set) are checked if all supplied values are correct.
 * If the input values are correct, they will be assigned to the global  property
 values.
-* Resource Description:
 */
 static void
 post_binaryswitch(oc_request_t *request, oc_interface_mask_t interfaces,

--- a/apps/temp_sensor_client_linux.c
+++ b/apps/temp_sensor_client_linux.c
@@ -79,11 +79,9 @@ discovery(const char *anchor, const char *uri, oc_string_array_t types,
   (void)iface_mask;
   (void)user_data;
   (void)bm;
-  int i;
-  int uri_len = strlen(uri);
+  size_t uri_len = strlen(uri);
   uri_len = (uri_len >= MAX_URI_LENGTH) ? MAX_URI_LENGTH - 1 : uri_len;
-
-  for (i = 0; i < (int)oc_string_array_get_allocated_size(types); i++) {
+  for (size_t i = 0; i < oc_string_array_get_allocated_size(types); i++) {
     char *t = oc_string_array_get_item(types, i);
     if (strlen(t) == 16 && strncmp(t, "oic.r.tempsensor", 16) == 0) {
       oc_endpoint_list_copy(&temp_sensor, endpoint);

--- a/include/oc_clock_util.h
+++ b/include/oc_clock_util.h
@@ -26,7 +26,6 @@
 #include "util/oc_compiler.h"
 #include <stdbool.h>
 #include <stddef.h>
-#include <time.h>
 
 #ifdef OC_HAVE_TIME_H
 #include <time.h>
@@ -121,11 +120,6 @@ bool oc_clock_monotonic_time_to_posix(oc_clock_time_t time_mt,
 #endif /* OC_HAVE_CLOCKID_T */
 
 #endif /* OC_HAVE_TIME_H */
-
-/**
- * @brief Convert clock time into a C struct timespec
- */
-struct timespec oc_clock_time_to_timespec(oc_clock_time_t time);
 
 #ifdef __cplusplus
 }

--- a/include/oc_clock_util.h
+++ b/include/oc_clock_util.h
@@ -26,6 +26,7 @@
 #include "util/oc_compiler.h"
 #include <stdbool.h>
 #include <stddef.h>
+#include <time.h>
 
 #ifdef OC_HAVE_TIME_H
 #include <time.h>
@@ -120,6 +121,11 @@ bool oc_clock_monotonic_time_to_posix(oc_clock_time_t time_mt,
 #endif /* OC_HAVE_CLOCKID_T */
 
 #endif /* OC_HAVE_TIME_H */
+
+/**
+ * @brief Convert clock time into a C struct timespec
+ */
+struct timespec oc_clock_time_to_timespec(oc_clock_time_t time);
 
 #ifdef __cplusplus
 }

--- a/include/oc_rep.h
+++ b/include/oc_rep.h
@@ -23,12 +23,14 @@
 #define OC_REP_H
 
 #include <cbor.h>
+#include "oc_config.h"
 #include "oc_export.h"
 #include "oc_helpers.h"
+#include "util/oc_compiler.h"
 #include "util/oc_memb.h"
 #include "util/oc_features.h"
-#include <oc_config.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -49,7 +51,17 @@ extern int g_err;
  * @param[in] max_size maximum size the encoder buffer
  */
 OC_API
-void oc_rep_new_realloc(uint8_t **payload, int size, int max_size);
+void oc_rep_new_realloc_v1(uint8_t **payload, size_t size, size_t max_size)
+  OC_NONNULL();
+
+/**
+ * Initialize the buffer used to hold the cbor encoded data with reallocation.
+ *
+ * @deprecated replaced by oc_rep_new_realloc_v1 in v2.2.5.6
+ */
+OC_API
+void oc_rep_new_realloc(uint8_t **payload, int size, int max_size) OC_NONNULL()
+  OC_DEPRECATED("replaced by oc_rep_new_realloc_v1 in v2.2.5.6");
 
 /**
  * Initialize the buffer used to hold the cbor encoded data without
@@ -61,7 +73,17 @@ void oc_rep_new_realloc(uint8_t **payload, int size, int max_size);
  * @param[in] size size of the payload buffer
  */
 OC_API
-void oc_rep_new(uint8_t *payload, int size);
+void oc_rep_new_v1(uint8_t *payload, size_t size) OC_NONNULL();
+
+/**
+ * Initialize the buffer used to hold the cbor encoded data without
+ * reallocation.
+ *
+ * @deprecated replaced by oc_rep_new_v1 in v2.2.5.6
+ */
+OC_API
+void oc_rep_new(uint8_t *payload, int size) OC_NONNULL()
+  OC_DEPRECATED("replaced by oc_rep_new_v1 in v2.2.5.6");
 
 /**
  * @brief Get the global cbor encoder
@@ -69,7 +91,7 @@ void oc_rep_new(uint8_t *payload, int size);
  * @return global cbor encoder
  */
 OC_API
-CborEncoder *oc_rep_get_encoder(void);
+CborEncoder *oc_rep_get_encoder(void) OC_RETURNS_NONNULL;
 
 /**
  * Get the size of the encoder buffer.

--- a/include/oc_uuid.h
+++ b/include/oc_uuid.h
@@ -27,6 +27,7 @@
 #define OC_UUID_H
 
 #include "oc_export.h"
+#include "util/oc_compiler.h"
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -67,10 +68,10 @@ typedef struct
  * oc_str_to_uuid("1628fbcc-13ce-4e37-b883-1fd8d2ad945d", &uuid);
  * ```
  * @param[in] str the UUID string
- * @param[out] uuid the oc_uuid_t to hold the UUID bits.
+ * @param[out] uuid the oc_uuid_t to hold the UUID bits (cannot be NULL).
  */
 OC_API
-void oc_str_to_uuid(const char *str, oc_uuid_t *uuid);
+void oc_str_to_uuid(const char *str, oc_uuid_t *uuid) OC_NONNULL(2);
 
 /**
  * Convert the 128 bit oc_uuid_t to a string representation.
@@ -113,7 +114,7 @@ void oc_uuid_to_str(const oc_uuid_t *uuid, char *buffer, size_t buflen);
  * @param[out] uuid the randomly generated UUID
  */
 OC_API
-void oc_gen_uuid(oc_uuid_t *uuid);
+void oc_gen_uuid(oc_uuid_t *uuid) OC_NONNULL();
 
 /**
  * @brief Compare two uuid values.

--- a/messaging/coap/coap.c
+++ b/messaging/coap/coap.c
@@ -47,24 +47,28 @@
  * This file is part of the Contiki operating system.
  */
 
-#include <stdio.h>
-#include <string.h>
-#include <inttypes.h>
-
 #include "coap.h"
 #include "coap_internal.h"
+#include "oc_ri.h"
 #include "transactions.h"
+#include "util/oc_macros_internal.h"
+
 #ifdef OC_OSCORE
 #include "oscore.h"
 #endif /* OC_OSCORE */
+
 #ifdef OC_TCP
 #include "coap_signal.h"
 #endif /* OC_TCP */
-#include "oc_ri.h"
+
 #ifdef OC_SECURITY
 #include "security/oc_audit.h"
 #include "security/oc_tls_internal.h"
 #endif /* OC_SECURITY */
+
+#include <stdio.h>
+#include <string.h>
+#include <inttypes.h>
 
 /* option format serialization */
 #define COAP_SERIALIZE_INT_OPTION(number, field, text)                         \
@@ -1812,25 +1816,22 @@ coap_set_header_location_query(void *packet, const char *query)
 }
 /*---------------------------------------------------------------------------*/
 int
-coap_get_header_observe(const void *packet, int32_t *observe)
+coap_get_header_observe(const coap_packet_t *packet, int32_t *observe)
 {
-  const coap_packet_t *const coap_pkt = (const coap_packet_t *)packet;
-
-  if (!IS_OPTION(coap_pkt, COAP_OPTION_OBSERVE)) {
+  if (!IS_OPTION(packet, COAP_OPTION_OBSERVE)) {
     return 0;
   }
-  *observe = coap_pkt->observe;
+  *observe = packet->observe;
   return 1;
 }
-int
-coap_set_header_observe(void *packet, int32_t observe)
-{
-  coap_packet_t *const coap_pkt = (coap_packet_t *)packet;
 
-  coap_pkt->observe = observe;
-  SET_OPTION(coap_pkt, COAP_OPTION_OBSERVE);
-  return 1;
+void
+coap_set_header_observe(coap_packet_t *packet, int32_t observe)
+{
+  packet->observe = observe;
+  SET_OPTION(packet, COAP_OPTION_OBSERVE);
 }
+
 /*---------------------------------------------------------------------------*/
 int
 coap_get_header_block2(const void *packet, uint32_t *num, uint8_t *more,

--- a/messaging/coap/coap.c
+++ b/messaging/coap/coap.c
@@ -270,7 +270,7 @@ coap_serialize_int_option(unsigned int number, unsigned int current_number,
 static size_t
 coap_serialize_array_option(unsigned int number, unsigned int current_number,
                             uint8_t *buffer, uint8_t *array, size_t length,
-                            char split_char)
+                            unsigned char split_char)
 {
   size_t i = 0;
 
@@ -1615,7 +1615,7 @@ coap_set_header_etag(void *packet, const uint8_t *etag, size_t etag_len)
   return coap_pkt->etag_len;
 }
 /*---------------------------------------------------------------------------*/
-int
+size_t
 coap_get_header_proxy_uri(const void *packet, const char **uri)
 {
   const coap_packet_t *const coap_pkt = (const coap_packet_t *)packet;
@@ -1626,7 +1626,7 @@ coap_get_header_proxy_uri(const void *packet, const char **uri)
   *uri = coap_pkt->proxy_uri;
   return coap_pkt->proxy_uri_len;
 }
-int
+size_t
 coap_set_header_proxy_uri(void *packet, const char *uri)
 {
   coap_packet_t *const coap_pkt = (coap_packet_t *)packet;
@@ -1965,7 +1965,7 @@ coap_set_header_size1(void *packet, uint32_t size)
   return 1;
 }
 /*---------------------------------------------------------------------------*/
-int
+uint32_t
 coap_get_payload(const void *packet, const uint8_t **payload)
 {
   const coap_packet_t *const coap_pkt = (const coap_packet_t *)packet;
@@ -1973,24 +1973,23 @@ coap_get_payload(const void *packet, const uint8_t **payload)
   if (coap_pkt->payload) {
     *payload = coap_pkt->payload;
     return coap_pkt->payload_len;
-  } else {
-    *payload = NULL;
-    return 0;
   }
+  *payload = NULL;
+  return 0;
 }
-int
-coap_set_payload(void *packet, const void *payload, size_t length)
+uint32_t
+coap_set_payload(void *packet, const void *payload, uint32_t length)
 {
   coap_packet_t *const coap_pkt = (coap_packet_t *)packet;
 
   coap_pkt->payload = (uint8_t *)payload;
 #ifdef OC_TCP
   if (coap_pkt->transport_type == COAP_TRANSPORT_TCP) {
-    coap_pkt->payload_len = (uint32_t)length;
+    coap_pkt->payload_len = length;
   } else
 #endif /* OC_TCP */
   {
-    coap_pkt->payload_len = (uint32_t)MIN((unsigned)OC_BLOCK_SIZE, length);
+    coap_pkt->payload_len = MIN((uint32_t)OC_BLOCK_SIZE, length);
   }
 
   return coap_pkt->payload_len;

--- a/messaging/coap/coap.c
+++ b/messaging/coap/coap.c
@@ -1811,7 +1811,7 @@ coap_set_header_location_query(void *packet, const char *query)
 }
 /*---------------------------------------------------------------------------*/
 int
-coap_get_header_observe(const void *packet, uint32_t *observe)
+coap_get_header_observe(const void *packet, int32_t *observe)
 {
   const coap_packet_t *const coap_pkt = (const coap_packet_t *)packet;
 
@@ -1822,7 +1822,7 @@ coap_get_header_observe(const void *packet, uint32_t *observe)
   return 1;
 }
 int
-coap_set_header_observe(void *packet, uint32_t observe)
+coap_set_header_observe(void *packet, int32_t observe)
 {
   coap_packet_t *const coap_pkt = (coap_packet_t *)packet;
 

--- a/messaging/coap/coap.c
+++ b/messaging/coap/coap.c
@@ -290,7 +290,7 @@ coap_serialize_array_option(unsigned int number, unsigned int current_number,
         OC_DBG("STEP %zu/%zu (%c)", j, length, array[j]);
       }
 
-      if (array[j] == (uint8_t)split_char || j == length) {
+      if (array[j] == split_char || j == length) {
         part_end = array + j;
         temp_length = part_end - part_start;
 
@@ -845,7 +845,8 @@ coap_oscore_parse_option(coap_packet_t *const coap_pkt, uint8_t *current_option,
       break;
 #endif
     case COAP_OPTION_OBSERVE:
-      coap_pkt->observe = coap_parse_int_option(current_option, option_length);
+      coap_pkt->observe =
+        (int32_t)coap_parse_int_option(current_option, option_length);
       OC_DBG("  Observe [%lu]", (unsigned long)coap_pkt->observe);
       break;
     case COAP_OPTION_BLOCK2:

--- a/messaging/coap/coap.h
+++ b/messaging/coap/coap.h
@@ -106,7 +106,7 @@ typedef struct
   uint8_t token_len;
   uint8_t token[COAP_TOKEN_LEN];
 
-  uint8_t options[COAP_OPTION_SIZE1 / (int)OPTION_MAP_SIZE +
+  uint8_t options[COAP_OPTION_SIZE1 / OPTION_MAP_SIZE +
                   1]; /* bitmap to check if option is set */
 
   uint16_t content_format; /* parse options once and store; allows setting

--- a/messaging/coap/coap.h
+++ b/messaging/coap/coap.h
@@ -52,11 +52,6 @@
 
 #include "conf.h"
 #include "constants.h"
-#include <stddef.h> /* for size_t */
-#include <stdint.h>
-#ifdef OC_OSCORE
-#include "oscore_constants.h"
-#endif /* OC_OSCORE */
 #include "oc_buffer.h"
 #include "oc_config.h"
 #include "oc_ri.h"
@@ -64,20 +59,15 @@
 #include "port/oc_log_internal.h"
 #include "port/oc_random.h"
 
+#ifdef OC_OSCORE
+#include "oscore_constants.h"
+#endif /* OC_OSCORE */
+
+#include <stddef.h> /* size_t */
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
-#endif
-
-#ifndef MAX
-#define MAX(n, m) (((n) < (m)) ? (m) : (n))
-#endif
-
-#ifndef MIN
-#define MIN(n, m) (((n) < (m)) ? (n) : (m))
-#endif
-
-#ifndef ABS
-#define ABS(n) (((n) < 0) ? -(n) : (n))
 #endif
 
 /* bitmap for set options */
@@ -90,7 +80,17 @@ enum { OPTION_MAP_SIZE = sizeof(uint8_t) * 8 };
    (1 << ((opt) % OPTION_MAP_SIZE)))
 
 /* enum value for coap transport type  */
-typedef enum { COAP_TRANSPORT_UDP, COAP_TRANSPORT_TCP } coap_transport_type_t;
+typedef enum {
+  COAP_TRANSPORT_UDP,
+  COAP_TRANSPORT_TCP,
+} coap_transport_type_t;
+
+enum {
+  OC_COAP_OBSERVE_NOT_SET = -1,
+  OC_COAP_OBSERVE_REGISTER = 0,
+  OC_COAP_OBSERVE_UNREGISTER = 1,
+  // observe values [2, 2^24-1] are used for the sequence number
+};
 
 /* parsed message struct */
 typedef struct
@@ -265,8 +265,8 @@ int coap_get_header_location_query(
   const char **query); /* in-place string might not be 0-terminated. */
 size_t coap_set_header_location_query(void *packet, const char *query);
 
-int coap_get_header_observe(const void *packet, int32_t *observe);
-int coap_set_header_observe(void *packet, int32_t observe);
+int coap_get_header_observe(const coap_packet_t *packet, int32_t *observe);
+void coap_set_header_observe(coap_packet_t *packet, int32_t observe);
 
 int coap_get_header_block2(const void *packet, uint32_t *num, uint8_t *more,
                            uint16_t *size, uint32_t *offset);

--- a/messaging/coap/coap.h
+++ b/messaging/coap/coap.h
@@ -265,8 +265,8 @@ int coap_get_header_location_query(
   const char **query); /* in-place string might not be 0-terminated. */
 size_t coap_set_header_location_query(void *packet, const char *query);
 
-int coap_get_header_observe(const void *packet, uint32_t *observe);
-int coap_set_header_observe(void *packet, uint32_t observe);
+int coap_get_header_observe(const void *packet, int32_t *observe);
+int coap_set_header_observe(void *packet, int32_t observe);
 
 int coap_get_header_block2(const void *packet, uint32_t *num, uint8_t *more,
                            uint16_t *size, uint32_t *offset);

--- a/messaging/coap/coap.h
+++ b/messaging/coap/coap.h
@@ -85,13 +85,6 @@ typedef enum {
   COAP_TRANSPORT_TCP,
 } coap_transport_type_t;
 
-enum {
-  OC_COAP_OBSERVE_NOT_SET = -1,
-  OC_COAP_OBSERVE_REGISTER = 0,
-  OC_COAP_OBSERVE_UNREGISTER = 1,
-  // observe values [2, 2^24-1] are used for the sequence number
-};
-
 /* parsed message struct */
 typedef struct
 {
@@ -170,6 +163,15 @@ typedef struct
   uint32_t payload_len;
   uint8_t *payload;
 } coap_packet_t;
+
+typedef enum {
+  OC_COAP_OPTION_OBSERVE_NOT_SET = -1,
+  OC_COAP_OPTION_OBSERVE_REGISTER = 0,
+  OC_COAP_OPTION_OBSERVE_UNREGISTER = 1,
+  // observe values [2, 2^24-1] are used for the sequence number
+  OC_COAP_OPTION_OBSERVE_SEQUENCE_START_VALUE = 2,
+  OC_COAP_OPTION_OBSERVE_MAX_VALUE = ((1 << 24) - 1),
+} oc_coap_option_observe_t;
 
 void coap_init_connection(void);
 uint16_t coap_get_mid(void);

--- a/messaging/coap/coap.h
+++ b/messaging/coap/coap.h
@@ -106,7 +106,7 @@ typedef struct
   uint8_t token_len;
   uint8_t token[COAP_TOKEN_LEN];
 
-  uint8_t options[COAP_OPTION_SIZE1 / OPTION_MAP_SIZE +
+  uint8_t options[COAP_OPTION_SIZE1 / (int)OPTION_MAP_SIZE +
                   1]; /* bitmap to check if option is set */
 
   uint16_t content_format; /* parse options once and store; allows setting
@@ -230,10 +230,10 @@ int coap_set_header_max_age(void *packet, uint32_t age);
 int coap_get_header_etag(const void *packet, const uint8_t **etag);
 int coap_set_header_etag(void *packet, const uint8_t *etag, size_t etag_len);
 
-int coap_get_header_proxy_uri(
+size_t coap_get_header_proxy_uri(
   const void *packet,
   const char **uri); /* in-place string might not be 0-terminated. */
-int coap_set_header_proxy_uri(void *packet, const char *uri);
+size_t coap_set_header_proxy_uri(void *packet, const char *uri);
 
 int coap_get_header_proxy_scheme(
   void *packet,
@@ -284,8 +284,8 @@ int coap_set_header_size2(void *packet, uint32_t size);
 int coap_get_header_size1(const void *packet, uint32_t *size);
 int coap_set_header_size1(void *packet, uint32_t size);
 
-int coap_get_payload(const void *packet, const uint8_t **payload);
-int coap_set_payload(void *packet, const void *payload, size_t length);
+uint32_t coap_get_payload(const void *packet, const uint8_t **payload);
+uint32_t coap_set_payload(void *packet, const void *payload, uint32_t length);
 
 size_t coap_set_option_header(unsigned int delta, size_t length,
                               uint8_t *buffer);

--- a/messaging/coap/engine.c
+++ b/messaging/coap/engine.c
@@ -307,7 +307,7 @@ coap_receive(oc_message_t *msg)
 #ifdef OC_BLOCK_WISE
         const uint8_t *incoming_block;
         uint32_t incoming_block_len =
-          (uint32_t)coap_get_payload(message, &incoming_block);
+          coap_get_payload(message, &incoming_block);
         if (block1) {
           OC_DBG("processing block1 option");
           request_buffer = oc_blockwise_find_request_buffer(
@@ -751,7 +751,7 @@ coap_receive(oc_message_t *msg)
 
         const uint8_t *incoming_block;
         uint32_t incoming_block_len =
-          (uint32_t)coap_get_payload(message, &incoming_block);
+          coap_get_payload(message, &incoming_block);
         if (incoming_block_len > 0 &&
             oc_blockwise_handle_block(response_buffer, block2_offset,
                                       incoming_block,

--- a/messaging/coap/engine.c
+++ b/messaging/coap/engine.c
@@ -746,8 +746,7 @@ coap_receive(oc_message_t *msg)
         client_cb = (oc_client_cb_t *)response_buffer->client_cb;
         oc_blockwise_response_state_t *response_state =
           (oc_blockwise_response_state_t *)response_buffer;
-        coap_get_header_observe(message,
-                                (uint32_t *)&response_state->observe_seq);
+        coap_get_header_observe(message, &response_state->observe_seq);
 
         const uint8_t *incoming_block;
         uint32_t incoming_block_len =

--- a/messaging/coap/engine.c
+++ b/messaging/coap/engine.c
@@ -860,7 +860,7 @@ send_message:
       else {
         oc_blockwise_response_state_t *b =
           (oc_blockwise_response_state_t *)response_buffer;
-        if (b && b->observe_seq != OC_COAP_OBSERVE_NOT_SET) {
+        if (b && b->observe_seq != OC_COAP_OPTION_OBSERVE_NOT_SET) {
           response->token_len = sizeof(response->token);
           oc_random_buffer(response->token, response->token_len);
           if (request_buffer) {

--- a/messaging/coap/engine.c
+++ b/messaging/coap/engine.c
@@ -57,6 +57,7 @@
 #include "messaging/coap/coap_internal.h"
 #include "oc_api.h"
 #include "oc_buffer.h"
+#include "util/oc_macros_internal.h"
 
 #ifdef OC_SECURITY
 #include "security/oc_audit.h"
@@ -859,7 +860,7 @@ send_message:
       else {
         oc_blockwise_response_state_t *b =
           (oc_blockwise_response_state_t *)response_buffer;
-        if (b && b->observe_seq != -1) {
+        if (b && b->observe_seq != OC_COAP_OBSERVE_NOT_SET) {
           response->token_len = sizeof(response->token);
           oc_random_buffer(response->token, response->token_len);
           if (request_buffer) {

--- a/messaging/coap/observe.c
+++ b/messaging/coap/observe.c
@@ -549,8 +549,9 @@ send_notification(coap_observer_t *obs, oc_response_t *response,
                    "for client liveness");
             notification->type = COAP_TYPE_CON;
           }
-          coap_set_payload(notification, response->response_buffer->buffer,
-                           response->response_buffer->response_length);
+          coap_set_payload(
+            notification, response->response_buffer->buffer,
+            (uint32_t)response->response_buffer->response_length);
         } //! blockwise transfer
       }   // !is_revert
 

--- a/messaging/coap/observe.c
+++ b/messaging/coap/observe.c
@@ -641,10 +641,10 @@ coap_notify_collection(oc_collection_t *collection,
   request.method = OC_GET;
 
 #ifdef OC_DYNAMIC_ALLOCATION
-  oc_rep_new_realloc(&response_buffer.buffer, response_buffer.buffer_size,
-                     OC_MAX_OBSERVE_SIZE);
+  oc_rep_new_realloc_v1(&response_buffer.buffer, response_buffer.buffer_size,
+                        OC_MAX_OBSERVE_SIZE);
 #else  /* OC_DYNAMIC_ALLOCATION */
-  oc_rep_new(response_buffer.buffer, response_buffer.buffer_size);
+  oc_rep_new_v1(response_buffer.buffer, response_buffer.buffer_size);
 #endif /* !OC_DYNAMIC_ALLOCATION */
 
   request.resource = (oc_resource_t *)collection;
@@ -725,10 +725,10 @@ coap_notify_collections(oc_resource_t *resource)
 
     request.resource = (oc_resource_t *)collection;
 #ifdef OC_DYNAMIC_ALLOCATION
-    oc_rep_new_realloc(&response_buffer.buffer, response_buffer.buffer_size,
-                       OC_MAX_OBSERVE_SIZE);
+    oc_rep_new_realloc_v1(&response_buffer.buffer, response_buffer.buffer_size,
+                          OC_MAX_OBSERVE_SIZE);
 #else  /* OC_DYNAMIC_ALLOCATION */
-    oc_rep_new(response_buffer.buffer, response_buffer.buffer_size);
+    oc_rep_new_v1(response_buffer.buffer, response_buffer.buffer_size);
 #endif /* !OC_DYNAMIC_ALLOCATION */
 
     if (!oc_handle_collection_request(OC_GET, &request, OC_IF_B, resource)) {
@@ -786,12 +786,12 @@ fill_response(oc_resource_t *resource, const oc_endpoint_t *endpoint,
     iface_mask = resource->default_interface;
   }
 #ifdef OC_DYNAMIC_ALLOCATION
-  oc_rep_new_realloc(&response->response_buffer->buffer,
-                     response->response_buffer->buffer_size,
-                     OC_MAX_OBSERVE_SIZE);
+  oc_rep_new_realloc_v1(&response->response_buffer->buffer,
+                        response->response_buffer->buffer_size,
+                        OC_MAX_OBSERVE_SIZE);
 #else  /* OC_DYNAMIC_ALLOCATION */
-  oc_rep_new(response->response_buffer->buffer,
-             response->response_buffer->buffer_size);
+  oc_rep_new_v1(response->response_buffer->buffer,
+                response->response_buffer->buffer_size);
 #endif /* !OC_DYNAMIC_ALLOCATION */
   if (resource->get_handler.cb) {
     resource->get_handler.cb(&request, iface_mask,
@@ -1080,10 +1080,10 @@ process_batch_observers(void *data)
     }
 #endif /* OC_BLOCK_WISE */
 #ifdef OC_DYNAMIC_ALLOCATION
-    oc_rep_new_realloc(&response_buffer.buffer, response_buffer.buffer_size,
-                       OC_MAX_OBSERVE_SIZE);
+    oc_rep_new_realloc_v1(&response_buffer.buffer, response_buffer.buffer_size,
+                          OC_MAX_OBSERVE_SIZE);
 #else  /* OC_DYNAMIC_ALLOCATION */
-    oc_rep_new(response_buffer.buffer, response_buffer.buffer_size);
+    oc_rep_new_v1(response_buffer.buffer, response_buffer.buffer_size);
 #endif /* !OC_DYNAMIC_ALLOCATION */
     oc_rep_start_links_array();
     int size_before = oc_rep_get_encoded_payload_size();

--- a/messaging/coap/observe.c
+++ b/messaging/coap/observe.c
@@ -159,17 +159,15 @@ remove_discovery_batch_observers(cmp_batch_observer_t *cmp, void *ctx)
 
 /*-------------------*/
 
-#define COAP_OBSERVE_MAX_VALUE ((1 << 24) - 1) // 2^24 - 1
-#define COAP_OBSERVE_START_VALUE (3)
-
-int32_t g_observe_counter = COAP_OBSERVE_START_VALUE;
+int32_t g_observe_counter = OC_COAP_OPTION_OBSERVE_SEQUENCE_START_VALUE;
 
 static int32_t
 observe_increment_observe_counter(int32_t *counter)
 {
   int32_t prev = *counter;
-  prev == COAP_OBSERVE_START_VALUE ? *counter = COAP_OBSERVE_START_VALUE
-                                   : ++(*counter);
+  prev == OC_COAP_OPTION_OBSERVE_MAX_VALUE
+    ? *counter = OC_COAP_OPTION_OBSERVE_SEQUENCE_START_VALUE
+    : ++(*counter);
   return prev;
 }
 
@@ -576,7 +574,8 @@ send_notification(coap_observer_t *obs, oc_response_t *response,
           notification, observe_increment_observe_counter(&obs->obs_counter));
         observe_increment_observe_counter(&g_observe_counter);
       } else {
-        coap_set_header_observe(notification, OC_COAP_OBSERVE_UNREGISTER);
+        coap_set_header_observe(notification,
+                                OC_COAP_OPTION_OBSERVE_UNREGISTER);
       }
       if (response->response_buffer->content_format > 0) {
         coap_set_header_content_format(
@@ -1332,12 +1331,12 @@ coap_observe_handler(const coap_packet_t *request,
       !IS_OPTION(request, COAP_OPTION_OBSERVE)) {
     return -1;
   }
-  if (request->observe == 0) {
+  if (request->observe == OC_COAP_OPTION_OBSERVE_REGISTER) {
     return add_observer(resource, block2_size, endpoint, request->token,
                         request->token_len, request->uri_path,
                         request->uri_path_len, iface_mask);
   }
-  if (request->observe == 1) {
+  if (request->observe == OC_COAP_OPTION_OBSERVE_UNREGISTER) {
     return coap_remove_observer_by_token(endpoint, request->token,
                                          request->token_len);
   }

--- a/messaging/coap/separate.c
+++ b/messaging/coap/separate.c
@@ -69,7 +69,7 @@ OC_MEMB(separate_requests, coap_separate_t, OC_MAX_NUM_CONCURRENT_REQUESTS);
 /**
  * \brief Initiate a separate response with an empty ACK
  * \param request The request to accept
- * \param separate_store A pointer to the data structure that will store the
+ * \param separate_response A pointer to the data structure that will store the
  *   relevant information for the response
  *
  * When the server does not have enough resources left to store the information

--- a/messaging/coap/separate.c
+++ b/messaging/coap/separate.c
@@ -60,7 +60,7 @@
 #include <stdio.h>
 #include <string.h>
 
-OC_MEMB(separate_requests, coap_separate_t, OC_MAX_NUM_CONCURRENT_REQUESTS);
+OC_MEMB(g_separate_requests, coap_separate_t, OC_MAX_NUM_CONCURRENT_REQUESTS);
 
 /*---------------------------------------------------------------------------*/
 /*- Separate Response API ---------------------------------------------------*/
@@ -93,6 +93,10 @@ coap_separate_accept(const coap_packet_t *request,
     OC_LIST_STRUCT_INIT(separate_response, requests);
 #ifdef OC_DYNAMIC_ALLOCATION
     separate_response->buffer = (uint8_t *)malloc(OC_MAX_APP_DATA_SIZE);
+    if (!separate_response->buffer) {
+      OC_WRN("insufficient memory to store separate response");
+      return 0;
+    }
 #endif /* OC_DYNAMIC_ALLOCATION */
   }
 
@@ -108,14 +112,12 @@ coap_separate_accept(const coap_packet_t *request,
   }
 
   if (!separate_store) {
-    separate_store = oc_memb_alloc(&separate_requests);
+    separate_store = oc_memb_alloc(&g_separate_requests);
 
     if (!separate_store) {
       OC_WRN("insufficient memory to store new request for separate response");
       return 0;
     }
-
-    oc_list_add(separate_response->requests, separate_store);
 
     /* store correct response type */
     separate_store->type = COAP_TYPE_NON;
@@ -131,11 +133,13 @@ coap_separate_accept(const coap_packet_t *request,
 #ifdef OC_BLOCK_WISE
     separate_store->block2_size = block2_size;
 #endif /* OC_BLOCK_WISE */
+
+    separate_store->observe = observe;
+
+    oc_list_add(separate_response->requests, separate_store);
   }
 
   memcpy(&separate_store->endpoint, endpoint, sizeof(oc_endpoint_t));
-
-  separate_store->observe = observe;
 
   /* send separate ACK for CON */
   if (request->type == COAP_TYPE_CON) {
@@ -193,7 +197,7 @@ coap_separate_clear(oc_separate_response_t *separate_response,
   oc_free_string(&separate_store->uri);
 #endif /* OC_BLOCK_WISE */
   oc_list_remove(separate_response->requests, separate_store);
-  oc_memb_free(&separate_requests, separate_store);
+  oc_memb_free(&g_separate_requests, separate_store);
 }
 
 #endif /* OC_SERVER */

--- a/messaging/coap/unittest/coapsignaltest.cpp
+++ b/messaging/coap/unittest/coapsignaltest.cpp
@@ -111,11 +111,10 @@ TEST_F(TestCoapSignal, coap_send_pong_message_N)
 
 TEST_F(TestCoapSignal, coap_send_release_message_P)
 {
-  const char *addr = "coap+tcp://127.0.0.1:5683";
-  size_t addr_len = strlen(addr) + 1;
+  std::string addr = "coap+tcp://127.0.0.1:5683";
   uint32_t hold_off = 10;
-
-  int ret = coap_send_release_message(target_ep, addr, addr_len, hold_off);
+  int ret = coap_send_release_message(target_ep, addr.c_str(),
+                                      addr.length() + 1, hold_off);
   EXPECT_EQ(1, ret);
 }
 
@@ -128,10 +127,10 @@ TEST_F(TestCoapSignal, coap_send_release_message_N)
 TEST_F(TestCoapSignal, coap_send_abort_message_P)
 {
   uint16_t opt = 10;
-  const char *msg = "Abort!";
-  size_t msg_len = strlen(msg) + 1;
+  std::string msg = "Abort!";
 
-  int ret = coap_send_abort_message(target_ep, opt, msg, msg_len);
+  int ret =
+    coap_send_abort_message(target_ep, opt, msg.c_str(), msg.length() + 1);
   EXPECT_EQ(1, ret);
 }
 
@@ -393,16 +392,15 @@ TEST_F(TestCoapSignal, SignalSetCustodyTest_N)
 TEST_F(TestCoapSignal, SignalGetAltAddrTest_P)
 {
   coap_packet_t packet{};
-  const char *addr = "coap+tcp://127.0.0.1:5683";
-  size_t addr_len = strlen(addr) + 1;
+  std::string addr = "coap+tcp://127.0.0.1:5683";
   coap_tcp_init_message(&packet, RELEASE_7_04);
-  coap_signal_set_alt_addr(&packet, addr, addr_len);
+  coap_signal_set_alt_addr(&packet, addr.c_str(), addr.length() + 1);
 
   const char *actual = nullptr;
   size_t actual_len = coap_signal_get_alt_addr(&packet, &actual);
 
-  ASSERT_EQ(addr, actual);
-  ASSERT_EQ(addr_len, actual_len);
+  ASSERT_EQ(addr.length() + 1, actual_len);
+  ASSERT_EQ(addr.c_str(), actual);
 }
 
 /*
@@ -432,16 +430,15 @@ TEST_F(TestCoapSignal, SignalSetAltAddrTest_P)
   coap_packet_t packet{};
   coap_tcp_init_message(&packet, RELEASE_7_04);
 
-  const char *addr = "coap+tcp://127.0.0.1:5683";
-  size_t addr_len = strlen(addr) + 1;
-  size_t length = coap_signal_set_alt_addr(&packet, addr, addr_len);
-
-  ASSERT_EQ(addr_len, length);
+  std::string addr = "coap+tcp://127.0.0.1:5683";
+  size_t length =
+    coap_signal_set_alt_addr(&packet, addr.c_str(), addr.length() + 1);
+  ASSERT_EQ(addr.length() + 1, length);
 
   const char *actual = nullptr;
   length = coap_signal_get_alt_addr(&packet, &actual);
-  ASSERT_EQ(addr_len, length);
-  ASSERT_EQ(addr, actual);
+  ASSERT_EQ(addr.length() + 1, length);
+  ASSERT_STREQ(addr.c_str(), actual);
 }
 
 /*
@@ -676,9 +673,8 @@ TEST_F(TestCoapSignal, SignalSerializeParseTest_RELEASE)
   coap_packet_t packet{};
   coap_tcp_init_message(&packet, RELEASE_7_04);
 
-  const char *addr = "coap+tcp://127.0.0.1:5683";
-  size_t addr_len = strlen(addr) + 1;
-  coap_signal_set_alt_addr(&packet, addr, addr_len);
+  std::string addr = "coap+tcp://127.0.0.1:5683";
+  coap_signal_set_alt_addr(&packet, addr.c_str(), addr.length() + 1);
   uint32_t hold_off = 10;
   coap_signal_set_hold_off(&packet, hold_off);
 
@@ -705,9 +701,9 @@ TEST_F(TestCoapSignal, SignalSerializeParseTest_ABORT)
   uint16_t bad_csm_opt = 10;
   coap_signal_set_bad_csm(&packet, bad_csm_opt);
 
-  const char *diagnostic = "BAD CSM OPTION";
-  size_t diagnostic_len = strlen(diagnostic) + 1;
-  coap_set_payload(&packet, diagnostic, diagnostic_len);
+  std::string diagnostic = "BAD CSM OPTION";
+  coap_set_payload(&packet, diagnostic.c_str(),
+                   static_cast<uint32_t>(diagnostic.length() + 1));
 
   std::vector<uint8_t> buffer;
   buffer.reserve(OC_PDU_SIZE);
@@ -720,7 +716,7 @@ TEST_F(TestCoapSignal, SignalSerializeParseTest_ABORT)
   ASSERT_EQ(COAP_NO_ERROR, ret);
   ASSERT_EQ(packet.code, parse_packet.code);
   ASSERT_EQ(packet.bad_csm_opt, parse_packet.bad_csm_opt);
-  ASSERT_STREQ(diagnostic, (char *)parse_packet.payload);
+  ASSERT_STREQ(diagnostic.c_str(), (char *)parse_packet.payload);
 }
 
 #endif /* OC_TCP && IPV4 */

--- a/messaging/coap/unittest/observetest.cpp
+++ b/messaging/coap/unittest/observetest.cpp
@@ -1,0 +1,19 @@
+/****************************************************************************
+ *
+ * Copyright (c) 2023 plgd.dev s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"),
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+// TODO: add tests for messaging/coap/observe.c

--- a/onboarding_tool/obtmain.c
+++ b/onboarding_tool/obtmain.c
@@ -17,6 +17,7 @@
  ****************************************************************************/
 
 #include "oc_api.h"
+#include "oc_clock_util.h"
 #include "oc_core_res.h"
 #include "oc_log.h"
 #include "oc_obt.h"

--- a/port/esp32/adapter/src/vfs_pipe.c
+++ b/port/esp32/adapter/src/vfs_pipe.c
@@ -23,6 +23,8 @@
 #include "port/oc_assert.h"
 #include "port/oc_log_internal.h"
 #include "sdkconfig.h"
+#include "util/oc_macros_internal.h"
+
 #include <stdarg.h>
 #include <stdbool.h>
 #include <string.h>

--- a/port/esp32/main/CMakeLists.txt
+++ b/port/esp32/main/CMakeLists.txt
@@ -66,6 +66,7 @@ set(sources
 	${CMAKE_CURRENT_SOURCE_DIR}/../../../util/oc_memb.c
 	${CMAKE_CURRENT_SOURCE_DIR}/../../../util/oc_mmem.c
 	${CMAKE_CURRENT_SOURCE_DIR}/../../../util/oc_process.c
+	${CMAKE_CURRENT_SOURCE_DIR}/../../../util/oc_secure_string.c
 	${CMAKE_CURRENT_SOURCE_DIR}/../../../util/oc_timer.c
 
 	main.c

--- a/port/esp32/main/main.c
+++ b/port/esp32/main/main.c
@@ -17,6 +17,7 @@
  ******************************************************************/
 
 #include "oc_api.h"
+#include "oc_clock_util.h"
 #include "oc_core_res.h"
 #include "oc_esp.h"
 #include "oc_log.h"
@@ -574,8 +575,7 @@ server_main(void *pvParameter)
     if (next_event == 0) {
       pthread_cond_wait(&cv, &mutex);
     } else {
-      ts.tv_sec = (next_event / OC_CLOCK_SECOND);
-      ts.tv_nsec = (next_event % OC_CLOCK_SECOND) * 1.e09 / OC_CLOCK_SECOND;
+      ts = oc_clock_time_to_timespec(next_event);
       pthread_cond_timedwait(&cv, &mutex, &ts);
     }
     pthread_mutex_unlock(&mutex);

--- a/port/linux/Makefile
+++ b/port/linux/Makefile
@@ -175,11 +175,11 @@ endif
 
 
 ifeq ($(WKCORE),1)
-	CFLAGS += -DOC_WKCORE
+	EXTRA_CFLAGS += -DOC_WKCORE
 endif
 
 ifeq ($(CLOUD),1)
-	CFLAGS += -DOC_CLOUD
+	EXTRA_CFLAGS += -DOC_CLOUD
 	TCP=1
 	IPV4=1
 	SAMPLES += cloud_client cloud_server cloud_tests cloud_proxy
@@ -199,7 +199,7 @@ else
 endif
 
 ifeq ($(MEMORY_TRACE), 1)
-	CFLAGS += -DOC_MEMORY_TRACE
+	EXTRA_CFLAGS += -DOC_MEMORY_TRACE
 endif
 
 ifeq ($(PKI),1)
@@ -294,10 +294,6 @@ endif
 
 CFLAGS += $(EXTRA_CFLAGS)
 CXXFLAGS += $(EXTRA_CFLAGS)
-
-ifeq ($(MEMTRACE),1)
-	CFLAGS += -DOC_MEMORY_TRACE
-endif
 
 SAMPLES_CREDS = $(addsuffix _creds, ${SAMPLES} ${OBT})
 

--- a/port/linux/dns.c
+++ b/port/linux/dns.c
@@ -25,6 +25,7 @@
 #include "port/oc_log_internal.h"
 #include "port/oc_connectivity.h"
 #include "util/oc_memb.h"
+#include "util/oc_macros_internal.h"
 #include <arpa/inet.h>
 #include <errno.h>
 #include <netdb.h>
@@ -111,7 +112,10 @@ oc_dns_lookup(const char *domain, oc_string_t *addr, transport_flags flags)
 
     if (ret == 0) {
       if ((flags & IPV6) != 0) {
+        CLANG_IGNORE_WARNING_START
+        CLANG_IGNORE_WARNING("-Wcast-align")
         const struct sockaddr_in6 *r = (struct sockaddr_in6 *)result->ai_addr;
+        CLANG_IGNORE_WARNING_END
         memcpy(a.ipv6.address, r->sin6_addr.s6_addr,
                sizeof(r->sin6_addr.s6_addr));
         a.ipv6.port = ntohs(r->sin6_port);
@@ -119,7 +123,10 @@ oc_dns_lookup(const char *domain, oc_string_t *addr, transport_flags flags)
       }
 #ifdef OC_IPV4
       else {
+        CLANG_IGNORE_WARNING_START
+        CLANG_IGNORE_WARNING("-Wcast-align")
         const struct sockaddr_in *r = (struct sockaddr_in *)result->ai_addr;
+        CLANG_IGNORE_WARNING_END
         memcpy(a.ipv4.address, &r->sin_addr.s_addr, sizeof(r->sin_addr.s_addr));
         a.ipv4.port = ntohs(r->sin_port);
       }

--- a/port/linux/ipadapter.c
+++ b/port/linux/ipadapter.c
@@ -1007,7 +1007,7 @@ to_timeval(oc_clock_time_t ticks)
 {
   unsigned sec = (unsigned)(ticks / OC_CLOCK_SECOND);
   unsigned usec =
-    (unsigned)((ticks % OC_CLOCK_SECOND) * (1.e06 / OC_CLOCK_SECOND));
+    (unsigned)((double)(ticks % OC_CLOCK_SECOND) * (1.e06 / OC_CLOCK_SECOND));
   if (sec == 0 && usec == 0) {
     usec = 1;
   }

--- a/port/linux/ipadapter.c
+++ b/port/linux/ipadapter.c
@@ -34,6 +34,7 @@
 #include "port/oc_network_event_handler_internal.h"
 #include "util/oc_atomic.h"
 #include "util/oc_features.h"
+#include "util/oc_macros_internal.h"
 
 #ifdef OC_SESSION_EVENTS
 #include "api/oc_session_events_internal.h"
@@ -351,7 +352,10 @@ get_interface_addresses(ip_context_t *dev, unsigned char family, int port,
         }
         ep.interface_index = addrmsg->ifa_index;
         include = true;
-        struct rtattr *attr = (struct rtattr *)IFA_RTA(addrmsg);
+        CLANG_IGNORE_WARNING_START
+        CLANG_IGNORE_WARNING("-Wcast-align")
+        struct rtattr *attr = IFA_RTA(addrmsg);
+        CLANG_IGNORE_WARNING_END
         int att_len = IFA_PAYLOAD(response);
         while (RTA_OK(attr, att_len)) {
           if (attr->rta_type == IFA_ADDRESS) {
@@ -370,7 +374,10 @@ get_interface_addresses(ip_context_t *dev, unsigned char family, int port,
               include = false;
             }
           }
+          CLANG_IGNORE_WARNING_START
+          CLANG_IGNORE_WARNING("-Wcast-align")
           attr = RTA_NEXT(attr, att_len);
+          CLANG_IGNORE_WARNING_END
         }
       }
       if (include) {
@@ -406,7 +413,10 @@ get_interface_addresses(ip_context_t *dev, unsigned char family, int port,
       }
 
     next_ifaddr:
+      CLANG_IGNORE_WARNING_START
+      CLANG_IGNORE_WARNING("-Wcast-align")
       response = NLMSG_NEXT(response, response_len);
+      CLANG_IGNORE_WARNING_END
     }
   }
   close(nl_sock);
@@ -557,7 +567,10 @@ process_interface_change_event(void)
           oc_network_interface_event(NETWORK_INTERFACE_UP);
         }
 #endif /* OC_NETWORK_MONITOR */
-        struct rtattr *attr = (struct rtattr *)IFA_RTA(ifa);
+        CLANG_IGNORE_WARNING_START
+        CLANG_IGNORE_WARNING("-Wcast-align")
+        struct rtattr *attr = IFA_RTA(ifa);
+        CLANG_IGNORE_WARNING_END
         int att_len = IFA_PAYLOAD(response);
         while (RTA_OK(attr, att_len)) {
           if (attr->rta_type == IFA_ADDRESS) {
@@ -587,7 +600,10 @@ process_interface_change_event(void)
                 }
               }
           }
+          CLANG_IGNORE_WARNING_START
+          CLANG_IGNORE_WARNING("-Wcast-align")
           attr = RTA_NEXT(attr, att_len);
+          CLANG_IGNORE_WARNING_END
         }
       }
       if_state_changed = true;
@@ -602,7 +618,10 @@ process_interface_change_event(void)
       }
       if_state_changed = true;
     }
+    CLANG_IGNORE_WARNING_START
+    CLANG_IGNORE_WARNING("-Wcast-align")
     response = NLMSG_NEXT(response, response_len);
+    CLANG_IGNORE_WARNING_END
   }
 
   if (if_state_changed) {
@@ -674,7 +693,10 @@ recv_msg(int sock, uint8_t *recv_buf, long recv_buf_size,
       endpoint->addr.ipv6.port = ntohs(c6->sin6_port);
 
       /* Set receiving network interface index */
+      CLANG_IGNORE_WARNING_START
+      CLANG_IGNORE_WARNING("-Wcast-align")
       struct in6_pktinfo *pktinfo = (struct in6_pktinfo *)CMSG_DATA(cmsg);
+      CLANG_IGNORE_WARNING_END
       endpoint->interface_index = pktinfo->ipi6_ifindex;
 
       /* For a unicast receiving socket, extract the destination address
@@ -696,7 +718,10 @@ recv_msg(int sock, uint8_t *recv_buf, long recv_buf_size,
         OC_ERR("anciliary data contains invalid source address");
         return -1;
       }
+      CLANG_IGNORE_WARNING_START
+      CLANG_IGNORE_WARNING("-Wcast-align")
       struct in_pktinfo *pktinfo = (struct in_pktinfo *)CMSG_DATA(cmsg);
+      CLANG_IGNORE_WARNING_END
       struct sockaddr_in *c4 = (struct sockaddr_in *)&client;
       memcpy(endpoint->addr.ipv4.address, &c4->sin_addr.s_addr,
              sizeof(c4->sin_addr.s_addr));
@@ -1080,7 +1105,10 @@ send_msg(int sock, struct sockaddr_storage *receiver,
     cmsg->cmsg_type = IPV6_PKTINFO;
     cmsg->cmsg_len = CMSG_LEN(sizeof(struct in6_pktinfo));
 
+    CLANG_IGNORE_WARNING_START
+    CLANG_IGNORE_WARNING("-Wcast-align")
     pktinfo = (struct in6_pktinfo *)CMSG_DATA(cmsg);
+    CLANG_IGNORE_WARNING_END
     memset(pktinfo, 0, sizeof(struct in6_pktinfo));
 
     /* Get the outgoing interface index from message->endpint */
@@ -1104,7 +1132,10 @@ send_msg(int sock, struct sockaddr_storage *receiver,
     cmsg->cmsg_type = IP_PKTINFO;
     cmsg->cmsg_len = CMSG_LEN(sizeof(struct in_pktinfo));
 
+    CLANG_IGNORE_WARNING_START
+    CLANG_IGNORE_WARNING("-Wcast-align")
     pktinfo = (struct in_pktinfo *)CMSG_DATA(cmsg);
+    CLANG_IGNORE_WARNING_END
     memset(pktinfo, 0, sizeof(struct in_pktinfo));
 
     pktinfo->ipi_ifindex = message->endpoint.interface_index;
@@ -1248,7 +1279,10 @@ send_ipv6_discovery_request(oc_message_t *message,
 #define IN6_IS_ADDR_MC_REALM_LOCAL(addr)                                       \
   IN6_IS_ADDR_MULTICAST(addr) && ((((const uint8_t *)(addr))[1] & 0x0f) == 0x03)
 
+  CLANG_IGNORE_WARNING_START
+  CLANG_IGNORE_WARNING("-Wcast-align")
   const struct sockaddr_in6 *addr = (struct sockaddr_in6 *)interface->ifa_addr;
+  CLANG_IGNORE_WARNING_END
   if (IN6_IS_ADDR_LINKLOCAL(&addr->sin6_addr)) {
     unsigned int mif = if_nametoindex(interface->ifa_name);
     if (setsockopt(server_sock, IPPROTO_IPV6, IPV6_MULTICAST_IF, &mif,
@@ -1291,7 +1325,10 @@ send_ipv4_discovery_request(oc_message_t *message,
     OC_ERR("server socket for IPv4 is disabled");
     return false;
   }
+  CLANG_IGNORE_WARNING_START
+  CLANG_IGNORE_WARNING("-Wcast-align")
   struct sockaddr_in *addr = (struct sockaddr_in *)interface->ifa_addr;
+  CLANG_IGNORE_WARNING_END
   if (setsockopt(server_sock, IPPROTO_IP, IP_MULTICAST_IF, &addr->sin_addr,
                  sizeof(addr->sin_addr)) == -1) {
     OC_ERR("setting socket option for default IP_MULTICAST_IF: %d", errno);

--- a/port/linux/netsocket.c
+++ b/port/linux/netsocket.c
@@ -20,7 +20,7 @@
 #include "netsocket.h"
 
 #include "port/oc_log_internal.h"
-#include "util/oc_macros.h"
+#include "util/oc_macros_internal.h"
 
 #include <assert.h>
 #include <errno.h>
@@ -188,8 +188,11 @@ netsocket_configure_mcast(int mcast_sock, int sa_family)
     int if_index = if_nametoindex(interface->ifa_name);
     /* Accordingly handle IPv6/IPv4 addresses */
     if (sa_family == AF_INET6) {
+      CLANG_IGNORE_WARNING_START
+      CLANG_IGNORE_WARNING("-Wcast-align")
       const struct sockaddr_in6 *addr =
         (struct sockaddr_in6 *)interface->ifa_addr;
+      CLANG_IGNORE_WARNING_END
       if (addr == NULL || !IN6_IS_ADDR_LINKLOCAL(&addr->sin6_addr)) {
         continue;
       }
@@ -200,8 +203,11 @@ netsocket_configure_mcast(int mcast_sock, int sa_family)
     }
 #ifdef OC_IPV4
     if (sa_family == AF_INET) {
+      CLANG_IGNORE_WARNING_START
+      CLANG_IGNORE_WARNING("-Wcast-align")
       const struct sockaddr_in *addr =
         (struct sockaddr_in *)interface->ifa_addr;
+      CLANG_IGNORE_WARNING_END
       if (addr == NULL) {
         continue;
       }

--- a/port/linux/storage.c
+++ b/port/linux/storage.c
@@ -23,6 +23,7 @@
 #include "port/oc_log_internal.h"
 #include "port/oc_storage.h"
 #include "port/oc_storage_internal.h"
+#include "util/oc_secure_string_internal.h"
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -30,7 +31,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define STORE_PATH_SIZE 64
+#define STORE_PATH_SIZE (64)
 
 static char g_store_path[STORE_PATH_SIZE] = { 0 };
 static size_t g_store_path_len = 0;
@@ -39,7 +40,7 @@ static bool g_path_set = false;
 int
 oc_storage_config(const char *store)
 {
-  size_t store_len = strlen(store);
+  size_t store_len = oc_strnlen_s(store, STORE_PATH_SIZE);
   if (store_len >= STORE_PATH_SIZE) {
     return -ENOENT;
   }
@@ -67,7 +68,7 @@ oc_storage_read(const char *store, uint8_t *buf, size_t size)
   if (!g_path_set) {
     return -ENOENT;
   }
-  size_t store_len = strlen(store);
+  size_t store_len = oc_strnlen_s(store, STORE_PATH_SIZE);
   if (1 + store_len + g_store_path_len >= STORE_PATH_SIZE) {
     return -ENOENT;
   }
@@ -109,7 +110,7 @@ write_and_flush(FILE *fp, const uint8_t *buf, size_t size)
 long
 oc_storage_write(const char *store, const uint8_t *buf, size_t size)
 {
-  size_t store_len = strlen(store);
+  size_t store_len = oc_strnlen_s(store, STORE_PATH_SIZE);
   if (!g_path_set || (store_len + g_store_path_len >= STORE_PATH_SIZE)) {
     return -ENOENT;
   }

--- a/port/linux/tcpsession.c
+++ b/port/linux/tcpsession.c
@@ -21,17 +21,18 @@
 #include "api/oc_network_events_internal.h"
 #include "api/oc_session_events_internal.h"
 #include "api/oc_tcp_internal.h"
-#include "messaging/coap/coap.h"
-#include "port/oc_assert.h"
-#include "port/oc_connectivity_internal.h"
-#include "util/oc_features.h"
-#include "util/oc_memb.h"
 #include "ipadapter.h"
 #include "ipcontext.h"
+#include "messaging/coap/coap.h"
 #include "oc_buffer.h"
 #include "oc_endpoint.h"
 #include "oc_session_events.h"
+#include "port/oc_assert.h"
+#include "port/oc_connectivity_internal.h"
 #include "tcpsession.h"
+#include "util/oc_features.h"
+#include "util/oc_macros_internal.h"
+#include "util/oc_memb.h"
 #include <arpa/inet.h>
 #include <assert.h>
 #include <errno.h>
@@ -122,6 +123,8 @@ is_matching_address(const struct sockaddr *first, const struct sockaddr *second)
   if (first->sa_family != second->sa_family) {
     return false;
   }
+  CLANG_IGNORE_WARNING_START
+  CLANG_IGNORE_WARNING("-Wcast-align")
   if (first->sa_family == AF_INET6) {
     const struct sockaddr_in6 *a = (const struct sockaddr_in6 *)first;
     const struct sockaddr_in6 *b = (const struct sockaddr_in6 *)second;
@@ -134,6 +137,7 @@ is_matching_address(const struct sockaddr *first, const struct sockaddr *second)
     return a->sin_addr.s_addr == b->sin_addr.s_addr;
   }
 #endif /* OC_IPV4 */
+  CLANG_IGNORE_WARNING_END
   return false;
 }
 
@@ -520,8 +524,8 @@ try_connect_nonblocking(int sockfd, const struct sockaddr *r, int r_len)
     return -1;
   }
 
-  int n;
-  if ((n = connect(sockfd, r, r_len)) < 0 && (errno != EINPROGRESS)) {
+  int n = connect(sockfd, r, r_len);
+  if (n < 0 && errno != EINPROGRESS) {
     OC_DBG("connect to socked(%d) failed with error: %d", sockfd, (int)errno);
     return -1;
   }
@@ -576,9 +580,9 @@ tcp_create_connected_socket(const oc_endpoint_t *endpoint,
   }
 
   socklen_t size = sizeof(*receiver);
-  int ret;
-  if ((ret = try_connect_nonblocking(sock, (const struct sockaddr *)receiver,
-                                     size)) < 0) {
+  int ret =
+    try_connect_nonblocking(sock, (const struct sockaddr *)receiver, size);
+  if (ret < 0) {
     close(sock);
     return cs;
   }

--- a/port/linux/tcpsession.c
+++ b/port/linux/tcpsession.c
@@ -517,7 +517,7 @@ find_session_by_endpoint_locked(const oc_endpoint_t *endpoint)
 #ifdef OC_HAS_FEATURE_TCP_ASYNC_CONNECT
 
 static int
-try_connect_nonblocking(int sockfd, const struct sockaddr *r, int r_len)
+try_connect_nonblocking(int sockfd, const struct sockaddr *r, socklen_t r_len)
 {
   if (oc_set_fd_flags(sockfd, O_NONBLOCK, 0) < 0) {
     OC_ERR("cannot set non-blocking socket(%d)", sockfd);

--- a/port/linux/tcpsession.h
+++ b/port/linux/tcpsession.h
@@ -123,7 +123,7 @@ void tcp_session_shutdown(const ip_context_t *dev);
  * sessions. Retry the connection process for sessions that haven't reached the
  * maximal amount of retries. Get the nearest timeout of a non-expired session.
  *
- * @param now current monotonic time
+ * @param now_mt current monotonic time
  * @return 0 no non-expired session was found
  * @return >0 the nearest timeout of a non-expired session
  *

--- a/port/windows/storage.c
+++ b/port/windows/storage.c
@@ -21,6 +21,7 @@
 #ifdef OC_STORAGE
 #include "port/oc_storage.h"
 #include "port/oc_storage_internal.h"
+#include "util/oc_secure_string_internal.h"
 
 #include <errno.h>
 #include <stdbool.h>
@@ -28,7 +29,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#define STORE_PATH_SIZE 64
+#define STORE_PATH_SIZE (64)
 
 static char g_store_path[STORE_PATH_SIZE] = { 0 };
 static size_t g_store_path_len = 0;
@@ -40,7 +41,7 @@ oc_storage_config(const char *store)
   if (!store || !*store) {
     return -EINVAL;
   }
-  size_t store_len = strlen(store);
+  size_t store_len = oc_strnlen(store, STORE_PATH_SIZE);
   if (store_len >= STORE_PATH_SIZE) {
     return -ENOENT;
   }
@@ -76,7 +77,7 @@ oc_storage_read(const char *store, uint8_t *buf, size_t size)
     return -ENOENT;
   }
 
-  size_t store_len = strlen(store);
+  size_t store_len = oc_strnlen_s(store, STORE_PATH_SIZE);
   if (store_len + g_store_path_len >= STORE_PATH_SIZE) {
     return -ENOENT;
   }
@@ -96,15 +97,14 @@ oc_storage_read(const char *store, uint8_t *buf, size_t size)
 long
 oc_storage_write(const char *store, const uint8_t *buf, size_t size)
 {
-  FILE *fp;
-  size_t store_len = strlen(store);
-
-  if (!g_path_set || (store_len + g_store_path_len >= STORE_PATH_SIZE))
+  size_t store_len = oc_strnlen_s(store, STORE_PATH_SIZE);
+  if (!g_path_set || (store_len + g_store_path_len >= STORE_PATH_SIZE)) {
     return -ENOENT;
+  }
 
   memcpy(g_store_path + g_store_path_len, store, store_len);
   g_store_path[g_store_path_len + store_len] = '\0';
-  fp = fopen(g_store_path, "wb");
+  FILE *fp = fopen(g_store_path, "wb");
   if (!fp)
     return -EINVAL;
 

--- a/python/oc_python.c
+++ b/python/oc_python.c
@@ -28,6 +28,7 @@
 #include "oc_python.h"
 #include "port/oc_clock.h"
 #include "util/oc_atomic.h"
+#include "util/oc_secure_string_internal.h"
 
 #ifdef OC_SECURITY
 #include "security/oc_obt_internal.h"
@@ -2191,11 +2192,11 @@ diplomat_discovery(const char *anchor, const char *uri, oc_string_array_t types,
   (void)iface_mask;
   (void)bm;
   (void)user_data;
-  size_t uri_len = strlen(uri);
-  uri_len = (uri_len >= MAX_URI_LENGTH) ? MAX_URI_LENGTH - 1 : uri_len;
+  size_t uri_len = oc_strnlen(uri, MAX_URI_LENGTH - 1);
   for (size_t i = 0; i < oc_string_array_get_allocated_size(types); i++) {
     char *t = oc_string_array_get_item(types, i);
-    if (strlen(t) == 14 && strncmp(t, "oic.r.diplomat", 14) == 0) {
+    if (oc_strnlen(t, STRING_ARRAY_ITEM_MAX_LEN) == 14 &&
+        strncmp(t, "oic.r.diplomat", 14) == 0) {
       oc_endpoint_list_copy(&diplomat_ep, endpoint);
       strncpy(diplomat_uri, uri, uri_len);
       diplomat_uri[uri_len] = '\0';

--- a/python/oc_python.c
+++ b/python/oc_python.c
@@ -1988,7 +1988,6 @@ resource_discovery(const char *anchor, const char *uri, oc_string_array_t types,
       if (comma)
         strcat(strinterfaces, ",");
       strcat(strinterfaces, "\"oic.r.b\"");
-      comma = true;
     }
     strcat(json, strinterfaces);
     strcat(json, "]");
@@ -2037,8 +2036,6 @@ void
 py_post(const char *uri, int value)
 {
   OC_PRINTF("[C] POST_light: %s-> %d\n", uri, value);
-  // int uri_len = strlen(uri);
-
   // static oc_endpoint_t *light_server;
   /*
   if (oc_init_post(a_light, light_server, NULL, &post2_light, LOW_QOS, NULL)) {
@@ -2052,7 +2049,7 @@ py_post(const char *uri, int value)
       OC_PRINTF("Could not send POST request\n");
   } else
     OC_PRINTF("Could not init POST request\n");
-    */
+  */
 }
 
 void
@@ -2193,10 +2190,9 @@ diplomat_discovery(const char *anchor, const char *uri, oc_string_array_t types,
   (void)iface_mask;
   (void)bm;
   (void)user_data;
-  int uri_len = strlen(uri);
+  size_t uri_len = strlen(uri);
   uri_len = (uri_len >= MAX_URI_LENGTH) ? MAX_URI_LENGTH - 1 : uri_len;
-
-  for (int i = 0; i < (int)oc_string_array_get_allocated_size(types); i++) {
+  for (size_t i = 0; i < oc_string_array_get_allocated_size(types); i++) {
     char *t = oc_string_array_get_item(types, i);
     if (strlen(t) == 14 && strncmp(t, "oic.r.diplomat", 14) == 0) {
       oc_endpoint_list_copy(&diplomat_ep, endpoint);
@@ -2333,10 +2329,9 @@ discovery_cb(const char *anchor, const char *uri, oc_string_array_t types,
   (void)user_data;
   (void)iface_mask;
   (void)bm;
-  int i;
-  int uri_len = strlen(uri);
+  size_t uri_len = strlen(uri);
   uri_len = (uri_len >= MAX_URI_LENGTH) ? MAX_URI_LENGTH - 1 : uri_len;
-  for (i = 0; i < (int)oc_string_array_get_allocated_size(types); i++) {
+  for (size_t i = 0; i < oc_string_array_get_allocated_size(types); i++) {
     char *t = oc_string_array_get_item(types, i);
     if (strlen(t) == 10 && strncmp(t, "core.light", 10) == 0) {
       oc_endpoint_list_copy(&light_server, endpoint);

--- a/python/oc_python.c
+++ b/python/oc_python.c
@@ -21,6 +21,7 @@
 // #define OC_SERVER
 
 #include "oc_api.h"
+#include "oc_clock_util.h"
 #include "oc_core_res.h"
 #include "oc_log.h"
 #include "oc_obt.h"

--- a/security/oc_acl.c
+++ b/security/oc_acl.c
@@ -18,6 +18,7 @@
 
 #ifdef OC_SECURITY
 
+#include "api/oc_helpers_internal.h"
 #include "api/oc_ri_internal.h"
 #include "oc_acl_internal.h"
 #include "oc_api.h"
@@ -33,7 +34,7 @@
 #include "oc_tls_internal.h"
 #include "port/oc_assert.h"
 #include "util/oc_features.h"
-#include "util/oc_macros.h"
+#include "util/oc_macros_internal.h"
 
 #ifdef OC_HAS_FEATURE_PLGD_TIME
 #include "api/plgd/plgd_time_internal.h"
@@ -97,7 +98,7 @@ get_new_aceid(size_t device)
 {
   int aceid;
   do {
-    aceid = oc_random_value() >> 1;
+    aceid = (int)(oc_random_value() >> 1);
   } while (!unique_aceid(aceid, device));
   return aceid;
 }
@@ -131,9 +132,8 @@ oc_sec_ace_find_resource(oc_ace_res_t *start, const oc_sec_ace_t *ace,
     }
 
     if (match && wildcard != 0 && res->wildcard != 0) {
-      if (wildcard != OC_ACE_WC_ALL && (wildcard & res->wildcard) != 0) {
-        positive = true;
-      } else if (wildcard == OC_ACE_WC_ALL && res->wildcard == OC_ACE_WC_ALL) {
+      if ((wildcard != OC_ACE_WC_ALL && (wildcard & res->wildcard) != 0) ||
+          (wildcard == OC_ACE_WC_ALL && res->wildcard == OC_ACE_WC_ALL)) {
         positive = true;
       } else {
         match = false;
@@ -190,18 +190,10 @@ oc_sec_acl_find_subject(oc_sec_ace_t *start, oc_ace_subject_type_t type,
         }
         break;
       case OC_SUBJECT_ROLE:
-        if (oc_string_len(subject->role.role) ==
-              oc_string_len(ace->subject.role.role) &&
-            memcmp(oc_string(subject->role.role),
-                   oc_string(ace->subject.role.role),
-                   oc_string_len(subject->role.role)) == 0) {
-          if (oc_string_len(ace->subject.role.authority) == 0) {
-            return ace;
-          } else if (oc_string_len(ace->subject.role.authority) ==
-                       oc_string_len(subject->role.authority) &&
-                     memcmp(oc_string(subject->role.authority),
-                            oc_string(ace->subject.role.authority),
-                            oc_string_len(subject->role.authority)) == 0) {
+        if (oc_string_is_equal(&subject->role.role, &ace->subject.role.role)) {
+          if (oc_string_len(ace->subject.role.authority) == 0 ||
+              oc_string_is_equal(&subject->role.authority,
+                                 &ace->subject.role.authority)) {
             return ace;
           }
         }
@@ -225,10 +217,10 @@ oc_ace_get_permission(const oc_sec_ace_t *ace, const oc_resource_t *resource,
 {
   /* If the resource is discoverable and exposes >=1 unsecured endpoints
    * then match with ACEs bearing any of the 3 wildcard resources.
-   * If the resource is discoverable and does not expose any unsecured endpoint,
-   * then match with ACEs bearing either OC_ACE_WC_ALL_SECURED or OC_ACE_WC_ALL.
-   * If the resource is not discoverable, then match only with ACEs bearing
-   *  OC_ACE_WC_ALL.
+   * If the resource is discoverable and does not expose any unsecured
+   * endpoint, then match with ACEs bearing either OC_ACE_WC_ALL_SECURED or
+   * OC_ACE_WC_ALL. If the resource is not discoverable, then match only with
+   * ACEs bearing OC_ACE_WC_ALL.
    */
   oc_ace_wildcard_t wc = 0;
   if (!is_DCR) {
@@ -372,7 +364,8 @@ oc_sec_check_acl_on_get(const oc_resource_t *resource, bool is_otm)
   const char *uri = oc_string(resource->uri);
   size_t uri_len = oc_string_len(resource->uri);
 
-  /* Retrieve requests to "/oic/res", "/oic/d" and "/oic/p" shall be granted. */
+  /* Retrieve requests to "/oic/res", "/oic/d" and "/oic/p" shall be granted.
+   */
   if (is_otm && ((uri_len == 8 && memcmp(uri, "/oic/res", 8) == 0) ||
                  (uri_len == 6 && memcmp(uri, "/oic/d", 6) == 0) ||
                  (uri_len == 6 && memcmp(uri, "/oic/p", 6) == 0))) {
@@ -526,16 +519,14 @@ oc_sec_check_acl(oc_method_t method, const oc_resource_t *resource,
     /* All Retrieve requests to the “/oic/sec/pstat” Resource shall be
        granted.
     */
-    else if (oc_string_len(resource->uri) == 14 &&
-             memcmp(oc_string(resource->uri), "/oic/sec/pstat", 14) == 0 &&
-             method == OC_GET) {
+    if (oc_string_len(resource->uri) == 14 &&
+        memcmp(oc_string(resource->uri), "/oic/sec/pstat", 14) == 0 &&
+        method == OC_GET) {
       OC_DBG("oc_sec_check_acl: R access granted to pstat prior to DOC");
       return true;
     }
     /* Reject all other requests */
-    else {
-      return false;
-    }
+    return false;
   }
 
   if ((pstat->s == OC_DOS_RFPRO || pstat->s == OC_DOS_RFNOP ||
@@ -571,9 +562,12 @@ oc_sec_check_acl(oc_method_t method, const oc_resource_t *resource,
   oc_sec_ace_t *match = NULL;
   if (uuid != NULL) {
     do {
-      match = oc_sec_acl_find_subject(
-        match, OC_SUBJECT_UUID, (const oc_ace_subject_t *)uuid, /*aceid*/ -1,
-        /*permission*/ 0, /*tag*/ NULL, /*match_tag*/ false, endpoint->device);
+      oc_ace_subject_t subject;
+      memcpy(&subject.uuid, uuid, sizeof(*uuid));
+      match = oc_sec_acl_find_subject(match, OC_SUBJECT_UUID, &subject,
+                                      /*aceid*/ -1,
+                                      /*permission*/ 0, /*tag*/ NULL,
+                                      /*match_tag*/ false, endpoint->device);
 
       if (match) {
         permission |= oc_ace_get_permission(match, resource, is_DCR, is_public);

--- a/security/oc_certs.c
+++ b/security/oc_certs.c
@@ -31,7 +31,7 @@
 #include "security/oc_entropy_internal.h"
 #include "security/oc_pki_internal.h"
 #include "security/oc_tls_internal.h"
-#include "util/oc_macros.h"
+#include "util/oc_macros_internal.h"
 
 #include <mbedtls/bignum.h>
 #include <mbedtls/ctr_drbg.h>

--- a/security/oc_cred.c
+++ b/security/oc_cred.c
@@ -539,7 +539,7 @@ oc_sec_get_valid_ecdsa_keypair(size_t device, size_t public_key_len,
   if (kp == NULL) {
     return NULL;
   }
-  uint8_t *pk_buffer = oc_cast(*public_key, uint8_t);
+  const uint8_t *pk_buffer = oc_cast(*public_key, uint8_t);
   if (pk_buffer == NULL) {
     return NULL;
   }

--- a/security/oc_cred.c
+++ b/security/oc_cred.c
@@ -34,7 +34,7 @@
 #include "security/oc_roles_internal.h"
 #include "security/oc_tls_internal.h"
 #include "util/oc_list.h"
-#include "util/oc_macros.h"
+#include "util/oc_macros_internal.h"
 #include "util/oc_memb.h"
 #include <stdlib.h>
 
@@ -68,15 +68,15 @@ static const int allowed_roles_num = sizeof(allowed_roles) / sizeof(char *);
 #define SYMMETRIC_KEY_128BIT_LEN 16
 #define SYMMETRIC_KEY_256BIT_LEN 32
 
-static int
-check_symmetric_key_length(int key_size)
+static bool
+check_symmetric_key_length(size_t key_size)
 {
   if (key_size != SYMMETRIC_KEY_128BIT_LEN &&
       key_size != SYMMETRIC_KEY_256BIT_LEN) {
-    OC_ERR("oc_cred: invalid PSK length(%d)", key_size);
-    return -1;
+    OC_ERR("oc_cred: invalid PSK length(%zu)", key_size);
+    return false;
   }
-  return 0;
+  return true;
 }
 
 oc_sec_creds_t *
@@ -216,7 +216,7 @@ get_new_credid(bool roles_resource, const oc_tls_peer_t *client, size_t device)
 {
   int credid;
   do {
-    credid = oc_random_value() >> 1;
+    credid = (int)(oc_random_value() >> 1);
   } while (oc_sec_is_existing_cred(credid, roles_resource, client, device));
   return credid;
 }
@@ -536,12 +536,16 @@ oc_sec_get_valid_ecdsa_keypair(size_t device, size_t public_key_len,
                                const uint8_t *publicdata)
 {
   oc_ecdsa_keypair_t *kp = oc_sec_ecdsa_get_keypair(device);
-  if (!kp) {
+  if (kp == NULL) {
     return NULL;
   }
-  if (memcmp(kp->public_key,
-             oc_cast(*public_key, uint8_t) + public_key->size - public_key_len,
-             public_key_len) != 0) {
+  uint8_t *pk_buffer = oc_cast(*public_key, uint8_t);
+  if (pk_buffer == NULL) {
+    return NULL;
+  }
+  // data is written at the end of the buffer
+  pk_buffer += public_key->size - public_key_len;
+  if (memcmp(kp->public_key, pk_buffer, public_key_len) != 0) {
     return NULL;
   }
   if (!check_uuid_from_cert_raw(publicdata_size + 1, publicdata,
@@ -570,17 +574,20 @@ oc_sec_add_new_cred(size_t device, bool roles_resource,
 #ifdef OC_PKI
   oc_string_t public_key;
   memset(&public_key, 0, sizeof(oc_string_t));
-  int public_key_len = 0;
-  if (credtype == OC_CREDTYPE_CERT &&
-      (public_key_len = oc_certs_parse_public_key_to_oc_string(
-         publicdata, publicdata_size + 1, &public_key)) < 0) {
-    goto add_new_cred_error;
+  size_t public_key_len = 0;
+  if (credtype == OC_CREDTYPE_CERT) {
+    int pk_len = oc_certs_parse_public_key_to_oc_string(
+      publicdata, publicdata_size + 1, &public_key);
+    if (pk_len < 0) {
+      goto add_new_cred_error;
+    }
+    public_key_len = (size_t)pk_len;
   }
 
   if (roles_resource &&
       (credtype != OC_CREDTYPE_CERT ||
-       !oc_sec_verify_role_cred(client, credusage, (size_t)public_key_len,
-                                &public_key, publicdata_size, publicdata))) {
+       !oc_sec_verify_role_cred(client, credusage, public_key_len, &public_key,
+                                publicdata_size, publicdata))) {
     goto add_new_cred_error;
   }
 #endif /* OC_PKI */
@@ -592,8 +599,8 @@ oc_sec_add_new_cred(size_t device, bool roles_resource,
 #ifdef OC_PKI
   oc_ecdsa_keypair_t *kp = NULL;
   if (credusage == OC_CREDUSAGE_IDENTITY_CERT && privatedata_size == 0) {
-    kp = oc_sec_get_valid_ecdsa_keypair(
-      device, (size_t)public_key_len, &public_key, publicdata_size, publicdata);
+    kp = oc_sec_get_valid_ecdsa_keypair(device, public_key_len, &public_key,
+                                        publicdata_size, publicdata);
     if (!kp) {
       goto add_new_cred_error;
     }
@@ -735,7 +742,7 @@ oc_sec_add_new_cred(size_t device, bool roles_resource,
       uint8_t key[64];
       memcpy(key, privatedata, privatedata_size);
       int key_size = oc_base64_decode(key, privatedata_size);
-      if (check_symmetric_key_length(key_size)) {
+      if (key_size < 0 || !check_symmetric_key_length((size_t)key_size)) {
         oc_sec_remove_cred(cred, device);
         goto add_new_cred_error;
       }
@@ -743,7 +750,7 @@ oc_sec_add_new_cred(size_t device, bool roles_resource,
       privatedata_encoding = OC_ENCODING_RAW;
     } else {
       if (credtype == OC_CREDTYPE_PSK &&
-          check_symmetric_key_length(privatedata_size)) {
+          !check_symmetric_key_length(privatedata_size)) {
         oc_sec_remove_cred(cred, device);
         goto add_new_cred_error;
       }

--- a/security/oc_csr.c
+++ b/security/oc_csr.c
@@ -184,7 +184,7 @@ generate_csr_error:
  * @return false on failure
  */
 static bool
-oc_sec_csr_verify_signature(mbedtls_x509_csr *csr, int md_flags)
+oc_sec_csr_verify_signature(mbedtls_x509_csr *csr, unsigned md_flags)
 {
   if (md_flags == 0) {
     OC_DBG("signature verification disabled");
@@ -219,7 +219,7 @@ oc_sec_csr_verify_signature(mbedtls_x509_csr *csr, int md_flags)
 
 bool
 oc_sec_csr_validate(mbedtls_x509_csr *csr, mbedtls_pk_type_t pk_type,
-                    int md_flags)
+                    unsigned md_flags)
 {
   assert(csr != NULL);
   mbedtls_pk_type_t pk = mbedtls_pk_get_type(&csr->pk);

--- a/security/oc_csr_internal.h
+++ b/security/oc_csr_internal.h
@@ -44,7 +44,7 @@ extern "C" {
  * @return false otherwise
  */
 bool oc_sec_csr_validate(mbedtls_x509_csr *csr, mbedtls_pk_type_t pk_type,
-                         int md_flags);
+                         unsigned md_flags);
 
 /**
  * @brief Extract subject from a CSR.

--- a/security/oc_obt.c
+++ b/security/oc_obt.c
@@ -267,9 +267,9 @@ oc_obt_dump_state(void)
   if (!buf)
     return;
 #ifdef OC_DYNAMIC_ALLOCATION
-  oc_rep_new_realloc(&buf, OC_MIN_APP_DATA_SIZE, OC_MAX_APP_DATA_SIZE);
+  oc_rep_new_realloc_v1(&buf, OC_MIN_APP_DATA_SIZE, OC_MAX_APP_DATA_SIZE);
 #else  /* OC_DYNAMIC_ALLOCATION */
-  oc_rep_new(buf, OC_MIN_APP_DATA_SIZE);
+  oc_rep_new_v1(buf, OC_MIN_APP_DATA_SIZE);
 #endif /* !OC_DYNAMIC_ALLOCATION */
   oc_rep_start_root_object();
 #ifdef OC_PKI
@@ -2807,7 +2807,8 @@ decode_cred(oc_rep_t *rep, oc_sec_creds_t *creds)
                                   oc_string_len(data->value.string));
                   } else if (len == 9 && memcmp(oc_string(data->name),
                                                 "authority", 9) == 0) {
-                    oc_new_string(&cr->role.role, oc_string(data->value.string),
+                    oc_new_string(&cr->role.authority,
+                                  oc_string(data->value.string),
                                   oc_string_len(data->value.string));
                   }
                   data = data->next;
@@ -2854,10 +2855,9 @@ cred_rsrc(oc_client_response_t *data)
     creds = (oc_sec_creds_t *)oc_memb_alloc(&oc_creds_m);
     if (creds) {
       OC_LIST_STRUCT_INIT(creds, creds);
-      if (decode_cred(data->payload, creds)) {
-        OC_DBG("oc_obt:decoded /oic/sec/cred payload");
-      } else {
-        OC_DBG("oc_obt:error decoding /oic/sec/cred payload");
+      OC_DBG("oc_obt: decoding /oic/sec/cred payload");
+      if (!decode_cred(data->payload, creds)) {
+        OC_DBG("oc_obt: error decoding /oic/sec/cred payload");
       }
       if (oc_list_length(creds->creds) > 0) {
         ctx->cb(creds, ctx->data);
@@ -3183,10 +3183,9 @@ acl2_rsrc(oc_client_response_t *data)
   if (data->code < OC_STATUS_BAD_REQUEST) {
     acl = (oc_sec_acl_t *)oc_memb_alloc(&oc_acl_m);
     if (acl) {
-      if (decode_acl(data->payload, acl)) {
-        OC_DBG("oc_obt:decoded /oic/sec/acl2 payload");
-      } else {
-        OC_DBG("oc_obt:error decoding /oic/sec/acl2 payload");
+      OC_DBG("oc_obt: decoding /oic/sec/acl2 payload");
+      if (!decode_acl(data->payload, acl)) {
+        OC_DBG("oc_obt: error decoding /oic/sec/acl2 payload");
       }
       if (oc_list_length(acl->subjects) > 0) {
         ctx->cb(acl, ctx->data);

--- a/security/oc_obt.c
+++ b/security/oc_obt.c
@@ -3596,11 +3596,11 @@ oc_obt_general_post(const oc_uuid_t *uuid, const char *query, const char *url,
           oc_rep_encode_text_string(&root_map, "", 0);
         }
       } else if (strstr(payload_types[i], "bytes") != NULL) {
-        int byte_string_len = (strlen(payload_values[i]) + 1) / 2;
+        size_t byte_string_len = (strlen(payload_values[i]) + 1) / 2;
         unsigned char payload_byte_string[10240];
 
         char *pos = payload_values[i];
-        for (int j = 0; j < byte_string_len; j++) {
+        for (size_t j = 0; j < byte_string_len; j++) {
           sscanf(pos, "%2hhx", &payload_byte_string[j]);
           pos += 2;
         }

--- a/security/oc_obt_certs.c
+++ b/security/oc_obt_certs.c
@@ -33,6 +33,7 @@
 #include "security/oc_keypair_internal.h"
 #include "security/oc_obt_internal.h"
 #include "security/oc_pki_internal.h"
+#include "util/oc_secure_string_internal.h"
 
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/entropy.h>
@@ -197,10 +198,10 @@ oc_obt_generate_self_signed_root_cert(
     return -1;
   }
 
-  int ret = oc_sec_add_new_cred(device, false, NULL, -1, OC_CREDTYPE_CERT,
-                                OC_CREDUSAGE_TRUSTCA, "*", 0, 0, NULL,
-                                OC_ENCODING_PEM, strlen((const char *)cert_pem),
-                                cert_pem, NULL, NULL, NULL, NULL);
+  int ret = oc_sec_add_new_cred(
+    device, false, NULL, -1, OC_CREDTYPE_CERT, OC_CREDUSAGE_TRUSTCA, "*", 0, 0,
+    NULL, OC_ENCODING_PEM, oc_strnlen((const char *)cert_pem, sizeof(cert_pem)),
+    cert_pem, NULL, NULL, NULL, NULL);
 
   if (ret == -1) {
     OC_ERR("could not write root cert into /oic/sec/cred");

--- a/security/oc_oscore_crypto.c
+++ b/security/oc_oscore_crypto.c
@@ -36,23 +36,25 @@ HMAC_SHA256(const uint8_t *key, uint8_t key_len, const uint8_t *data,
 
   mbedtls_md_context_t hmac_SHA256;
   mbedtls_md_init(&hmac_SHA256);
-  int ret = 0;
-  if ((ret = mbedtls_md_setup(
-         &hmac_SHA256, mbedtls_md_info_from_type(MBEDTLS_MD_SHA256), 1)) != 0) {
+  int ret = mbedtls_md_setup(&hmac_SHA256,
+                             mbedtls_md_info_from_type(MBEDTLS_MD_SHA256), 1);
+  if (ret != 0) {
     OC_ERR("failed to setup message-digest context for HMAC computation: %d",
            ret);
     goto finish;
   }
-
-  if ((ret = mbedtls_md_hmac_starts(&hmac_SHA256, key, key_len)) != 0) {
+  ret = mbedtls_md_hmac_starts(&hmac_SHA256, key, key_len);
+  if (ret != 0) {
     OC_ERR("failed to start the HMAC computation: %d", ret);
     goto finish;
   }
-  if ((ret = mbedtls_md_hmac_update(&hmac_SHA256, data, data_len)) != 0) {
+  ret = mbedtls_md_hmac_update(&hmac_SHA256, data, data_len);
+  if (ret != 0) {
     OC_ERR("failed to compute HMAC: %d", ret);
     goto finish;
   }
-  if ((ret = mbedtls_md_hmac_finish(&hmac_SHA256, hmac)) != 0) {
+  ret = mbedtls_md_hmac_finish(&hmac_SHA256, hmac);
+  if (ret != 0) {
     OC_ERR("failed to finish the HMAC computation: %d", ret);
     goto finish;
   }

--- a/security/oc_oscore_engine.c
+++ b/security/oc_oscore_engine.c
@@ -727,7 +727,7 @@ oc_oscore_send_message(oc_message_t *msg)
      * notifications.
      */
     int32_t observe_option = coap_pkt->observe;
-    if (coap_pkt->observe > 1) {
+    if (coap_pkt->observe >= OC_COAP_OPTION_OBSERVE_SEQUENCE_START_VALUE) {
       coap_pkt->observe = 0;
       OC_DBG(
         "---response is a notification; making inner Observe option empty");

--- a/security/oc_sdi.c
+++ b/security/oc_sdi.c
@@ -28,7 +28,7 @@
 #include "oc_store.h"
 #include "port/oc_assert.h"
 #include "port/oc_log_internal.h"
-#include "util/oc_macros.h"
+#include "util/oc_macros_internal.h"
 
 #include <assert.h>
 #include <stdlib.h>

--- a/security/oc_sp.c
+++ b/security/oc_sp.c
@@ -29,7 +29,7 @@
 #include "oc_store.h"
 #include "port/oc_assert.h"
 #include "port/oc_log_internal.h"
-#include "util/oc_macros.h"
+#include "util/oc_macros_internal.h"
 
 #include <assert.h>
 

--- a/security/oc_sp.c
+++ b/security/oc_sp.c
@@ -30,6 +30,7 @@
 #include "port/oc_assert.h"
 #include "port/oc_log_internal.h"
 #include "util/oc_macros_internal.h"
+#include "util/oc_secure_string_internal.h"
 
 #include <assert.h>
 
@@ -195,7 +196,8 @@ oc_sec_sp_decode(const oc_rep_t *rep, int flags, oc_sec_sp_t *dst)
     for (size_t i = 0;
          i < oc_string_array_get_allocated_size(*supportedprofiles); ++i) {
       const char *p = oc_string_array_get_item(*supportedprofiles, i);
-      oc_sp_types_t profile = oc_sec_sp_type_from_string(p, strlen(p));
+      oc_sp_types_t profile =
+        oc_sec_sp_type_from_string(p, oc_strnlen(p, STRING_ARRAY_ITEM_MAX_LEN));
       if (profile == 0) {
         OC_ERR("oc_sp: invalid supportedprofiles item value([%zu]=%s)", i, p);
         return false;

--- a/security/oc_store.c
+++ b/security/oc_store.c
@@ -205,9 +205,9 @@ oc_sec_dump_ecdsa_keypair(size_t device)
     OC_ERR("cannot dump %s to store: cannot allocate buffer", "keypair");
     return;
   }
-  oc_rep_new_realloc(&sb.buffer, OC_MIN_APP_DATA_SIZE, OC_MAX_APP_DATA_SIZE);
+  oc_rep_new_realloc_v1(&sb.buffer, OC_MIN_APP_DATA_SIZE, OC_MAX_APP_DATA_SIZE);
 #else  /* !OC_APP_DATA_STORAGE_BUFFER */
-  oc_rep_new(sb.buffer, OC_MIN_APP_DATA_SIZE);
+  oc_rep_new_v1(sb.buffer, OC_MIN_APP_DATA_SIZE);
 #endif /* OC_APP_DATA_STORAGE_BUFFER */
 
   oc_sec_ecdsa_encode_keypair_for_device(device);
@@ -260,9 +260,9 @@ oc_sec_dump_cred(size_t device)
     OC_ERR("cannot dump %s to store: cannot allocate buffer", "cred");
     return;
   }
-  oc_rep_new_realloc(&sb.buffer, OC_MIN_APP_DATA_SIZE, OC_MAX_APP_DATA_SIZE);
+  oc_rep_new_realloc_v1(&sb.buffer, OC_MIN_APP_DATA_SIZE, OC_MAX_APP_DATA_SIZE);
 #else  /* !OC_APP_DATA_STORAGE_BUFFER */
-  oc_rep_new(sb.buffer, OC_MIN_APP_DATA_SIZE);
+  oc_rep_new_v1(sb.buffer, OC_MIN_APP_DATA_SIZE);
 #endif /* OC_APP_DATA_STORAGE_BUFFER */
 
   oc_sec_encode_cred(device, 0, true);
@@ -316,9 +316,9 @@ oc_sec_dump_acl(size_t device)
     OC_ERR("cannot dump %s to store: cannot allocate buffer", "acl");
     return;
   }
-  oc_rep_new_realloc(&sb.buffer, OC_MIN_APP_DATA_SIZE, OC_MAX_APP_DATA_SIZE);
+  oc_rep_new_realloc_v1(&sb.buffer, OC_MIN_APP_DATA_SIZE, OC_MAX_APP_DATA_SIZE);
 #else  /* !OC_APP_DATA_STORAGE_BUFFER */
-  oc_rep_new(sb.buffer, OC_MIN_APP_DATA_SIZE);
+  oc_rep_new_v1(sb.buffer, OC_MIN_APP_DATA_SIZE);
 #endif /* OC_APP_DATA_STORAGE_BUFFER */
 
   oc_sec_encode_acl(device, 0, true);
@@ -392,9 +392,9 @@ oc_sec_dump_unique_ids(size_t device)
     OC_ERR("cannot dump %s to store: cannot allocate buffer", "unique_ids");
     return;
   }
-  oc_rep_new_realloc(&sb.buffer, OC_MIN_APP_DATA_SIZE, OC_MAX_APP_DATA_SIZE);
+  oc_rep_new_realloc_v1(&sb.buffer, OC_MIN_APP_DATA_SIZE, OC_MAX_APP_DATA_SIZE);
 #else  /* !OC_APP_DATA_STORAGE_BUFFER */
-  oc_rep_new(sb.buffer, OC_MIN_APP_DATA_SIZE);
+  oc_rep_new_v1(sb.buffer, OC_MIN_APP_DATA_SIZE);
 #endif /* OC_APP_DATA_STORAGE_BUFFER */
 
   const oc_device_info_t *device_info = oc_core_get_device_info(device);
@@ -457,9 +457,9 @@ oc_sec_dump_ael(size_t device)
     OC_ERR("cannot dump %s to store: cannot allocate buffer", "ael");
     return;
   }
-  oc_rep_new_realloc(&sb.buffer, OC_MIN_APP_DATA_SIZE, OC_MAX_APP_DATA_SIZE);
+  oc_rep_new_realloc_v1(&sb.buffer, OC_MIN_APP_DATA_SIZE, OC_MAX_APP_DATA_SIZE);
 #else  /* !OC_APP_DATA_STORAGE_BUFFER */
-  oc_rep_new(sb.buffer, OC_MIN_APP_DATA_SIZE);
+  oc_rep_new_v1(sb.buffer, OC_MIN_APP_DATA_SIZE);
 #endif /* OC_APP_DATA_STORAGE_BUFFER */
 
   /* ael */

--- a/security/oc_tls.c
+++ b/security/oc_tls.c
@@ -2122,7 +2122,7 @@ oc_tls_init_context(void)
   if (mbedtls_ctr_drbg_seed(&g_oc_ctr_drbg_ctx, mbedtls_entropy_func,
                             &g_entropy_ctx,
                             (const unsigned char *)PERSONALIZATION_DATA,
-                            strlen(PERSONALIZATION_DATA)) != 0) {
+                            sizeof(PERSONALIZATION_DATA)) != 0) {
     OC_ERR("error initializing RNG");
     goto dtls_init_err;
   }

--- a/security/oc_tls.c
+++ b/security/oc_tls.c
@@ -2726,7 +2726,7 @@ read_application_data_error(int err)
 
 #if defined(OC_DEBUG) && OC_ERR_IS_ENABLED
   char buf[256];
-  mbedtls_strerror(err, buf, sizeof(256));
+  mbedtls_strerror(err, buf, sizeof(buf));
   OC_ERR("oc_tls: mbedtls_error: %s", buf);
 #endif /* OC_DEBUG && OC_ERR_IS_ENABLED */
 }

--- a/security/oc_tls.c
+++ b/security/oc_tls.c
@@ -675,10 +675,11 @@ ssl_set_timer(void *ctx, uint32_t int_ms, uint32_t fin_ms)
     return;
   }
   oc_tls_retry_timer_t *timer = (oc_tls_retry_timer_t *)ctx;
-  timer->int_ticks = (oc_clock_time_t)((int_ms * OC_CLOCK_SECOND) / 1.e03);
+  timer->int_ticks =
+    (oc_clock_time_t)((double)int_ms * (OC_CLOCK_SECOND / 1.e03));
   oc_etimer_stop(&timer->fin_timer);
   timer->fin_timer.timer.interval =
-    (oc_clock_time_t)((fin_ms * OC_CLOCK_SECOND) / 1.e03);
+    (oc_clock_time_t)((double)fin_ms * (OC_CLOCK_SECOND / 1.e03));
   OC_PROCESS_CONTEXT_BEGIN(&oc_tls_handler)
   oc_etimer_restart(&timer->fin_timer);
   OC_PROCESS_CONTEXT_END(&oc_tls_handler)

--- a/security/unittest/credtest.cpp
+++ b/security/unittest/credtest.cpp
@@ -21,7 +21,7 @@
 #include "oc_cred.h"
 #include "oc_helpers.h"
 #include "security/oc_cred_internal.h"
-#include "util/oc_macros.h"
+#include "util/oc_macros_internal.h"
 
 #include <gtest/gtest.h>
 

--- a/security/unittest/doxmtest.cpp
+++ b/security/unittest/doxmtest.cpp
@@ -30,7 +30,7 @@
 #include "port/oc_storage_internal.h"
 #include "security/oc_doxm_internal.h"
 #include "security/oc_svr_internal.h"
-#include "util/oc_macros.h"
+#include "util/oc_macros_internal.h"
 
 #ifdef OC_HAS_FEATURE_PUSH
 #include "api/oc_push_internal.h"

--- a/security/unittest/dtlstest.cpp
+++ b/security/unittest/dtlstest.cpp
@@ -27,7 +27,7 @@
 #include "tests/gtest/Device.h"
 #include "tests/gtest/tls/DTLS.h"
 #include "tests/gtest/tls/DTLSClient.h"
-#include "util/oc_macros.h"
+#include "util/oc_macros_internal.h"
 
 #include <atomic>
 #include <gtest/gtest.h>

--- a/security/unittest/keypairtest.cpp
+++ b/security/unittest/keypairtest.cpp
@@ -141,7 +141,7 @@ TEST_F(TestKeyPair, EncodeFail_BufferTooSmall)
 {
   /* buffer for oc_rep_t */
   std::array<uint8_t, 10> buf{}; // Purposely small buffer
-  oc_rep_new(buf.data(), buf.size());
+  oc_rep_new_v1(buf.data(), buf.size());
 
   oc_ecdsa_keypair_t kp = oc::GetOCKeyPair(MBEDTLS_ECP_DP_SECP256R1);
   EXPECT_FALSE(oc_sec_ecdsa_encode_keypair(&kp));

--- a/swig/swig_interfaces/oc_rep.i
+++ b/swig/swig_interfaces/oc_rep.i
@@ -1869,5 +1869,7 @@ char *jni_rep_to_json(oc_rep_t *rep, bool prettyPrint)
 
 #define OC_API
 #define OC_DEPRECATED(...)
+#define OC_NONNULL(...)
+#define OC_RETURNS_NONNULL
 %include "oc_rep.h"
 /*******************End oc_rep.h****************************/

--- a/swig/swig_interfaces/oc_rep.i
+++ b/swig/swig_interfaces/oc_rep.i
@@ -55,6 +55,9 @@ struct CborEncoder
 %ignore g_err;
 
 %ignore oc_rep_new;
+%ignore oc_rep_new_v1;
+%ignore oc_rep_new_realloc;
+%ignore oc_rep_new_realloc_v1;
 // DOCUMENTATION workaround
 %javamethodmodifiers newBuffer "/**
    * Allocate memory needed hold the OCRepresentation object.
@@ -96,12 +99,12 @@ void deleteBuffer() {
   g_new_rep_buffer = NULL;
 }
 
-void newBuffer(int size) {
+void newBuffer(size_t size) {
   if (g_new_rep_buffer) {
     deleteBuffer();
   }
   g_new_rep_buffer = (uint8_t *)malloc(size);
-  oc_rep_new(g_new_rep_buffer, size);
+  oc_rep_new_v1(g_new_rep_buffer, size);
   g_rep_objects.size = sizeof(oc_rep_t);
   g_rep_objects.num = 0;
   g_rep_objects.count = NULL;
@@ -1865,5 +1868,6 @@ char *jni_rep_to_json(oc_rep_t *rep, bool prettyPrint)
 %}
 
 #define OC_API
+#define OC_DEPRECATED(...)
 %include "oc_rep.h"
 /*******************End oc_rep.h****************************/

--- a/swig/swig_interfaces/oc_uuid.i
+++ b/swig/swig_interfaces/oc_uuid.i
@@ -101,4 +101,5 @@ oc_uuid_t * jni_gen_uuid()
 %}
 
 #define OC_API
+#define OC_DEPRECATED(...)
 %include oc_uuid.h

--- a/swig/swig_interfaces/oc_uuid.i
+++ b/swig/swig_interfaces/oc_uuid.i
@@ -101,5 +101,5 @@ oc_uuid_t * jni_gen_uuid()
 %}
 
 #define OC_API
-#define OC_DEPRECATED(...)
+#define OC_NONNULL(...)
 %include oc_uuid.h

--- a/tests/client_get_linux.c
+++ b/tests/client_get_linux.c
@@ -16,6 +16,7 @@
 
 #include "test.h"
 #include "oc_api.h"
+#include "oc_clock_util.h"
 #include "port/oc_clock.h"
 #include "util/oc_compiler.h"
 

--- a/tests/client_get_linux.c
+++ b/tests/client_get_linux.c
@@ -140,8 +140,9 @@ discovery_cb(const char *di, const char *uri, oc_string_array_t types,
     int ret;
     const char *rt = oc_string_array_get_item(types, i);
 
-    if (!rt || strcmp(rt, "constrained.r.test"))
+    if (!rt || strcmp(rt, "constrained.r.test") != 0) {
       continue;
+    }
 
     ret =
       oc_do_get(uri, server, NULL, check_resource_cb, HIGH_QOS, &light[pos]);

--- a/tests/gtest/Device.cpp
+++ b/tests/gtest/Device.cpp
@@ -22,6 +22,7 @@
 #include "api/oc_ri_internal.h"
 #include "oc_acl.h"
 #include "oc_api.h"
+#include "oc_clock_util.h"
 #include "oc_core_res.h"
 
 #ifdef OC_HAS_FEATURE_PLGD_TIME

--- a/tests/gtest/Device.cpp
+++ b/tests/gtest/Device.cpp
@@ -326,6 +326,7 @@ TestDevice::AddDynamicResource(const DynamicResourceToAdd &dr, size_t device)
     permission |= OC_PERM_DELETE;
   }
 
+  (void)permission;
 #ifdef OC_SECURITY
   if (dr.isPublic) {
     oc_resource_make_public(res);
@@ -334,8 +335,6 @@ TestDevice::AddDynamicResource(const DynamicResourceToAdd &dr, size_t device)
       res, true, static_cast<oc_ace_permissions_t>(permission));
 #endif /* OC_HAS_FEATURE_RESOURCE_ACCESS_IN_RFOTM */
   }
-#else  /* !OC_SECURITY */
-  (void)permission;
 #endif /* OC_SECURITY */
 
   if (!oc_add_resource(res)) {

--- a/tests/gtest/RepPool.cpp
+++ b/tests/gtest/RepPool.cpp
@@ -26,10 +26,10 @@ RepPool::RepPool(size_t size)
   : size_{ size }
 {
 #ifdef OC_DYNAMIC_ALLOCATION
-  oc_rep_new_realloc(&buffer_, 0, size);
+  oc_rep_new_realloc_v1(&buffer_, 0, size);
 #else
   buffer_.resize(size);
-  oc_rep_new(buffer_.data(), buffer_.size());
+  oc_rep_new_v1(buffer_.data(), buffer_.size());
   memset(rep_objects_alloc_, 0, OC_MAX_NUM_REP_OBJECTS * sizeof(char));
   memset(rep_objects_pool_, 0, OC_MAX_NUM_REP_OBJECTS * sizeof(oc_rep_t));
 #endif /* OC_DYNAMIC_ALLOCATION */
@@ -46,10 +46,10 @@ void
 RepPool::Clear()
 {
 #ifdef OC_DYNAMIC_ALLOCATION
-  oc_rep_new_realloc(&buffer_, 0, size_);
+  oc_rep_new_realloc_v1(&buffer_, 0, size_);
 #else
   buffer_.resize(size_);
-  oc_rep_new(buffer_.data(), buffer_.size());
+  oc_rep_new_v1(buffer_.data(), buffer_.size());
   memset(rep_objects_alloc_, 0, OC_MAX_NUM_REP_OBJECTS * sizeof(char));
   memset(rep_objects_pool_, 0, OC_MAX_NUM_REP_OBJECTS * sizeof(oc_rep_t));
 #endif /* OC_DYNAMIC_ALLOCATION */

--- a/tests/gtest/tls/DTLS.cpp
+++ b/tests/gtest/tls/DTLS.cpp
@@ -24,7 +24,7 @@
 
 #include "api/oc_core_res_internal.h"
 #include "security/oc_cred_internal.h"
-#include "util/oc_macros.h"
+#include "util/oc_macros_internal.h"
 
 namespace oc::tls {
 

--- a/tests/itc/ri/helper/RIHelper.cpp
+++ b/tests/itc/ri/helper/RIHelper.cpp
@@ -55,7 +55,6 @@ int
 RIHelper::createResource()
 {
   OC_PRINTF("createResource\n");
-  int init = 0;
   struct sigaction sa;
   sigfillset(&sa.sa_mask);
   sa.sa_flags = 0;
@@ -69,9 +68,7 @@ RIHelper::createResource()
 
   oc_set_con_res_announced(false);
 
-  init = oc_main_init(&s_handler);
-
-  return init;
+  return oc_main_init(&s_handler);
 }
 int
 RIHelper::waitForEvent()
@@ -325,11 +322,10 @@ RIHelper::discovery(const char *di, const char *uri, oc_string_array_t types,
   (void)interfaces;
   (void)user_data;
   (void)bm;
-  int i;
-  int uri_len = strlen(uri);
+  size_t uri_len = strlen(uri);
   uri_len = (uri_len >= MAX_URI_LENGTH) ? MAX_URI_LENGTH - 1 : uri_len;
   OC_PRINTF("discovery: %s\n", uri);
-  for (i = 0; i < (int)oc_string_array_get_allocated_size(types); i++) {
+  for (size_t i = 0; i < oc_string_array_get_allocated_size(types); ++i) {
     char *t = oc_string_array_get_item(types, i);
     if (strlen(t) == 10 && strncmp(t, RESOURCE_TYPE_LIGHT, 10) == 0) {
       strncpy(s_lightUri, uri, uri_len);

--- a/tools/doxygen.ini
+++ b/tools/doxygen.ini
@@ -2217,10 +2217,10 @@ INCLUDE_FILE_PATTERNS  =
 PREDEFINED             = OC_API \
                          OC_NO_DISCARD_RETURN \
                          OC_NO_RETURN \
-                         OC_DEPRECATED \
-                         OC_NONNULL \
+                         OC_DEPRECATED(...)= \
+                         OC_NONNULL(...)= \
                          OC_RETURNS_NONNULL \
-                         OC_PRINTF_FORMAT \
+                         OC_PRINTF_FORMAT(...)= \
                          OC_COLLECTIONS \
                          OC_CLIENT \
                          OC_SERVER \

--- a/util/oc_macros_internal.h
+++ b/util/oc_macros_internal.h
@@ -27,6 +27,18 @@
 
 #define OC_ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
 
+#ifndef MAX
+#define MAX(n, m) (((n) < (m)) ? (m) : (n))
+#endif /* MAX */
+
+#ifndef MIN
+#define MIN(n, m) (((n) < (m)) ? (n) : (m))
+#endif /* MIN */
+
+#ifndef ABS
+#define ABS(n) (((n) < 0) ? -(n) : (n))
+#endif /* ABS */
+
 #if defined(__GNUC__) && !defined(__clang__)
 #define OC_DO_PRAGMA(x) _Pragma(#x)
 #define GCC_IGNORE_WARNING_START OC_DO_PRAGMA(GCC diagnostic push)

--- a/util/oc_macros_internal.h
+++ b/util/oc_macros_internal.h
@@ -16,8 +16,8 @@
  *
  ******************************************************************/
 
-#ifndef OC_MACROS_H
-#define OC_MACROS_H
+#ifndef OC_MACROS_INTERNAL_H
+#define OC_MACROS_INTERNAL_H
 
 #define OC_TO_STR(x) #x
 
@@ -27,4 +27,27 @@
 
 #define OC_ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
 
-#endif // OC_MACROS_H
+#if defined(__GNUC__) && !defined(__clang__)
+#define OC_DO_PRAGMA(x) _Pragma(#x)
+#define GCC_IGNORE_WARNING_START OC_DO_PRAGMA(GCC diagnostic push)
+#define GCC_IGNORE_WARNING(warning) OC_DO_PRAGMA(GCC diagnostic ignored warning)
+#define GCC_IGNORE_WARNING_END OC_DO_PRAGMA(GCC diagnostic pop)
+#else
+#define GCC_IGNORE_WARNING_START
+#define GCC_IGNORE_WARNING(warning)
+#define GCC_IGNORE_WARNING_END
+#endif /* __GNUC__ && !__clang__ */
+
+#ifdef __clang__
+#define OC_DO_PRAGMA(x) _Pragma(#x)
+#define CLANG_IGNORE_WARNING_START OC_DO_PRAGMA(clang diagnostic push)
+#define CLANG_IGNORE_WARNING(warning)                                          \
+  OC_DO_PRAGMA(clang diagnostic ignored warning)
+#define CLANG_IGNORE_WARNING_END OC_DO_PRAGMA(clang diagnostic pop)
+#else
+#define CLANG_IGNORE_WARNING_START
+#define CLANG_IGNORE_WARNING(warning)
+#define CLANG_IGNORE_WARNING_END
+#endif /* __clang__ */
+
+#endif // OC_MACROS_INTERNAL_H

--- a/util/oc_secure_string.c
+++ b/util/oc_secure_string.c
@@ -1,0 +1,58 @@
+/******************************************************************
+ *
+ * Copyright (c) 2023 plgd.dev s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"),
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************/
+
+#include "oc_secure_string_internal.h"
+
+// on _WIN32 with __STDC_WANT_SECURE_LIB__ set to 1 following functions are
+// available from string.h:
+//   strnlen_s
+
+size_t
+oc_strnlen(const char *str, size_t strsz)
+{
+#if defined(_WIN32) && defined(__STDC_WANT_SECURE_LIB__) &&                    \
+  (__STDC_WANT_SECURE_LIB__ == 1)
+  return strnlen(str, strsz);
+#else /* !_WIN32 || __STDC_WANT_SECURE_LIB__ != 1 */
+#if defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 200809L)
+  return strnlen(str, strsz);
+#else  /* !_POSIX_C_SOURCE || _POSIX_C_SOURCE < 200809L */
+  size_t count = 0;
+  while (strsz > 0 && *str != '\0') {
+    ++str;
+    --strsz;
+    ++count;
+  }
+  return count;
+#endif /* _POSIX_C_SOURCE >= 200809L */
+#endif /* _WIN32 && __STDC_WANT_SECURE_LIB__ == 1  */
+}
+
+size_t
+oc_strnlen_s(const char *str, size_t strsz)
+{
+#if defined(_WIN32) && defined(__STDC_WANT_SECURE_LIB__) &&                    \
+  (__STDC_WANT_SECURE_LIB__ == 1)
+  return strnlen_s(str, strsz);
+#else  /* !_WIN32 || __STDC_WANT_SECURE_LIB__ != 1 */
+  if (str == NULL) {
+    return 0;
+  }
+  return oc_strnlen(str, strsz);
+#endif /* _WIN32 && __STDC_WANT_SECURE_LIB__ == 1 */
+}

--- a/util/oc_secure_string_internal.h
+++ b/util/oc_secure_string_internal.h
@@ -1,0 +1,58 @@
+/******************************************************************
+ *
+ * Copyright (c) 2023 plgd.dev s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"),
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************/
+
+#ifndef OC_SECURE_STRING_INTERNAL_H
+#define OC_SECURE_STRING_INTERNAL_H
+
+#include "util/oc_compiler.h"
+#include <stddef.h>
+#include <string.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Get the number of characters in the string, not including the
+ * terminating null character.
+ *
+ * @param str pointer to the null-terminated byte string to be examined (cannot
+ * be NULL)
+ * @param strsz maximum number of characters to examine
+ * @return length of the null-terminated byte string str on success
+ * @return strsz if the null character was not found
+ */
+size_t oc_strnlen(const char *str, size_t strsz) OC_NONNULL();
+
+/**
+ * @brief Get the number of characters in the string, not including the
+ * terminating null character.
+ *
+ * @param str pointer to the null-terminated byte string to be examined
+ * @param strsz maximum number of characters to examine
+ * @return 0 if str is a null pointer
+ * @return length of the null-terminated byte string str on success
+ * @return strsz if the null character was not found
+ */
+size_t oc_strnlen_s(const char *str, size_t strsz);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OC_SECURE_STRING_INTERNAL_H */

--- a/util/unittest/securestringtest.cpp
+++ b/util/unittest/securestringtest.cpp
@@ -1,0 +1,68 @@
+/****************************************************************************
+ *
+ * Copyright (c) 2023 plgd.dev s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"),
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#include "util/oc_secure_string_internal.h"
+
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
+
+TEST(TestSecureString, oc_strnlen)
+{
+  EXPECT_EQ(0, oc_strnlen_s("", 0));
+
+  std::string nullTerminated = "test";
+  EXPECT_EQ(nullTerminated.length(),
+            oc_strnlen(nullTerminated.c_str(), nullTerminated.size()));
+  // early termination
+  EXPECT_EQ(2, oc_strnlen_s(nullTerminated.c_str(), 2));
+
+  std::vector<char> nonNullTerminated = { 't', 'e', 's', 't' };
+  EXPECT_EQ(nonNullTerminated.size(),
+            oc_strnlen(nonNullTerminated.data(), nonNullTerminated.size()));
+
+  // string with multiple null terminators
+  std::vector<char> multipleNullTerminators = {
+    't', 'e', '\0', 's', 't', '\0'
+  };
+  EXPECT_EQ(2, oc_strnlen(multipleNullTerminators.data(),
+                          multipleNullTerminators.size()));
+}
+
+TEST(TestSecureString, oc_strnlen_s)
+{
+  EXPECT_EQ(0, oc_strnlen_s(nullptr, 0));
+  EXPECT_EQ(0, oc_strnlen_s("", 0));
+
+  std::string nullTerminated = "test";
+  EXPECT_EQ(nullTerminated.length(),
+            oc_strnlen_s(nullTerminated.c_str(), nullTerminated.size()));
+  // early termination
+  EXPECT_EQ(2, oc_strnlen_s(nullTerminated.c_str(), 2));
+
+  std::vector<char> nonNullTerminated = { 't', 'e', 's', 't' };
+  EXPECT_EQ(nonNullTerminated.size(),
+            oc_strnlen_s(nonNullTerminated.data(), nonNullTerminated.size()));
+
+  // string with multiple null terminators
+  std::vector<char> multipleNullTerminators = {
+    't', 'e', '\0', 's', 't', '\0'
+  };
+  EXPECT_EQ(2, oc_strnlen_s(multipleNullTerminators.data(),
+                            multipleNullTerminators.size()));
+}


### PR DESCRIPTION
Fixed issues:
- clang-analyzer-deadcode.DeadStores
- bugprone-branch-clone
- some bugprone-narrowing-conversions