### PR TITLE
swupdate: add API function for validating update payloads

### DIFF
--- a/api/oc_swupdate.c
+++ b/api/oc_swupdate.c
@@ -111,7 +111,7 @@ static struct
   oc_swupdate_cb_t cbs;
   bool cbs_set;
 } g_swupdate_impl = {
-  .cbs = { NULL },
+  .cbs = { NULL, NULL, NULL, NULL },
   .cbs_set = false,
 };
 
@@ -538,13 +538,8 @@ swupdate_decode_string_property(const oc_rep_t *rep, int flags,
                          OC_CHAR_ARRAY_LEN(OC_SWU_PROP_SIGNED))) {
 
     if (!from_storage) {
-      return OC_SWUPDATE_VALIDATE_UPDATE_ERROR_READONLY_PROPERTY; // cannot be
-                                                                  // edited
-                                                                  // currently,
-                                                                  // only
-                                                                  // "vendor"
-                                                                  // value is
-                                                                  // supported
+      // cannot be edited currently, only "vendor" value is supported
+      return OC_SWUPDATE_VALIDATE_UPDATE_ERROR_READONLY_PROPERTY;
     }
     swudecode->signage = &rep->value.string;
     return 0;
@@ -737,7 +732,7 @@ swupdate_decode(const oc_rep_t *rep, int flags, bool has_purl,
 bool
 oc_swupdate_decode(const oc_rep_t *rep, int flags, oc_swupdate_t *dst)
 {
-  oc_swupdate_on_error_t on_error = { NULL };
+  oc_swupdate_on_error_t on_error = { NULL, NULL };
   oc_swupdate_decode_t swudecode = { 0 };
   if (!swupdate_decode(rep, flags, oc_string(dst->purl) != NULL, on_error,
                        &swudecode)) {
@@ -851,7 +846,6 @@ oc_swupdate_encode_with_resource(const oc_swupdate_t *swu,
     oc_process_baseline_interface(swu_res);
   }
 
-  bool to_storage = (flags & OC_SWUPDATE_ENCODE_FLAG_TO_STORAGE) != 0;
   if (!swupdate_encode_package_url(&swu->purl)) {
     OC_ERR("swupdate: failed to encode purl property");
     return -1;
@@ -883,6 +877,7 @@ oc_swupdate_encode_with_resource(const oc_swupdate_t *swu,
     return -1;
   }
 
+  bool to_storage = (flags & OC_SWUPDATE_ENCODE_FLAG_TO_STORAGE) != 0;
   if ((!to_storage || swu->updatetime > 0) &&
       !oc_swupdate_encode_clocktime_to_string(swu->updatetime,
                                               swupdate_on_encode_updatetime)) {

--- a/api/oc_swupdate.c
+++ b/api/oc_swupdate.c
@@ -106,7 +106,14 @@ static oc_swupdate_t *g_sw;
 static oc_swupdate_t g_sw[OC_MAX_NUM_DEVICES];
 #endif /* !OC_DYNAMIC_ALLOCATION */
 
-static const oc_swupdate_cb_t *g_swupdate_impl;
+static struct
+{
+  oc_swupdate_cb_t cbs;
+  bool cbs_set;
+} g_swupdate_impl = {
+  .cbs = { NULL },
+  .cbs_set = false,
+};
 
 static oc_event_callback_retval_t swupdate_update_async(void *data);
 
@@ -193,9 +200,7 @@ static oc_status_t
 swupdate_encode_for_device_with_interface(oc_interface_mask_t iface,
                                           size_t device)
 {
-  switch (iface) {
-  case OC_IF_RW:
-  case OC_IF_BASELINE:
+  if (iface == OC_IF_RW || iface == OC_IF_BASELINE) {
     if (!oc_swupdate_encode_for_device(
           device, iface == OC_IF_BASELINE
                     ? OC_SWUPDATE_ENCODE_FLAG_INCLUDE_BASELINE
@@ -204,8 +209,6 @@ swupdate_encode_for_device_with_interface(oc_interface_mask_t iface,
       return OC_STATUS_INTERNAL_SERVER_ERROR;
     }
     return OC_STATUS_OK;
-  default:
-    break;
   }
   return OC_STATUS_BAD_REQUEST;
 }
@@ -287,9 +290,9 @@ swupdate_resource_post(oc_request_t *request, oc_interface_mask_t iface,
 {
   (void)data;
   size_t device = request->resource->device;
-  if (!oc_swupdate_decode_for_device(request->request_payload,
-                                     OC_SWUPDATE_DECODE_FLAG_COAP_UPDATE,
-                                     device)) {
+  if (!oc_swupdate_decode_for_device(
+        request->request_payload, OC_SWUPDATE_DECODE_FLAG_VALIDATE_DECODED_DATA,
+        device)) {
     oc_send_response_with_callback(request, OC_STATUS_NOT_ACCEPTABLE, true);
     return;
   }
@@ -452,23 +455,23 @@ swupdate_decode_copy(const oc_swupdate_decode_t *src, oc_swupdate_t *dst)
   }
 }
 
-static bool
+static int
 swupdate_decode_int_property(const oc_rep_t *rep, int flags,
                              oc_swupdate_decode_t *swudecode)
 {
   assert(rep->type == OC_REP_INT);
   if (oc_rep_is_property(rep, OC_SWU_PROP_UPDATERESULT,
                          OC_CHAR_ARRAY_LEN(OC_SWU_PROP_UPDATERESULT))) {
-    if ((flags & OC_SWUPDATE_DECODE_FLAG_FROM_STORAGE) != 0) {
-      assert(rep->value.integer <= INT_MAX);
-      swudecode->swupdateresult = (int)rep->value.integer;
-      swudecode->swupdateresult_set = true;
-      return true;
+    if ((flags & OC_SWUPDATE_DECODE_FLAG_FROM_STORAGE) == 0) {
+      /* Read-only property */
+      return OC_SWUPDATE_VALIDATE_UPDATE_ERROR_READONLY_PROPERTY;
     }
-    /* Read-only property */
-    return false;
+    assert(rep->value.integer <= INT_MAX);
+    swudecode->swupdateresult = (int)rep->value.integer;
+    swudecode->swupdateresult_set = true;
+    return 0;
   }
-  return false;
+  return OC_SWUPDATE_VALIDATE_UPDATE_ERROR_INVALID_PROPERTY;
 }
 
 static bool
@@ -481,41 +484,40 @@ swupdate_decode_timestamp(const oc_string_t *value, oc_clock_time_t *time)
                                         oc_string_len(*value), time);
 }
 
-static bool
+static int
 swupdate_decode_update_time(const oc_rep_t *rep, int flags,
                             oc_swupdate_decode_t *swudecode)
 {
   assert(rep->type == OC_REP_STRING);
 
   bool from_storage = (flags & OC_SWUPDATE_DECODE_FLAG_FROM_STORAGE) != 0;
-
   if (!from_storage) {
     // allow special values for UPDATE
     if (oc_string_is_cstr_equal(
           &rep->value.string, OC_SWU_PROP_UPDATETIME_NONE,
           OC_CHAR_ARRAY_LEN(OC_SWU_PROP_UPDATETIME_NONE))) {
       swudecode->updatetime_set = UPDATE_TIME_NONE;
-      return true;
+      return 0;
     }
     if (oc_string_is_cstr_equal(
           &rep->value.string, OC_SWU_PROP_UPDATETIME_NOW,
           OC_CHAR_ARRAY_LEN(OC_SWU_PROP_UPDATETIME_NOW))) {
       swudecode->updatetime_set = UPDATE_TIME_NOW;
-      return true;
+      return 0;
     }
   }
   oc_clock_time_t updatetime;
   if (!swupdate_decode_timestamp(&rep->value.string, &updatetime)) {
     OC_ERR("swupdate: invalid updatetime property(%s)",
            oc_string(rep->value.string));
-    return false;
+    return OC_SWUPDATE_VALIDATE_UPDATE_ERROR_INVALID_PROPERTY_VALUE;
   }
   swudecode->updatetime = updatetime;
   swudecode->updatetime_set = UPDATE_TIME_SET;
-  return true;
+  return 0;
 }
 
-static bool
+static int
 swupdate_decode_string_property(const oc_rep_t *rep, int flags,
                                 oc_swupdate_decode_t *swudecode)
 {
@@ -526,21 +528,26 @@ swupdate_decode_string_property(const oc_rep_t *rep, int flags,
                          OC_CHAR_ARRAY_LEN(OC_SWU_PROP_NEWVERSION))) {
     if (!from_storage) {
       /* Read-only property */
-      return false;
+      return OC_SWUPDATE_VALIDATE_UPDATE_ERROR_READONLY_PROPERTY;
     }
     swudecode->nv = &rep->value.string;
-    return true;
+    return 0;
   }
 
   if (oc_rep_is_property(rep, OC_SWU_PROP_SIGNED,
                          OC_CHAR_ARRAY_LEN(OC_SWU_PROP_SIGNED))) {
 
     if (!from_storage) {
-      return false; // cannot be edited currently, only "vendor" value is
-                    // supported
+      return OC_SWUPDATE_VALIDATE_UPDATE_ERROR_READONLY_PROPERTY; // cannot be
+                                                                  // edited
+                                                                  // currently,
+                                                                  // only
+                                                                  // "vendor"
+                                                                  // value is
+                                                                  // supported
     }
     swudecode->signage = &rep->value.string;
-    return true;
+    return 0;
   }
 
   if (oc_rep_is_property(rep, OC_SWU_PROP_UPDATEACTION,
@@ -548,44 +555,44 @@ swupdate_decode_string_property(const oc_rep_t *rep, int flags,
     int action = oc_swupdate_action_from_str(oc_string(rep->value.string),
                                              oc_string_len(rep->value.string));
     if (action < 0) {
-      return false;
+      return OC_SWUPDATE_VALIDATE_UPDATE_ERROR_INVALID_PROPERTY_VALUE;
     }
     swudecode->swupdateaction = (oc_swupdate_action_t)action;
     swudecode->swupdateaction_set = true;
-    return true;
+    return 0;
   }
 
   if (oc_rep_is_property(rep, OC_SWU_PROP_UPDATESTATE,
                          OC_CHAR_ARRAY_LEN(OC_SWU_PROP_UPDATESTATE))) {
     if (!from_storage) {
       /* Read-only property */
-      return false;
+      return OC_SWUPDATE_VALIDATE_UPDATE_ERROR_READONLY_PROPERTY;
     }
     int state = oc_swupdate_state_from_str(oc_string(rep->value.string),
                                            oc_string_len(rep->value.string));
     if (state < 0) {
-      return false;
+      return OC_SWUPDATE_VALIDATE_UPDATE_ERROR_INVALID_PROPERTY_VALUE;
     }
     swudecode->swupdatestate = (oc_swupdate_state_t)state;
     swudecode->swupdatestate_set = true;
-    return true;
+    return 0;
   }
 
   if (oc_rep_is_property(rep, OC_SWU_PROP_LASTUPDATE,
                          OC_CHAR_ARRAY_LEN(OC_SWU_PROP_LASTUPDATE))) {
     if (!from_storage) {
       /* Read-only property */
-      return false;
+      return OC_SWUPDATE_VALIDATE_UPDATE_ERROR_READONLY_PROPERTY;
     }
     oc_clock_time_t lastupdate;
     if (!swupdate_decode_timestamp(&rep->value.string, &lastupdate)) {
       OC_ERR("swupdate: invalid lastupdate property(%s)",
              oc_string(rep->value.string));
-      return false;
+      return OC_SWUPDATE_VALIDATE_UPDATE_ERROR_INVALID_PROPERTY_VALUE;
     }
     swudecode->lastupdate = lastupdate;
     swudecode->lastupdate_set = true;
-    return true;
+    return 0;
   }
 
   if (oc_rep_is_property(rep, OC_SWU_PROP_UPDATETIME,
@@ -596,85 +603,146 @@ swupdate_decode_string_property(const oc_rep_t *rep, int flags,
   if (oc_rep_is_property(rep, OC_SWU_PROP_PACKAGEURL,
                          OC_CHAR_ARRAY_LEN(OC_SWU_PROP_PACKAGEURL))) {
     swudecode->purl = &rep->value.string;
-    return true;
+    return 0;
   }
-  return false;
+  return OC_SWUPDATE_VALIDATE_UPDATE_ERROR_INVALID_PROPERTY;
 }
 
-static bool
-swupdate_validate_decode(const oc_swupdate_decode_t *swudecode,
-                         bool skip_purl_validation)
+static int
+swupdate_decode_property(const oc_rep_t *rep, int flags,
+                         oc_swupdate_decode_t *swudecode)
+{
+  if (rep->type == OC_REP_INT) {
+    return swupdate_decode_int_property(rep, flags, swudecode);
+  }
+  if (rep->type == OC_REP_STRING) {
+    return swupdate_decode_string_property(rep, flags, swudecode);
+  }
+  return OC_SWUPDATE_VALIDATE_UPDATE_ERROR_INVALID_PROPERTY;
+}
+
+static int
+swupdate_validate_updatetime(const oc_swupdate_decode_t *swudecode)
 {
   if (swudecode->updatetime_set == UPDATE_TIME_NOT_SET) {
     OC_ERR("swupdate: updatetime not set");
-    return false;
+    return OC_SWUPDATE_VALIDATE_UPDATE_ERROR_UPDATETIME_NOT_SET;
   }
   if (swudecode->updatetime_set == UPDATE_TIME_SET &&
       swudecode->updatetime < oc_clock_time()) {
     OC_ERR("swupdate: updatetime(%ld) is in the past",
            (long)swudecode->updatetime);
-    return false;
+    return OC_SWUPDATE_VALIDATE_UPDATE_ERROR_UPDATETIME_INVALID;
+  }
+  return 0;
+}
+
+static int
+swupdate_validate_package_url(const oc_swupdate_decode_t *swudecode)
+{
+  const char *purl =
+    swudecode->purl == NULL ? NULL : oc_string(*swudecode->purl);
+  if (purl == NULL) {
+    OC_ERR("swupdate: package URL not set");
+    return OC_SWUPDATE_VALIDATE_UPDATE_ERROR_PURL_NOT_SET;
   }
 
-  if (!skip_purl_validation) {
-    const char *purl =
-      swudecode->purl == NULL ? NULL : oc_string(*swudecode->purl);
-    if (purl == NULL) {
-      OC_ERR("swupdate: package URL not set");
-      return false;
-    }
-
-    if (g_swupdate_impl == NULL || (g_swupdate_impl->validate_purl == NULL)) {
-      OC_ERR("swupdate: cannot validate package URL");
-      return false;
-    }
-    if (g_swupdate_impl->validate_purl(purl) < 0) {
-      OC_ERR("swupdate: package URL not valid");
-      return false;
-    }
+  if (!g_swupdate_impl.cbs_set || (g_swupdate_impl.cbs.validate_purl == NULL)) {
+    OC_ERR("swupdate: cannot validate package URL");
+    return OC_SWUPDATE_VALIDATE_UPDATE_ERROR_INVALID_IMPLEMENTATION;
   }
-  return true;
+  if (g_swupdate_impl.cbs.validate_purl(purl) < 0) {
+    OC_ERR("swupdate: package URL not valid");
+    return OC_SWUPDATE_VALIDATE_UPDATE_ERROR_PURL_INVALID;
+  }
+  return 0;
+}
+
+static bool
+swupdate_validate_decoded_data(const oc_swupdate_decode_t *swudecode,
+                               bool skip_purl_validation,
+                               oc_swupdate_on_error_t on_error)
+{
+  bool is_valid = true;
+  int err = swupdate_validate_updatetime(swudecode);
+  if (err != 0) {
+    if (on_error.fn == NULL ||
+        !on_error.fn(NULL, (oc_swupdate_validate_update_error_t)err,
+                     on_error.data)) {
+      return false;
+    }
+    is_valid = false;
+  }
+
+  if (skip_purl_validation) {
+    return is_valid;
+  }
+
+  err = swupdate_validate_package_url(swudecode);
+  if (err == 0) {
+    return is_valid;
+  }
+  if (on_error.fn != NULL) {
+    on_error.fn(NULL, (oc_swupdate_validate_update_error_t)err, on_error.data);
+  }
+  return false;
+}
+
+static bool
+swupdate_decode(const oc_rep_t *rep, int flags, bool has_purl,
+                oc_swupdate_on_error_t on_error,
+                oc_swupdate_decode_t *swudecode)
+
+{
+  bool is_valid = true;
+  for (; rep != NULL; rep = rep->next) {
+    int err = swupdate_decode_property(rep, flags, swudecode);
+    if (err == 0) {
+      continue;
+    }
+    if ((flags & OC_SWUPDATE_DECODE_FLAG_IGNORE_ERRORS) != 0) {
+      OC_DBG("swupdate: cannot decode property (name=%s, type=%d)",
+             oc_string(rep->name), (int)rep->type);
+      continue;
+    }
+    OC_ERR("swupdate: cannot decode property (name=%s, type=%d)",
+           oc_string(rep->name), (int)rep->type);
+    if (on_error.fn == NULL ||
+        !on_error.fn(rep, (oc_swupdate_validate_update_error_t)err,
+                     on_error.data)) {
+      return false;
+    }
+    is_valid = false;
+  }
+
+  if (!is_valid ||
+      (flags & OC_SWUPDATE_DECODE_FLAG_VALIDATE_DECODED_DATA) == 0) {
+    return is_valid;
+  }
+
+  // special case for non-idle actions -> if purl is empty we keep the
+  // previous purl and skip purl validation
+  bool skip_purl_validation = false;
+  if (swudecode->swupdateaction_set &&
+      swudecode->swupdateaction != OC_SWUPDATE_IDLE &&
+      swudecode->purl != NULL && oc_string(*swudecode->purl)[0] == '\0' &&
+      has_purl) {
+    skip_purl_validation = true;
+  }
+  return swupdate_validate_decoded_data(swudecode, skip_purl_validation,
+                                        on_error) &&
+         is_valid;
 }
 
 bool
 oc_swupdate_decode(const oc_rep_t *rep, int flags, oc_swupdate_t *dst)
 {
+  oc_swupdate_on_error_t on_error = { NULL };
   oc_swupdate_decode_t swudecode = { 0 };
-  for (; rep != NULL; rep = rep->next) {
-    if (rep->type == OC_REP_STRING &&
-        swupdate_decode_string_property(rep, flags, &swudecode)) {
-      continue;
-    }
-    if (rep->type == OC_REP_INT &&
-        swupdate_decode_int_property(rep, flags, &swudecode)) {
-      continue;
-    }
-
-    if ((flags & OC_SWUPDATE_DECODE_FLAG_IGNORE_ERRORS) == 0) {
-      OC_ERR("swupdate: cannot decode property (name=%s, type=%d)",
-             oc_string(rep->name), (int)rep->type);
-      return false;
-    }
-    OC_DBG("swupdate: cannot decode property (name=%s, type=%d)",
-           oc_string(rep->name), (int)rep->type);
+  if (!swupdate_decode(rep, flags, oc_string(dst->purl) != NULL, on_error,
+                       &swudecode)) {
+    return false;
   }
-
-  if ((flags & OC_SWUPDATE_DECODE_FLAG_COAP_UPDATE) != 0) {
-    // special case for non-idle actions -> if purl is empty we keep the
-    // previous purl and skip purl validation
-    bool skip_purl_validation = false;
-    if (swudecode.swupdateaction_set &&
-        swudecode.swupdateaction != OC_SWUPDATE_IDLE &&
-        swudecode.purl != NULL && oc_string(*swudecode.purl)[0] == '\0' &&
-        oc_string(dst->purl) != NULL) {
-      skip_purl_validation = true;
-    }
-
-    if (!swupdate_validate_decode(&swudecode, skip_purl_validation)) {
-      return false;
-    }
-  }
-
   swupdate_decode_copy(&swudecode, dst);
   return true;
 }
@@ -683,6 +751,21 @@ bool
 oc_swupdate_decode_for_device(const oc_rep_t *rep, int flags, size_t device)
 {
   return oc_swupdate_decode(rep, flags, &g_sw[device]);
+}
+
+bool
+oc_swupdate_validate_update(size_t device, const oc_rep_t *rep,
+                            oc_swupdate_on_validate_update_error_fn_t on_error,
+                            void *on_error_data)
+{
+  oc_swupdate_on_error_t on_error_impl = {
+    .fn = on_error,
+    .data = on_error_data,
+  };
+  oc_swupdate_decode_t swudecode = { 0 };
+  return swupdate_decode(rep, OC_SWUPDATE_DECODE_FLAG_VALIDATE_DECODED_DATA,
+                         oc_string(g_sw[device].purl) != NULL, on_error_impl,
+                         &swudecode);
 }
 
 static bool
@@ -874,7 +957,13 @@ oc_swupdate_dump(size_t device)
 void
 oc_swupdate_set_impl(const oc_swupdate_cb_t *swupdate_impl)
 {
-  g_swupdate_impl = swupdate_impl;
+  if (swupdate_impl == NULL) {
+    memset(&g_swupdate_impl.cbs, 0, sizeof(g_swupdate_impl.cbs));
+    g_swupdate_impl.cbs_set = false;
+    return;
+  }
+  memcpy(&g_swupdate_impl.cbs, swupdate_impl, sizeof(*swupdate_impl));
+  g_swupdate_impl.cbs_set = true;
 }
 
 void
@@ -980,24 +1069,27 @@ oc_swupdate_perform_action(oc_swupdate_action_t action, size_t device)
   oc_swupdate_t *s = &g_sw[device];
   s->swupdateaction = action;
   if (action == OC_SWUPDATE_ISAC) {
-    if (g_swupdate_impl && g_swupdate_impl->check_new_version &&
-        g_swupdate_impl->check_new_version(device, oc_string(s->purl),
-                                           oc_string(s->nv)) < 0) {
+    if (g_swupdate_impl.cbs_set &&
+        g_swupdate_impl.cbs.check_new_version != NULL &&
+        g_swupdate_impl.cbs.check_new_version(device, oc_string(s->purl),
+                                              oc_string(s->nv)) < 0) {
       OC_ERR("swupdate: could not check for availability of new version of "
              "software");
     }
     return;
   }
   if (action == OC_SWUPDATE_ISVV) {
-    if (g_swupdate_impl && g_swupdate_impl->download_update &&
-        g_swupdate_impl->download_update(device, oc_string(s->purl)) < 0) {
+    if (g_swupdate_impl.cbs_set &&
+        g_swupdate_impl.cbs.download_update != NULL &&
+        g_swupdate_impl.cbs.download_update(device, oc_string(s->purl)) < 0) {
       OC_ERR("swupdate: could not download new software update");
     }
     return;
   }
   if (action == OC_SWUPDATE_UPGRADE) {
-    if (g_swupdate_impl && g_swupdate_impl->perform_upgrade &&
-        g_swupdate_impl->perform_upgrade(device, oc_string(s->purl)) < 0) {
+    if (g_swupdate_impl.cbs_set &&
+        g_swupdate_impl.cbs.perform_upgrade != NULL &&
+        g_swupdate_impl.cbs.perform_upgrade(device, oc_string(s->purl)) < 0) {
       OC_ERR("swupdate: could not initiate a software update");
     }
     return;

--- a/api/oc_swupdate_internal.h
+++ b/api/oc_swupdate_internal.h
@@ -21,6 +21,7 @@
 
 #include "oc_config.h"
 #include "oc_helpers.h"
+#include "oc_swupdate.h"
 #include "util/oc_compiler.h"
 #include <stdbool.h>
 #include <stddef.h>
@@ -175,10 +176,16 @@ typedef bool (*oc_swupdate_on_encode_timestamp_to_string_t)(const char *)
 bool oc_swupdate_encode_clocktime_to_string(
   oc_clock_time_t time, oc_swupdate_on_encode_timestamp_to_string_t encode);
 
+typedef struct
+{
+  oc_swupdate_on_validate_update_error_fn_t fn;
+  void *data;
+} oc_swupdate_on_error_t;
+
 typedef enum {
   OC_SWUPDATE_DECODE_FLAG_IGNORE_ERRORS = 1 << 0,
   OC_SWUPDATE_DECODE_FLAG_FROM_STORAGE = 1 << 1,
-  OC_SWUPDATE_DECODE_FLAG_COAP_UPDATE = 1 << 2,
+  OC_SWUPDATE_DECODE_FLAG_VALIDATE_DECODED_DATA = 1 << 2,
 } oc_swupdate_decode_flag_t;
 
 /**

--- a/api/unittest/swupdatetest.cpp
+++ b/api/unittest/swupdatetest.cpp
@@ -576,15 +576,13 @@ storeError(const oc_rep_t *rep, oc_swupdate_validate_update_error_t error,
 
 static bool
 hasStoredError(const std::vector<ValidateUpdateError> &errors,
-               const std::string &property,
+               std::string_view property,
                oc_swupdate_validate_update_error_t error)
 {
-  for (const auto &e : errors) {
-    if ((property.empty() || e.property == property) && e.error == error) {
-      return true;
-    }
-  }
-  return false;
+  return std::any_of(
+    std::begin(errors), std::end(errors), [property, error](const auto &e) {
+      return (property.empty() || e.property == property) && e.error == error;
+    });
 }
 
 TEST_F(TestSWUpdateWithServer, ValidateUpdate_FailInvalidImplementation)

--- a/api/unittest/swupdatetest.cpp
+++ b/api/unittest/swupdatetest.cpp
@@ -1034,9 +1034,13 @@ TEST_F(TestSWUpdateWithServer, DeleteRequest_FailMethodNotSupported)
 
 #endif /* !OC_SECURITY || OC_HAS_FEATURE_RESOURCE_ACCESS_IN_RFOTM */
 
+/** Test all SWU steps
+ *   - SWU notification with success (OC_SWUPDATE_RESULT_SUCCESS) should trigger
+ * the corresponding action
+ */
 TEST_F(TestSWUpdateWithServer, Upgrade)
 {
-  std::string version{ "1.0" };
+  std::string version{ "4.2" };
 
   EXPECT_EQ(0, TestSWUpdateImplementation::checkNewVersionCounter_);
   oc_swupdate_perform_action(OC_SWUPDATE_ISAC, kDeviceID);
@@ -1073,6 +1077,22 @@ TEST_F(TestSWUpdateWithServer, Upgrade)
 #ifdef OC_SECURITY
   EXPECT_EQ(0, oc_sec_pstat_current_mode(kDeviceID));
 #endif /* OC_SECURITY */
+}
+
+/** Notification with unsuccesful result should not trigger the next step */
+TEST_F(TestSWUpdateWithServer, UpgradeNoNextStep)
+{
+  std::string version{ "4.2" };
+
+  EXPECT_EQ(0, TestSWUpdateImplementation::downloadUpgradeCounter_);
+  oc_swupdate_notify_new_version_available(kDeviceID, version.c_str(),
+                                           OC_SWUPDATE_RESULT_SVV_FAIL);
+  EXPECT_EQ(0, TestSWUpdateImplementation::downloadUpgradeCounter_);
+
+  EXPECT_EQ(0, TestSWUpdateImplementation::performUpgradeCounter_);
+  oc_swupdate_notify_downloaded(kDeviceID, version.c_str(),
+                                OC_SWUPDATE_RESULT_CONN_FAIL);
+  EXPECT_EQ(0, TestSWUpdateImplementation::performUpgradeCounter_);
 }
 
 #endif /* OC_SOFTWARE_UPDATE */

--- a/include/oc_swupdate.h
+++ b/include/oc_swupdate.h
@@ -15,9 +15,15 @@
  * language governing permissions and limitations under the License.
  *
  ****************************************************************************/
+
 /**
-  @file
-*/
+ * @defgroup swupdate Software Update
+ *
+ * Notify the application of a new software update and perform the update.
+ *
+ * @{
+ */
+
 #ifndef OC_SWUPDATE_H
 #define OC_SWUPDATE_H
 
@@ -125,30 +131,31 @@ typedef struct
  *
  * @param swupdate_impl the structure with the software update callbacks
  *
- * @note the callbacks are copied to internal storage, so the validity of the
+ * @note the callbacks are copied to runtime variable, so the validity of the
  * structure is only required during the call to this function
  */
 OC_API
 void oc_swupdate_set_impl(const oc_swupdate_cb_t *swupdate_impl);
 
+/// @brief Validation error codes
 typedef enum {
   OC_SWUPDATE_VALIDATE_UPDATE_ERROR_INVALID_IMPLEMENTATION =
-    -1, // software update callbacks not assigned correctly
+    -1, ///< software update callbacks not assigned correctly
 
-  OC_SWUPDATE_VALIDATE_UPDATE_ERROR_INVALID_PROPERTY = -8, // invalid property
+  OC_SWUPDATE_VALIDATE_UPDATE_ERROR_INVALID_PROPERTY = -8, ///< invalid property
   OC_SWUPDATE_VALIDATE_UPDATE_ERROR_READONLY_PROPERTY =
-    -9, // trying to update a read-only property
+    -9, ///< trying to update a read-only property
   OC_SWUPDATE_VALIDATE_UPDATE_ERROR_INVALID_PROPERTY_VALUE =
-    -10, // invalid property value
+    -10, ///< invalid property value
 
   OC_SWUPDATE_VALIDATE_UPDATE_ERROR_UPDATETIME_NOT_SET =
-    -16, // updatetime property is not set
+    -16, ///< updatetime property is not set
   OC_SWUPDATE_VALIDATE_UPDATE_ERROR_UPDATETIME_INVALID =
-    -17, // updatetime property has invalid value
-  OC_SWUPDATE_VALIDATE_UPDATE_ERROR_PURL_NOT_SET = -18, // purl property not set
+    -17, ///< updatetime property has invalid value
+  OC_SWUPDATE_VALIDATE_UPDATE_ERROR_PURL_NOT_SET =
+    -18, ///< purl property not set
   OC_SWUPDATE_VALIDATE_UPDATE_ERROR_PURL_INVALID =
-    -19, // purl property has invalid value
-
+    -19, ///< purl property has invalid value
 } oc_swupdate_validate_update_error_t;
 
 /**
@@ -189,3 +196,5 @@ bool oc_swupdate_validate_update(
 #endif
 
 #endif /* OC_SWUPDATE_H */
+
+/** @} */

--- a/tests/gtest/Storage.cpp
+++ b/tests/gtest/Storage.cpp
@@ -50,8 +50,12 @@ Storage::Config()
 int
 Storage::Clear()
 {
-  for (const auto &entry : std::filesystem::directory_iterator(path_)) {
-    std::filesystem::remove_all(entry.path());
+  try {
+    for (const auto &entry : std::filesystem::directory_iterator(path_)) {
+      std::filesystem::remove_all(entry.path());
+    }
+  } catch (...) {
+    // ignore errors
   }
   return oc_storage_reset();
 }

--- a/tools/doxygen.ini
+++ b/tools/doxygen.ini
@@ -2174,7 +2174,7 @@ ENABLE_PREPROCESSING   = YES
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-MACRO_EXPANSION        = NO
+MACRO_EXPANSION        = YES
 
 # If the EXPAND_ONLY_PREDEF and MACRO_EXPANSION tags are both set to YES then
 # the macro expansion is limited to the macros specified with the PREDEFINED and
@@ -2182,7 +2182,7 @@ MACRO_EXPANSION        = NO
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_ONLY_PREDEF     = NO
+EXPAND_ONLY_PREDEF     = YES
 
 # If the SEARCH_INCLUDES tag is set to YES, the include files in the
 # INCLUDE_PATH will be searched if a #include is found.
@@ -2214,7 +2214,14 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = OC_COLLECTIONS \
+PREDEFINED             = OC_API \
+                         OC_NO_DISCARD_RETURN \
+                         OC_NO_RETURN \
+                         OC_DEPRECATED \
+                         OC_NONNULL \
+                         OC_RETURNS_NONNULL \
+                         OC_PRINTF_FORMAT \
+                         OC_COLLECTIONS \
                          OC_CLIENT \
                          OC_SERVER \
                          OC_COLLECTIONS_IF_CREATE \

--- a/util/oc_list.h
+++ b/util/oc_list.h
@@ -51,6 +51,7 @@
  * list with list_remove(). The head and tail of a list can be
  * extracted using list_head() and list_tail(), respectively.
  *
+ * @{
  */
 
 #ifndef OC_LIST_H
@@ -151,3 +152,5 @@ void *oc_list_item_next(void *item);
 #endif
 
 #endif /* OC_LIST_H */
+
+/** @} */


### PR DESCRIPTION
This commit introduces the oc_swupdate_validate_update global function to the swupdate module. The function is responsible for validating Software Update payloads and triggering a callback function in case of any encountered errors.