### PR TITLE
Fix runtime disabling of logging

### DIFF
--- a/api/oc_log.c
+++ b/api/oc_log.c
@@ -24,6 +24,7 @@
 
 #include "oc_log_internal.h"
 #include "port/oc_log_internal.h"
+#include "util/oc_atomic.h"
 
 #include <assert.h>
 #include <stddef.h>
@@ -43,14 +44,15 @@ oc_log_get_logger(void)
 void
 oc_log_set_level(oc_log_level_t level)
 {
-  assert(level < UINT8_MAX);
-  g_logger.level = (uint8_t)level;
+  assert(level >= INT8_MIN);
+  assert(level <= INT8_MAX);
+  OC_ATOMIC_STORE8(g_logger.level, (int8_t)level);
 }
 
 oc_log_level_t
 oc_log_get_level(void)
 {
-  return g_logger.level;
+  return OC_ATOMIC_LOAD8(g_logger.level);
 }
 
 const char *

--- a/api/oc_log_internal.h
+++ b/api/oc_log_internal.h
@@ -28,7 +28,6 @@
 #define OC_LOG_INTERNAL_H
 
 #include "oc_log.h"
-#include "oc_clock_util.h"
 #include "util/oc_atomic.h"
 
 #include <stdio.h>
@@ -40,8 +39,8 @@ extern "C" {
 
 typedef struct oc_logger_t
 {
-  oc_print_log_fn_t fn;    ///< logging function
-  OC_ATOMIC_UINT8_T level; ///< mask of enabled log levels
+  oc_print_log_fn_t fn;   ///< logging function
+  OC_ATOMIC_INT8_T level; ///< mask of enabled log levels
 } oc_logger_t;
 
 /** Get global logger */

--- a/port/oc_log_internal.h
+++ b/port/oc_log_internal.h
@@ -44,8 +44,9 @@
 #define OC_PORT_LOG_INTERNAL_H
 
 #include "api/oc_log_internal.h"
-#include "oc_log.h"
+#include "oc_clock_util.h"
 #include "oc_helpers.h"
+#include "oc_log.h"
 
 #include <inttypes.h>
 


### PR DESCRIPTION
Updated the internal representation from an unsigned to a signed integer. The value OC_LOG_LEVEL_DISABLED (=-1) is now to disable logging during runtime. Whether a log level is enabled is checked by the '<' operator. Previously, when casting to uint8_t, the value overflowed to 255, causing all log levels to be enabled. This issue has been resolved by using a signed integer representation.