### PR TITLE
cloud: allows set the redirect uri as onboard parameter

### DIFF
--- a/api/cloud/oc_cloud.c
+++ b/api/cloud/oc_cloud.c
@@ -151,6 +151,10 @@ cloud_set_cloudconf(oc_cloud_context_t *ctx, const cloud_conf_update_t *data)
   if (data->sid && data->sid_len) {
     oc_set_string(&ctx->store.sid, data->sid, data->sid_len);
   }
+  if (data->redirect_uri && data->redirect_uri_len) {
+    oc_set_string(&ctx->store.redirect_uri, data->redirect_uri,
+                  data->redirect_uri_len);
+  }
 }
 
 int
@@ -158,6 +162,17 @@ oc_cloud_provision_conf_resource(oc_cloud_context_t *ctx, const char *server,
                                  const char *access_token,
                                  const char *server_id,
                                  const char *auth_provider)
+{
+  return oc_cloud_provision_conf_resource_v1(ctx, server, access_token,
+                                             server_id, auth_provider, NULL);
+}
+
+int
+oc_cloud_provision_conf_resource_v1(oc_cloud_context_t *ctx, const char *server,
+                                    const char *access_token,
+                                    const char *server_id,
+                                    const char *auth_provider,
+                                    const char *redirect_uri)
 {
   assert(ctx != NULL);
   if (!server || !access_token || !server_id) {
@@ -180,6 +195,8 @@ oc_cloud_provision_conf_resource(oc_cloud_context_t *ctx, const char *server,
     .sid_len = strlen(server_id),
     .auth_provider = auth_provider,
     .auth_provider_len = auth_provider != NULL ? strlen(auth_provider) : 0,
+    .redirect_uri = redirect_uri,
+    .redirect_uri_len = redirect_uri != NULL ? strlen(redirect_uri) : 0
   };
   cloud_set_cloudconf(ctx, &data);
   cloud_rd_reset_context(ctx);

--- a/api/cloud/oc_cloud_access.c
+++ b/api/cloud/oc_cloud_access.c
@@ -88,11 +88,20 @@ cloud_tls_add_peer(const oc_endpoint_t *endpoint, int selected_identity_cred_id)
 
 #endif /* OC_SECURITY */
 
-/* Internal APIs for accessing the OCF Cloud */
 bool
 oc_cloud_access_register(oc_cloud_access_conf_t conf, const char *auth_provider,
                          const char *auth_code, const char *uid,
                          const char *access_token)
+{
+  return oc_cloud_access_register_v1(conf, auth_provider, auth_code, uid,
+                                     access_token, NULL);
+}
+/* Internal APIs for accessing the OCF Cloud */
+bool
+oc_cloud_access_register_v1(oc_cloud_access_conf_t conf,
+                            const char *auth_provider, const char *auth_code,
+                            const char *uid, const char *access_token,
+                            const char *redirect_uri)
 {
   if (conf.endpoint == NULL || conf.handler == NULL ||
       ((auth_provider == NULL || auth_code == NULL) && access_token == NULL)) {
@@ -137,6 +146,9 @@ oc_cloud_access_register(oc_cloud_access_conf_t conf, const char *auth_provider,
     oc_rep_set_text_string(root, accesstoken, access_token);
   }
   oc_rep_set_text_string(root, devicetype, "device");
+  if (redirect_uri != NULL) {
+    oc_rep_set_text_string(root, redirecturi, redirect_uri);
+  }
   oc_rep_end_root_object();
 
   if (conf.timeout > 0) {

--- a/api/cloud/oc_cloud_apis.c
+++ b/api/cloud/oc_cloud_apis.c
@@ -122,9 +122,10 @@ cloud_register(oc_cloud_context_t *ctx, oc_cloud_cb_t cb, void *data,
     .user_data = p,
     .timeout = timeout,
   };
-  if (oc_cloud_access_register(conf, oc_string(ctx->store.auth_provider), NULL,
-                               oc_string(ctx->store.uid),
-                               oc_string(ctx->store.access_token))) {
+  if (oc_cloud_access_register_v1(conf, oc_string(ctx->store.auth_provider),
+                                  NULL, oc_string(ctx->store.uid),
+                                  oc_string(ctx->store.access_token),
+                                  oc_string(ctx->store.redirect_uri))) {
     ctx->store.cps = OC_CPS_REGISTERING;
     return 0;
   }

--- a/api/cloud/oc_cloud_internal.h
+++ b/api/cloud/oc_cloud_internal.h
@@ -50,6 +50,8 @@ typedef struct cloud_conf_update_t
   size_t ci_server_len;
   const char *sid; /**< OCF Cloud Identity as defined in OCF CNC 2.0 Spec. */
   size_t sid_len;
+  const char *redirect_uri; /**< Redirect URI for the auth code flow. */
+  size_t redirect_uri_len;
 } cloud_conf_update_t;
 
 typedef struct cloud_api_param_t

--- a/api/cloud/oc_cloud_manager.c
+++ b/api/cloud/oc_cloud_manager.c
@@ -431,9 +431,10 @@ cloud_manager_register_async(void *data)
     goto retry;
   }
   conf.endpoint = ctx->cloud_ep;
-  if (!oc_cloud_access_register(conf, oc_string(ctx->store.auth_provider), NULL,
-                                oc_string(ctx->store.uid),
-                                oc_string(ctx->store.access_token))) {
+  if (!oc_cloud_access_register_v1(conf, oc_string(ctx->store.auth_provider),
+                                   NULL, oc_string(ctx->store.uid),
+                                   oc_string(ctx->store.access_token),
+                                   oc_string(ctx->store.redirect_uri))) {
     OC_ERR("failed to sent register request to cloud");
     goto retry;
   }

--- a/api/cloud/oc_cloud_resource.c
+++ b/api/cloud/oc_cloud_resource.c
@@ -35,6 +35,7 @@
 #define OC_RSRVD_AUTHPROVIDER "apn"
 #define OC_RSRVD_CISERVER "cis"
 #define OC_RSRVD_SERVERID "sid"
+#define OC_RSRVD_REDIRECTURI "redirecturi"
 #define OC_RSRVD_LAST_ERROR_CODE "clec"
 
 static const char *
@@ -91,6 +92,11 @@ cloud_response(oc_cloud_context_t *ctx)
     OC_DBG("Creating Cloud Response: cps set to %s", cps);
   }
 
+  if (oc_string_len(ctx->store.redirect_uri) > 0) {
+    oc_rep_set_text_string(root, redirecturi,
+                           oc_string(ctx->store.redirect_uri));
+  }
+
   oc_rep_end_root_object();
 }
 
@@ -136,6 +142,14 @@ cloud_update_from_request(oc_cloud_context_t *ctx, const oc_request_t *request)
                                    &ci_server, &data.ci_server_len);
   if (has_cis) {
     data.ci_server = ci_server;
+  }
+
+  char *redirect_uri = NULL;
+  bool has_redirect_uri =
+    oc_rep_get_string(request->request_payload, OC_RSRVD_REDIRECTURI,
+                      &redirect_uri, &data.redirect_uri_len);
+  if (has_redirect_uri) {
+    data.redirect_uri = redirect_uri;
   }
 
   // OCF 2.0 spec version added sid property.

--- a/api/cloud/oc_cloud_store.c
+++ b/api/cloud/oc_cloud_store.c
@@ -49,6 +49,7 @@ check oc_config.h and make sure OC_STORAGE is defined if OC_CLOUD is defined.
 #define CLOUD_EXPIRES_IN expires_in
 #define CLOUD_STATUS status
 #define CLOUD_CPS cps
+#define CLOUD_REDIRECT_URI redirect_uri
 
 #define CLOUD_STR(s) #s
 #define CLOUD_XSTR(s) CLOUD_STR(s)
@@ -109,6 +110,8 @@ encode_cloud_with_map(CborEncoder *object_map, const oc_cloud_store_t *store)
                       oc_string(store->access_token));
   rep_set_text_string(object_map, CLOUD_XSTR(CLOUD_REFRESH_TOKEN),
                       oc_string(store->refresh_token));
+  rep_set_text_string(object_map, CLOUD_XSTR(CLOUD_REDIRECT_URI),
+                      oc_string(store->redirect_uri));
   rep_set_int(object_map, CLOUD_XSTR(CLOUD_STATUS), store->status);
   rep_set_int(object_map, CLOUD_XSTR(CLOUD_CPS), store->cps);
   rep_set_int(object_map, CLOUD_XSTR(CLOUD_EXPIRES_IN), store->expires_in);
@@ -222,6 +225,12 @@ cloud_store_parse_string_property(const oc_rep_t *rep, oc_cloud_store_t *store)
   if (oc_rep_is_property(rep, CLOUD_XSTR(CLOUD_REFRESH_TOKEN),
                          CLOUD_XSTRLEN(CLOUD_REFRESH_TOKEN))) {
     oc_set_string(&store->refresh_token, oc_string(rep->value.string),
+                  oc_string_len(rep->value.string));
+    return true;
+  }
+  if (oc_rep_is_property(rep, CLOUD_XSTR(CLOUD_REDIRECT_URI),
+                         CLOUD_XSTRLEN(CLOUD_REDIRECT_URI))) {
+    oc_set_string(&store->redirect_uri, oc_string(rep->value.string),
                   oc_string_len(rep->value.string));
     return true;
   }
@@ -340,6 +349,7 @@ cloud_store_deinitialize(oc_cloud_store_t *store)
   oc_set_string(&store->access_token, NULL, 0);
   oc_set_string(&store->refresh_token, NULL, 0);
   oc_set_string(&store->sid, NULL, 0);
+  oc_set_string(&store->redirect_uri, NULL, 0);
   store->status = 0;
   store->expires_in = 0;
   store->cps = OC_CPS_UNINITIALIZED;

--- a/api/cloud/unittest/cloud_access_test.cpp
+++ b/api/cloud/unittest/cloud_access_test.cpp
@@ -77,8 +77,8 @@ TEST_F(TestCloudAccess, cloud_access_register_p)
     /*.user_data = */ nullptr,
     /*.timeout=*/0,
   };
-  bool ret = oc_cloud_access_register(conf, "auth_provider", "auth_code", "uid",
-                                      "access_token");
+  bool ret = oc_cloud_access_register_v1(conf, "auth_provider", "auth_code",
+                                         "uid", "access_token", "redirect_uri");
 
   // Then
   EXPECT_TRUE(ret);
@@ -95,7 +95,8 @@ TEST_F(TestCloudAccess, cloud_access_register_f)
     /*.user_data = */ nullptr,
     /*.timeout=*/0,
   };
-  bool ret = oc_cloud_access_register(conf, nullptr, nullptr, nullptr, nullptr);
+  bool ret = oc_cloud_access_register_v1(conf, nullptr, nullptr, nullptr,
+                                         nullptr, nullptr);
 
   // Then
   EXPECT_FALSE(ret);

--- a/api/cloud/unittest/cloud_store_test.cpp
+++ b/api/cloud/unittest/cloud_store_test.cpp
@@ -41,6 +41,7 @@
 #define UID ("uid")
 #define CPS (OC_CPS_READYTOREGISTER)
 #define CLOUD_STORAGE ("storage_cloud")
+#define REDIRECT_URI ("redirect_uri")
 
 #define DEFAULT_CLOUD_CIS ("coaps+tcp://127.0.0.1")
 #define DEFAULT_CLOUD_SID ("00000000-0000-0000-0000-000000000000")
@@ -57,6 +58,7 @@ public:
     EXPECT_EQ(nullptr, oc_string(store->access_token));
     EXPECT_EQ(nullptr, oc_string(store->refresh_token));
     EXPECT_STREQ(DEFAULT_CLOUD_SID, oc_string(store->sid));
+    EXPECT_EQ(nullptr, oc_string(store->redirect_uri));
     EXPECT_EQ(0, store->expires_in);
     EXPECT_EQ(0, store->status);
     EXPECT_EQ(0, store->cps);
@@ -72,6 +74,7 @@ public:
     EXPECT_STREQ(oc_string(s1->access_token), oc_string(s2->access_token));
     EXPECT_STREQ(oc_string(s1->refresh_token), oc_string(s2->refresh_token));
     EXPECT_STREQ(oc_string(s1->sid), oc_string(s2->sid));
+    EXPECT_STREQ(oc_string(s1->redirect_uri), oc_string(s2->redirect_uri));
     EXPECT_EQ(s1->expires_in, s2->expires_in);
     EXPECT_EQ(s1->device, s2->device);
     EXPECT_EQ(s1->cps, s2->cps);
@@ -87,6 +90,7 @@ public:
     oc_free_string(&store->access_token);
     oc_free_string(&store->refresh_token);
     oc_free_string(&store->sid);
+    oc_free_string(&store->redirect_uri);
   }
 
   static void SetUpTestCase()
@@ -118,6 +122,7 @@ public:
     oc_new_string(&m_store.access_token, ACCESS_TOKEN, strlen(ACCESS_TOKEN));
     oc_new_string(&m_store.refresh_token, REFRESH_TOKEN, strlen(REFRESH_TOKEN));
     oc_new_string(&m_store.sid, SID, strlen(SID));
+    oc_new_string(&m_store.redirect_uri, REDIRECT_URI, strlen(REDIRECT_URI));
     m_store.expires_in = EXPIRES_IN;
     m_store.device = DEVICE;
     m_store.cps = CPS;

--- a/api/cloud/unittest/cloud_test.cpp
+++ b/api/cloud/unittest/cloud_test.cpp
@@ -66,6 +66,7 @@ TEST_F(TestCloud, cloud_update_by_resource)
   ctx->store.status = OC_CLOUD_FAILURE;
 
   cloud_conf_update_t data;
+  memset(&data, 0, sizeof(data));
   data.access_token = "access_token";
   data.access_token_len = strlen(data.access_token);
   data.auth_provider = "auth_provider";
@@ -74,6 +75,8 @@ TEST_F(TestCloud, cloud_update_by_resource)
   data.ci_server_len = strlen("ci_server");
   data.sid = "sid";
   data.sid_len = strlen(data.sid);
+  data.redirect_uri = "redirect_uri";
+  data.redirect_uri_len = strlen(data.redirect_uri);
 
   cloud_update_by_resource(ctx, &data);
 
@@ -84,7 +87,7 @@ TEST_F(TestCloud, cloud_update_by_resource)
   EXPECT_EQ(OC_CLOUD_INITIALIZED, ctx->store.status);
 }
 
-TEST_F(TestCloud, oc_cloud_provision_conf_resource)
+TEST_F(TestCloud, oc_cloud_provision_conf_resource_v1)
 {
   oc_cloud_context_t *ctx = oc_cloud_get_context(kDeviceID);
   ASSERT_NE(nullptr, ctx);
@@ -93,12 +96,15 @@ TEST_F(TestCloud, oc_cloud_provision_conf_resource)
   const char *auth_provider = "auth_provider";
   const char *ci_server = "ci_server";
   const char *sid = "sid";
-  ASSERT_EQ(0, oc_cloud_provision_conf_resource(ctx, ci_server, access_token,
-                                                sid, auth_provider));
+  const char *redirect_uri = "redirect_uri";
+  ASSERT_EQ(0, oc_cloud_provision_conf_resource_v1(ctx, ci_server, access_token,
+                                                   sid, auth_provider,
+                                                   redirect_uri));
 
   EXPECT_STREQ(access_token, oc_string(ctx->store.access_token));
   EXPECT_STREQ(auth_provider, oc_string(ctx->store.auth_provider));
   EXPECT_STREQ(ci_server, oc_string(ctx->store.ci_server));
   EXPECT_STREQ(sid, oc_string(ctx->store.sid));
+  EXPECT_STREQ(redirect_uri, oc_string(ctx->store.redirect_uri));
   EXPECT_EQ(OC_CLOUD_INITIALIZED, ctx->store.status);
 }

--- a/apps/cloud_certification_tests.c
+++ b/apps/cloud_certification_tests.c
@@ -338,7 +338,7 @@ cloud_register(void)
     pthread_mutex_unlock(&app_sync_lock);
     return;
   }
-  oc_cloud_provision_conf_resource(ctx, cis, auth_code, sid, apn);
+  oc_cloud_provision_conf_resource_v1(ctx, cis, auth_code, sid, apn, NULL);
   int ret = oc_cloud_register(ctx, cloud_register_cb, NULL);
   pthread_mutex_unlock(&app_sync_lock);
   if (ret < 0) {

--- a/apps/cloud_client.c
+++ b/apps/cloud_client.c
@@ -383,7 +383,7 @@ ocf_event_thread(LPVOID lpParam)
   if (ctx) {
     oc_cloud_manager_start(ctx, cloud_status_handler, NULL);
     if (cis) {
-      oc_cloud_provision_conf_resource(ctx, cis, auth_code, sid, apn);
+      oc_cloud_provision_conf_resource_v1(ctx, cis, auth_code, sid, apn, NULL);
     }
   }
   oc_clock_time_t next_event_mt;
@@ -430,7 +430,7 @@ ocf_event_thread(void *data)
   if (ctx) {
     oc_cloud_manager_start(ctx, cloud_status_handler, NULL);
     if (cis) {
-      oc_cloud_provision_conf_resource(ctx, cis, auth_code, sid, apn);
+      oc_cloud_provision_conf_resource_v1(ctx, cis, auth_code, sid, apn, NULL);
     }
   }
   oc_clock_time_t next_event_mt;

--- a/apps/cloud_proxy.c
+++ b/apps/cloud_proxy.c
@@ -1931,8 +1931,8 @@ main(int argc, char *argv[])
       if (argc == 6) {
         int retval;
         /* configure the */
-        retval =
-          oc_cloud_provision_conf_resource(ctx, cis, auth_code, sid, apn);
+        retval = oc_cloud_provision_conf_resource_v1(ctx, cis, auth_code, sid,
+                                                     apn, NULL);
         OC_PRINTF("   config status  %d\n", retval);
 
         OC_PRINTF("Conf Cloud Manager\n");

--- a/include/oc_cloud.h
+++ b/include/oc_cloud.h
@@ -68,6 +68,8 @@ typedef struct oc_cloud_store_t
   uint8_t status;
   oc_cps_t cps;
   size_t device;
+  oc_string_t
+    redirect_uri; /**< Redirect URI for authorization code flow(optional) */
 } oc_cloud_store_t;
 
 typedef enum {
@@ -323,7 +325,29 @@ int oc_cloud_provision_conf_resource(oc_cloud_context_t *ctx,
                                      const char *server,
                                      const char *access_token,
                                      const char *server_id,
-                                     const char *auth_provider);
+                                     const char *auth_provider)
+  OC_DEPRECATED("replaced by oc_cloud_provision_conf_resource_v1 in v2.2.5.7");
+
+/**
+ * @brief Configure cloud properties.
+ *
+ * @param ctx Cloud context to update (cannot be be NULL)
+ * @param server Cloud server URL
+ * @param access_token Access token from an Authorisation Provider
+ * @param server_id Cloud server ID
+ * @param auth_provider Name of the Authorization Provider which provided the
+ * access token
+ * @param redirect_uri Redirect URI for the auth code flow
+ * @return 0 on success
+ * @return -1 on failure
+ *
+ * @note Cloud manager will be restarted if is was started previously
+ */
+OC_API
+int oc_cloud_provision_conf_resource_v1(
+  oc_cloud_context_t *ctx, const char *server, const char *access_token,
+  const char *server_id, const char *auth_provider, const char *redirect_uri);
+
 /**
  * @brief Set identity certificate chain to establish TLS connection.
  *

--- a/include/oc_cloud_access.h
+++ b/include/oc_cloud_access.h
@@ -56,7 +56,27 @@ typedef struct oc_cloud_access_conf_t
 OC_API
 bool oc_cloud_access_register(oc_cloud_access_conf_t conf,
                               const char *auth_provider, const char *auth_code,
-                              const char *uid, const char *access_token);
+                              const char *uid, const char *access_token)
+  OC_DEPRECATED("replaced by oc_cloud_access_register_v1 in v2.2.5.7");
+
+/**
+ * @brief Send request to register device to cloud.
+ *
+ * @param conf cloud access configuration
+ * @param auth_provider authorization provider
+ * @param auth_code authorization code
+ * @param uid user id
+ * @param access_token access token
+ * @param redirect_uri redirect uri
+ * @return true on success
+ *         false otherwise
+ */
+OC_API
+bool oc_cloud_access_register_v1(oc_cloud_access_conf_t conf,
+                                 const char *auth_provider,
+                                 const char *auth_code, const char *uid,
+                                 const char *access_token,
+                                 const char *redirect_uri);
 
 /**
  * @brief Send request to deregister device from cloud.

--- a/swig/swig_interfaces/oc_cloud.i
+++ b/swig/swig_interfaces/oc_cloud.i
@@ -429,7 +429,7 @@ int jni_cloud_provision_conf_resource(oc_cloud_context_t *ctx,
                                       const char *authProvider)
 {
 #ifdef OC_CLOUD
-  return oc_cloud_provision_conf_resource(ctx, server, accessToken, serverId, authProvider);
+  return oc_cloud_provision_conf_resource_v1(ctx, server, accessToken, serverId, authProvider, NULL);
 #else /* OC_CLOUD*/
   OC_DBG("JNI: %s - Must build with OC_CLOUD defined to use this function.\n", __func__);
   (void)ctx;
@@ -437,6 +437,31 @@ int jni_cloud_provision_conf_resource(oc_cloud_context_t *ctx,
   (void)accessToken;
   (void)serverId;
   (void)authProvider;
+  return -1;
+#endif /* !OC_CLOUD */
+}
+%}
+
+%ignore oc_cloud_provision_conf_resource_v1;
+%rename(provisionConfResource) jni_cloud_provision_conf_resource_v1;
+%inline %{
+int jni_cloud_provision_conf_resource_v1(oc_cloud_context_t *ctx,
+                                      const char *server,
+                                      const char *accessToken,
+                                      const char *serverId,
+                                      const char *authProvider,
+                                      const char *redirectUri)
+{
+#ifdef OC_CLOUD
+  return oc_cloud_provision_conf_resource_v1(ctx, server, accessToken, serverId, authProvider, redirectUri);
+#else /* OC_CLOUD*/
+  OC_DBG("JNI: %s - Must build with OC_CLOUD defined to use this function.\n", __func__);
+  (void)ctx;
+  (void)server;
+  (void)accessToken;
+  (void)serverId;
+  (void)authProvider;
+  (void)redirectUri;
   return -1;
 #endif /* !OC_CLOUD */
 }


### PR DESCRIPTION
For a confidential OAuth client (e.g., server-side application), the client application must protect the client ID and client secret, which are used during the token request to authenticate the client to the authorization server. For redirect URI it is optional.

In summary, the redirect URI itself is not a secret parameter in the authorization code flow so it can be propagated to the device.