### PR TITLE
cred: set tag member when parsing a certificate to oc_sec_cred_t

### DIFF
--- a/security/oc_cred.c
+++ b/security/oc_cred.c
@@ -882,6 +882,7 @@ oc_sec_add_new_cred(size_t device, bool roles_resource,
     .privatedata = privatedata,
     .role = role,
     .authority = authority,
+    .tag = tag,
 #ifdef OC_PKI
     .publicdata = publicdata,
     .keypair = kp,


### PR DESCRIPTION
Fix bug introduced by a62f7726500d5d1b0062ff4fd4f387fd5bcb132f