### PR TITLE
Return oc_process_is_closing_all_tls_sessions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -980,7 +980,7 @@ if(BUILD_TESTING AND(UNIX OR MINGW))
     endif()
 
     file(GLOB UTILTEST_SRC util/unittest/*.cpp)
-    oc_package_add_test(TARGET utiltest SOURCES ${UTILTEST_SRC})
+    oc_package_add_test(TARGET utiltest SOURCES ${COMMONTEST_SRC} ${UTILTEST_SRC})
 
     if(OC_CLOUD_ENABLED)
         file(GLOB CLOUDTEST_SRC api/cloud/unittest/*.cpp)

--- a/messaging/coap/transactions.c
+++ b/messaging/coap/transactions.c
@@ -55,6 +55,7 @@
 #include "oc_buffer.h"
 #include "transactions.h"
 #include "util/oc_list.h"
+#include "util/oc_macros_internal.h"
 #include "util/oc_memb.h"
 #include <string.h>
 

--- a/security/oc_pstat.c
+++ b/security/oc_pstat.c
@@ -687,6 +687,24 @@ oc_reset_device(size_t device)
   oc_reset_device_v1(device, true);
 }
 
+#ifdef OC_TEST
+
+static uint64_t g_reset_delay_ms = OC_PSTAT_RESET_DELAY_MS;
+
+void
+oc_pstat_set_reset_delay_ms(uint64_t delay_ms)
+{
+  g_reset_delay_ms = delay_ms;
+}
+
+uint64_t
+oc_pstat_get_reset_delay_ms()
+{
+  return g_reset_delay_ms;
+}
+
+#endif /* OC_TEST */
+
 static bool
 set_delayed_reset(size_t device)
 {
@@ -710,7 +728,13 @@ set_delayed_reset(size_t device)
                         .om = 3,
                         .sm = 4 };
   oc_sec_pstat_copy(&g_pstat[device], &ps);
-  oc_set_delayed_callback((void *)device, delayed_reset, 2);
+#ifdef OC_TEST
+  oc_set_delayed_callback_ms_v1((void *)device, delayed_reset,
+                                oc_pstat_get_reset_delay_ms());
+#else  /* !OC_TEST */
+  oc_set_delayed_callback_ms_v1((void *)device, delayed_reset,
+                                OC_PSTAT_RESET_DELAY_MS);
+#endif /* OC_TEST */
   return true;
 }
 

--- a/security/oc_pstat_internal.h
+++ b/security/oc_pstat_internal.h
@@ -55,6 +55,8 @@ typedef struct
   bool reset_in_progress; ///< Reset in progress runtime flag
 } oc_sec_pstat_t;
 
+#define OC_PSTAT_RESET_DELAY_MS (2000)
+
 void oc_sec_pstat_init(void);
 void oc_sec_pstat_free(void);
 bool oc_sec_is_operational(size_t device);
@@ -99,6 +101,22 @@ bool oc_reset_in_progress(size_t device);
  * @param[in] num_device the number of devices
  */
 void oc_sec_pstat_init_for_devices(size_t num_device);
+
+#ifdef OC_TEST
+
+/**
+ * @brief Set interval in milliseconds before delayed reset is performed.
+ *
+ * @param delay_ms the interval in milliseconds
+ *
+ * @sa oc_reset_device_v1
+ */
+void oc_pstat_set_reset_delay_ms(uint64_t delay_ms);
+
+/** @brief Get reset delay interval in milliseconds. */
+uint64_t oc_pstat_get_reset_delay_ms(void);
+
+#endif /* OC_TEST */
 
 #ifdef __cplusplus
 }

--- a/util/oc_process.c
+++ b/util/oc_process.c
@@ -104,13 +104,12 @@ static OC_ATOMIC_INT8_T g_poll_requested;
 static void call_process(struct oc_process *p, oc_process_event_t ev,
                          oc_process_data_t data);
 
-/*---------------------------------------------------------------------------*/
 oc_process_event_t
 oc_process_alloc_event(void)
 {
   return oc_lastevent++;
 }
-/*---------------------------------------------------------------------------*/
+
 void
 oc_process_start(struct oc_process *p, oc_process_data_t data)
 {
@@ -134,7 +133,7 @@ oc_process_start(struct oc_process *p, oc_process_data_t data)
   /* Post a synchronous initialization event to the process. */
   oc_process_post_synch(p, OC_PROCESS_EVENT_INIT, data);
 }
-/*---------------------------------------------------------------------------*/
+
 static void
 exit_process(struct oc_process *p, const struct oc_process *fromprocess)
 {
@@ -197,7 +196,7 @@ exit_process(struct oc_process *p, const struct oc_process *fromprocess)
 
   oc_process_current = old_current;
 }
-/*---------------------------------------------------------------------------*/
+
 static void
 call_process(struct oc_process *p, oc_process_event_t ev,
              oc_process_data_t data)
@@ -231,13 +230,13 @@ call_process(struct oc_process *p, oc_process_event_t ev,
     break;
   }
 }
-/*---------------------------------------------------------------------------*/
+
 void
 oc_process_exit(struct oc_process *p)
 {
   exit_process(p, OC_PROCESS_CURRENT());
 }
-/*---------------------------------------------------------------------------*/
+
 void
 oc_process_shutdown(void)
 {
@@ -262,11 +261,11 @@ oc_process_init(void)
   g_nevents = g_fevent = 0;
   oc_process_current = oc_process_list = NULL;
 }
-/*---------------------------------------------------------------------------*/
+
 /*
  * Call each process' poll handler.
  */
-/*---------------------------------------------------------------------------*/
+
 static void
 do_poll(void)
 {
@@ -282,12 +281,11 @@ do_poll(void)
     }
   }
 }
-/*---------------------------------------------------------------------------*/
+
 /*
  * Process the next event in the event queue and deliver it to
  * listening processes.
  */
-/*---------------------------------------------------------------------------*/
 static void
 do_event(void)
 {
@@ -343,7 +341,7 @@ do_event(void)
     call_process(receiver, ev, data);
   }
 }
-/*---------------------------------------------------------------------------*/
+
 int
 oc_process_run(void)
 {
@@ -357,14 +355,29 @@ oc_process_run(void)
 
   return (int)g_nevents + OC_ATOMIC_LOAD8(g_poll_requested);
 }
-/*---------------------------------------------------------------------------*/
+
 int
 oc_process_nevents(void)
 {
   return (int)g_nevents + OC_ATOMIC_LOAD8(g_poll_requested);
 }
 
-/*---------------------------------------------------------------------------*/
+#ifdef OC_SECURITY
+bool
+oc_process_is_closing_all_tls_sessions(void)
+{
+  const oc_process_event_t tls_close =
+    oc_event_to_oc_process_event(TLS_CLOSE_ALL_SESSIONS);
+  for (oc_process_num_events_t i = 0; i < g_nevents; ++i) {
+    oc_process_num_events_t index = (g_fevent + i) % OC_PROCESS_NUMEVENTS;
+    if (g_events[index].ev == tls_close) {
+      return true;
+    }
+  }
+  return false;
+}
+#endif /* OC_SECURITY */
+
 int
 oc_process_drop(const struct oc_process *p, oc_process_drop_event_t drop_event,
                 const void *user_data)
@@ -407,7 +420,6 @@ oc_process_drop(const struct oc_process *p, oc_process_drop_event_t drop_event,
   return dropped;
 }
 
-/*---------------------------------------------------------------------------*/
 int
 oc_process_post(struct oc_process *p, oc_process_event_t ev,
                 oc_process_data_t data)
@@ -448,7 +460,7 @@ oc_process_post(struct oc_process *p, oc_process_event_t ev,
 
   return OC_PROCESS_ERR_OK;
 }
-/*---------------------------------------------------------------------------*/
+
 void
 oc_process_post_synch(struct oc_process *p, oc_process_event_t ev,
                       oc_process_data_t data)
@@ -458,7 +470,7 @@ oc_process_post_synch(struct oc_process *p, oc_process_event_t ev,
   call_process(p, ev, data);
   oc_process_current = caller;
 }
-/*---------------------------------------------------------------------------*/
+
 void
 oc_process_poll(struct oc_process *p)
 {
@@ -470,13 +482,12 @@ oc_process_poll(struct oc_process *p)
     }
   }
 }
-/*---------------------------------------------------------------------------*/
+
 int
 oc_process_is_running(const struct oc_process *p)
 {
   return OC_ATOMIC_LOAD8(p->state) != OC_PROCESS_STATE_NONE;
 }
-/*---------------------------------------------------------------------------*/
 
 #ifdef OC_TEST
 

--- a/util/oc_process.h
+++ b/util/oc_process.h
@@ -541,6 +541,18 @@ int oc_process_is_running(const struct oc_process *p);
  */
 int oc_process_nevents(void);
 
+#ifdef OC_SECURITY
+
+/**
+ * Check if closing of all tls sessions is currently scheduled by the process.
+ *
+ * \return true closing of all tls is sessions is scheduled by the process
+ * \return false otherwise
+ */
+bool oc_process_is_closing_all_tls_sessions(void);
+
+#endif /* OC_SECURITY */
+
 /** @} */
 
 extern struct oc_process *oc_process_list;

--- a/util/unittest/processtest.cpp
+++ b/util/unittest/processtest.cpp
@@ -1,0 +1,116 @@
+/****************************************************************************
+ *
+ * Copyright (c) 2023 plgd.dev s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"),
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#include "api/oc_buffer_internal.h"
+#include "api/oc_events_internal.h"
+#include "tests/gtest/Device.h"
+#include "util/oc_process.h"
+#include "util/oc_process_internal.h"
+
+#ifdef OC_SECURITY
+#include "security/oc_pstat_internal.h"
+#endif /* OC_SECURITY */
+
+#include <chrono>
+#include <gtest/gtest.h>
+
+using namespace std::chrono_literals;
+
+static constexpr size_t kDeviceID{ 0 };
+
+class TestProcess : public testing::Test {
+public:
+  static void SetUpTestCase()
+  {
+    oc_process_init();
+    oc_event_assign_oc_process_events();
+  }
+
+  static void TearDownTestCase() { oc_process_shutdown(); }
+};
+
+#ifdef OC_SECURITY
+
+TEST_F(TestProcess, IsClosingTLSSessions_F)
+{
+  EXPECT_FALSE(oc_process_is_closing_all_tls_sessions());
+}
+
+TEST_F(TestProcess, IsClosingTLSSessions)
+{
+  oc_message_buffer_handler_start();
+  oc_close_all_tls_sessions_for_device_reset(kDeviceID);
+  EXPECT_TRUE(oc_process_is_closing_all_tls_sessions());
+
+  oc_message_buffer_handler_stop();
+}
+
+class TestProcessWithServer : public testing::Test {
+public:
+  static void SetUpTestCase() { ASSERT_TRUE(oc::TestDevice::StartServer()); }
+
+  static void TearDownTestCase() { oc::TestDevice::StopServer(); }
+};
+
+TEST_F(TestProcessWithServer, IsClosingTLSSessionsOnForcedReset)
+{
+  ASSERT_FALSE(oc_process_is_closing_all_tls_sessions());
+
+  ASSERT_TRUE(oc_reset_device_v1(kDeviceID, true));
+  EXPECT_TRUE(oc_process_is_closing_all_tls_sessions());
+  int repeats = 0;
+  while (repeats < 100) {
+    oc::TestDevice::PoolEventsMsV1(1ms);
+    if (!oc_process_is_closing_all_tls_sessions()) {
+      break;
+    }
+    ++repeats;
+  }
+  EXPECT_FALSE(oc_process_is_closing_all_tls_sessions());
+}
+
+#ifdef OC_TEST
+
+TEST_F(TestProcessWithServer, IsClosingTLSSessionsOnDelayedReset)
+{
+  ASSERT_FALSE(oc_process_is_closing_all_tls_sessions());
+
+  oc_pstat_set_reset_delay_ms(0);
+  bool invoked = false;
+  oc_set_factory_presets_cb(
+    [](size_t, void *data) {
+      *static_cast<bool *>(data) = true;
+      EXPECT_TRUE(oc_process_is_closing_all_tls_sessions());
+    },
+    &invoked);
+
+  ASSERT_TRUE(oc_reset_device_v1(kDeviceID, false));
+
+  ASSERT_TRUE(oc_reset_in_progress(kDeviceID));
+  oc::TestDevice::PoolEventsMsV1(1ms);
+  ASSERT_FALSE(oc_reset_in_progress(kDeviceID));
+  EXPECT_TRUE(invoked);
+
+  // restore defaults
+  oc_set_factory_presets_cb(nullptr, nullptr);
+  oc_pstat_set_reset_delay_ms(OC_PSTAT_RESET_DELAY_MS);
+}
+
+#endif /* OC_TEST */
+
+#endif /* OC_SECURITY */


### PR DESCRIPTION
This function allows the user to detect that reset has scheduled the closing of TLS sessions, but has not yet been executed.

This reverts removal of the function by commit 005c0756a4b09698e581f558ebd40541863e1db8