### PR TITLE
resource storages: generate a debug log instead of an error in case of a read failure

### DIFF
--- a/api/oc_etag.c
+++ b/api/oc_etag.c
@@ -242,7 +242,7 @@ oc_etag_load_from_storage(bool from_storage_only)
     long ret = oc_storage_data_load(OC_ETAG_STORE_NAME, i,
                                     etag_store_decode_etags, &etag);
     if (ret <= 0) {
-      OC_ERR("failed to load etags for device %zu", i);
+      OC_DBG("failed to load etags for device %zu", i);
       success = false;
     }
   }

--- a/api/oc_storage.c
+++ b/api/oc_storage.c
@@ -119,7 +119,7 @@ oc_storage_data_load(const char *name, size_t device,
 
   long ret = oc_storage_read(svr_tag, buf.buffer, buf.size);
   if (ret < 0) {
-    OC_ERR("cannot load from %s from store: read error(%ld)", name, ret);
+    OC_DBG("cannot load from %s from store: read error(%ld)", name, ret);
     goto error;
   }
   OC_MEMB_LOCAL(rep_objects, oc_rep_t, OC_MAX_NUM_REP_OBJECTS);

--- a/api/oc_swupdate.c
+++ b/api/oc_swupdate.c
@@ -942,7 +942,7 @@ oc_swupdate_load(size_t device)
   long ret = oc_storage_data_load(OCF_SW_UPDATE_STORE_NAME, device,
                                   swupdate_store_decode, NULL);
   if (ret <= 0) {
-    OC_ERR("swupdate: failed to load swupdate from storage for device(%zu)",
+    OC_DBG("swupdate: failed to load swupdate from storage for device(%zu)",
            device);
     oc_swupdate_default(device);
     return ret;

--- a/api/plgd/plgd_time.c
+++ b/api/plgd/plgd_time.c
@@ -514,7 +514,7 @@ plgd_time_load(void)
   plgd_time_t pt = { 0 };
   if (oc_storage_data_load(PLGD_TIME_STORE_NAME, 0, store_decode_plgd_time,
                            &pt) <= 0) {
-    OC_ERR("failed to load plgd-time from storage");
+    OC_DBG("failed to load plgd-time from storage");
     return false;
   }
 

--- a/security/oc_store.c
+++ b/security/oc_store.c
@@ -49,8 +49,8 @@ void
 oc_sec_load_doxm(size_t device)
 {
   if (oc_storage_data_load("doxm", device, store_decode_doxm, NULL) <= 0) {
+    OC_DBG("failed to load doxm from storage for device(%zu)", device);
     oc_sec_doxm_default(device);
-    OC_ERR("failed to load doxm from storage for device(%zu)", device);
     return;
   }
   OC_DBG("%s resource loaded from storage for device(%zu)", "doxm", device);
@@ -92,8 +92,8 @@ void
 oc_sec_load_pstat(size_t device)
 {
   if (oc_storage_data_load("pstat", device, store_decode_pstat, NULL) <= 0) {
+    OC_DBG("failed to load pstat from storage for device(%zu)", device);
     oc_sec_pstat_default(device);
-    OC_ERR("failed to load pstat from storage for device(%zu)", device);
     return;
   }
   OC_DBG("%s resource loaded from storage for device(%zu)", "pstat", device);
@@ -132,7 +132,7 @@ oc_sec_load_sp(size_t device)
 {
   if (oc_storage_data_load(OCF_SEC_SP_STORE_NAME, device, store_decode_sp,
                            NULL) <= 0) {
-    OC_ERR("failed to load sp from storage for device(%zu)", device);
+    OC_DBG("failed to load sp from storage for device(%zu)", device);
     oc_sec_sp_default(device);
     return;
   }
@@ -492,7 +492,7 @@ oc_sec_load_sdi(size_t device)
 {
   if (oc_storage_data_load(OCF_SEC_SDI_STORE_NAME, device, store_decode_sdi,
                            NULL) <= 0) {
-    OC_ERR("failed to load sdi from storage for device(%zu)", device);
+    OC_DBG("failed to load sdi from storage for device(%zu)", device);
     oc_sec_sdi_default(device);
     return;
   }


### PR DESCRIPTION
In case resulting in the creation of a default configuration.