### PR TITLE
Update query public API

### DIFF
--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -115,7 +115,7 @@ jobs:
     with:
       build_args: -DOC_LOG_MAXIMUM_LOG_LEVEL=INFO -DOC_CLOUD_ENABLED=ON -DOC_COLLECTIONS_IF_CREATE_ENABLED=ON -DOC_MNT_ENABLED=ON -DOC_WKCORE_ENABLED=ON -DOC_SOFTWARE_UPDATE_ENABLED=ON -DOC_DISCOVERY_RESOURCE_OBSERVABLE_ENABLED=ON -DOC_PUSH_ENABLED=ON -DOC_RESOURCE_ACCESS_IN_RFOTM_ENABLED=ON -DPLGD_DEV_TIME_ENABLED=ON -DOC_ETAG_ENABLED=ON ${{ matrix.args }}
       build_type: Debug
-      clang: ${{ github.event_name == 'workflow_dispatch' && inputs.clang }}
+      clang: ${{ ((github.event_name == 'workflow_dispatch' && inputs.clang) || matrix.clang) || false }}
       coverage: false
       install_mbedtls: ${{ github.event_name == 'workflow_dispatch' && inputs.install_mbedtls }}
       install_tinycbor: ${{ github.event_name == 'workflow_dispatch' && inputs.install_tinycbor }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -988,7 +988,7 @@ if(BUILD_TESTING AND(UNIX OR MINGW))
         oc_package_add_test(TARGET cloudtest SOURCES ${COMMONTEST_SRC} ${CLOUDTEST_SRC})
     endif()
 
-    if(UNIX)
+    if(UNIX AND NOT OC_TSAN_ENABLED)
         # install https://github.com/wolfcw/libfaketime for this test suit to run
         find_library(FAKETIME_LIBRARY
             NAMES libfaketimeMT.so.1

--- a/api/oc_core_res.c
+++ b/api/oc_core_res.c
@@ -833,8 +833,8 @@ oc_filter_resource_by_rt(const oc_resource_t *resource,
   do {
     const char *rt = NULL;
     int rt_len = -1;
-    more_query_params =
-      oc_iterate_query_get_values(request, "rt", &rt, &rt_len);
+    more_query_params = oc_iterate_query_get_values_v1(
+      request, "rt", OC_CHAR_ARRAY_LEN("rt"), &rt, &rt_len);
     if (rt_len <= 0) {
       continue;
     }

--- a/api/oc_discovery.c
+++ b/api/oc_discovery.c
@@ -919,7 +919,8 @@ discovery_resource_get(oc_request_t *request, oc_interface_mask_t iface_mask,
   // for dev without SVRs, ignore queries for backward compatibility
 #ifdef OC_SECURITY
   const char *q;
-  int ql = oc_get_query_value(request, OCF_RES_QUERY_SDUUID, &q);
+  int ql = oc_get_query_value_v1(request, OCF_RES_QUERY_SDUUID,
+                                 OC_CHAR_ARRAY_LEN(OCF_RES_QUERY_SDUUID), &q);
   if (ql > 0 && !discovery_check_sduuid(request, q, (size_t)ql)) {
     return;
   }

--- a/api/oc_etag.c
+++ b/api/oc_etag.c
@@ -271,6 +271,44 @@ oc_etag_load_and_clear(void)
 #endif /* OC_STORAGE */
 
 void
+oc_etag_query_iterate_incremental_updates(const char *query, size_t query_len)
+{
+  (void)query;
+  (void)query_len;
+
+  // incChanges=<etag1 in base64>,<etag2 in base64>,...<etagk in
+  // base64>&incChanges<etagk+1>,...
+  // const char *key = "incChanges";
+  // size_t key_len = strlen(key);
+
+  // size_t n = 0;
+  // while (true) {
+  //   const char *value;
+  //   size_t value_len;
+  //   if (oc_ri_get_query_nth_key_value(query, query_len, key, key_len, value,
+  //                                     value_len, n) == -1) {
+  //     break;
+  //   }
+  //   OC_DBG("oc_etag: incremental update query: %.*s", (int)value_len, value);
+  //   ++n;
+  // }
+
+  // for (size_t pos = 0; pos < query_len;) {
+  //   const char *value = NULL;
+  //   int value_len =
+  //     oc_ri_get_query_value(query + pos, query_len - pos, key, &value);
+  //   if (value_len == -1) {
+  //     // pos == 0 key not found, otherwise device id not match the device.
+  //     return pos == 0;
+  //   }
+  //   if (OC_UUID_LEN == value_len + 1 && strncmp(di, value, value_len) == 0) {
+  //     return true;
+  //   }
+  //   pos = (value - query) + value_len;
+  // }
+}
+
+void
 oc_resource_set_etag(oc_resource_t *resource, uint64_t etag)
 {
   assert(resource != NULL);

--- a/api/oc_etag_internal.h
+++ b/api/oc_etag_internal.h
@@ -25,6 +25,7 @@
 #include "util/oc_compiler.h"
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -42,6 +43,9 @@ uint64_t oc_etag_set_global(uint64_t etag);
 
 /**  Get the next global ETag value. */
 uint64_t oc_etag_get(void);
+
+void oc_etag_query_iterate_incremental_updates(const char *query,
+                                               size_t query_len) OC_NONNULL();
 
 /** @brief Set ETag of given resource */
 void oc_resource_set_etag(oc_resource_t *resource, uint64_t etag) OC_NONNULL();

--- a/api/oc_push.c
+++ b/api/oc_push.c
@@ -242,6 +242,9 @@ static void (*oc_push_arrived)(oc_pushd_resource_rep_t *) = NULL;
 #define OC_PUSH_PROP_PRT "prt"
 #define OC_PUSH_PROP_PIF "pif"
 #define OC_PUSH_PROP_SOURCERT "sourcert"
+#define OC_PUSH_PROP_RECEIVEURI "receiveruri"
+
+#define OC_PUSH_QUERY_RECEIVERURI "receiveruri"
 
 void
 oc_set_on_push_arrived(oc_on_push_arrived_t func)
@@ -1854,7 +1857,7 @@ _update_recv_obj(oc_recv_t *recv_obj, const oc_recvs_t *recvs_instance,
   while (rep) {
     switch (rep->type) {
     case OC_REP_STRING:
-      if (strcmp(oc_string(rep->name), "receiveruri") == 0) {
+      if (strcmp(oc_string(rep->name), OC_PUSH_PROP_RECEIVEURI) == 0) {
         OC_PUSH_DBG("target receiveruri: \"%s\", new receiveruri: \"%s\"",
                     oc_string(recv_obj->receiveruri),
                     oc_string(rep->value.string));
@@ -1923,7 +1926,7 @@ _create_recv_obj(oc_recvs_t *recvs_instance, oc_rep_t *rep)
   while (rep) {
     switch (rep->type) {
     case OC_REP_STRING:
-      if (strcmp(oc_string(rep->name), "receiveruri") == 0) {
+      if (strcmp(oc_string(rep->name), OC_PUSH_PROP_RECEIVEURI) == 0) {
         oc_new_string(&recv_obj->receiveruri, oc_string(rep->value.string),
                       oc_string_len(rep->value.string));
         mandatory_property_check |= 0x1;
@@ -1994,7 +1997,7 @@ _validate_recv_obj_list(oc_rep_t *obj_list)
     for (; rep != NULL; rep = rep->next) {
       switch (rep->type) {
       case OC_REP_STRING:
-        if (strcmp(oc_string(rep->name), "receiveruri") == 0) {
+        if (strcmp(oc_string(rep->name), OC_PUSH_PROP_RECEIVEURI) == 0) {
           mandatory_property_check |= 0x1;
         }
         break;
@@ -2078,8 +2081,9 @@ post_pushrecv(oc_request_t *request, oc_interface_mask_t iface_mask,
 
   /* try to get "receiveruri" parameter */
   if (request->query) {
-    uri_param_len = oc_ri_get_query_value(request->query, request->query_len,
-                                          "receiveruri", &uri_param);
+    uri_param_len = oc_ri_get_query_value_v1(
+      request->query, request->query_len, OC_PUSH_QUERY_RECEIVERURI,
+      OC_CHAR_ARRAY_LEN(OC_PUSH_QUERY_RECEIVERURI), &uri_param);
     if (uri_param_len != -1) {
       OC_PUSH_DBG(
         "received query string: \"%.*s\", found \"receiveruri\": \"%.*s\" ",
@@ -2174,8 +2178,9 @@ delete_pushrecv(oc_request_t *request, oc_interface_mask_t iface_mask,
 
   /* try to get "receiveruri" parameter */
   if (request->query) {
-    uri_param_len = oc_ri_get_query_value(request->query, request->query_len,
-                                          "receiveruri", &uri_param);
+    uri_param_len = oc_ri_get_query_value_v1(
+      request->query, request->query_len, OC_PUSH_QUERY_RECEIVERURI,
+      OC_CHAR_ARRAY_LEN(OC_PUSH_QUERY_RECEIVERURI), &uri_param);
     if (uri_param_len != -1) {
       OC_PUSH_DBG(
         "received query string: \"%.*s\", found \"receiveruri\": \"%.*s\" ",

--- a/api/oc_query.c
+++ b/api/oc_query.c
@@ -78,8 +78,9 @@ static key_value_pair_t
 oc_ri_find_query_nth_key_value_pair(const char *query, size_t query_len,
                                     size_t n)
 {
+  assert(n > 0);
   key_value_pair_t res = { NULL, 0, NULL, 0 };
-  if (query == NULL) {
+  if (query == NULL || query_len == 0) {
     return res;
   }
   const char *start = query;
@@ -122,6 +123,7 @@ oc_ri_get_query_nth_key_value(const char *query, size_t query_len,
 {
   assert(key != NULL);
   assert(key_len != NULL);
+  assert(n > 0);
   key_value_pair_t kv =
     oc_ri_find_query_nth_key_value_pair(query, query_len, n);
   if (kv.key == NULL) {
@@ -146,8 +148,8 @@ oc_ri_get_query_nth_key_value(const char *query, size_t query_len,
 }
 
 int
-oc_ri_get_query_value(const char *query, size_t query_len, const char *key,
-                      const char **value)
+oc_ri_get_query_value_v1(const char *query, size_t query_len, const char *key,
+                         size_t key_len, const char **value)
 {
   assert(key != NULL);
   int found = -1;
@@ -155,14 +157,17 @@ oc_ri_get_query_value(const char *query, size_t query_len, const char *key,
   while (pos < query_len) {
     const char *k;
     size_t kl;
+    const char *v;
     size_t vl;
     int next_pos = oc_ri_get_query_nth_key_value(query + pos, query_len - pos,
-                                                 &k, &kl, value, &vl, 1u);
+                                                 &k, &kl, &v, &vl, 1u);
     if (next_pos == -1) {
       return -1;
     }
 
-    if (kl == strlen(key) && strncasecmp(key, k, kl) == 0) {
+    if (kl == key_len && strncasecmp(key, k, kl) == 0) {
+      assert(vl <= INT_MAX);
+      *value = v;
       found = (int)vl;
       break;
     }
@@ -173,11 +178,20 @@ oc_ri_get_query_value(const char *query, size_t query_len, const char *key,
 }
 
 int
+oc_ri_get_query_value(const char *query, size_t query_len, const char *key,
+                      const char **value)
+{
+  assert(key != NULL);
+  return oc_ri_get_query_value_v1(query, query_len, key, strlen(key), value);
+}
+
+int
 oc_ri_query_nth_key_exists(const char *query, size_t query_len,
                            const char **key, size_t *key_len, size_t n)
 {
   assert(key != NULL);
   assert(key_len != NULL);
+  assert(n > 0);
   key_value_pair_t kv =
     oc_ri_find_query_nth_key_value_pair(query, query_len, n);
   if (kv.key == NULL) {
@@ -189,17 +203,19 @@ oc_ri_query_nth_key_exists(const char *query, size_t query_len,
 
   size_t next_pos =
     kv.value != NULL ? (size_t)((kv.value + kv.value_len) - query) : kv.key_len;
-  ++next_pos; // +1 for '&'
+  if (next_pos < query_len) {
+    ++next_pos; // +1 for '&'
+  }
 
   assert(next_pos <= INT_MAX);
   return (int)next_pos;
 }
 
-int
-oc_ri_query_exists(const char *query, size_t query_len, const char *key)
+bool
+oc_ri_query_exists_v1(const char *query, size_t query_len, const char *key,
+                      size_t key_len)
 {
   assert(key != NULL);
-  int found = -1;
   size_t pos = 0;
   while (pos < query_len) {
     const char *k;
@@ -208,20 +224,22 @@ oc_ri_query_exists(const char *query, size_t query_len, const char *key)
       oc_ri_query_nth_key_exists(query + pos, query_len - pos, &k, &kl, 1u);
 
     if (next_pos == -1) {
-      return -1;
+      return false;
     }
-
-    if (kl == strlen(key) && strncasecmp(key, k, kl) == 0) {
-      found = 1;
-      break;
+    if (kl == key_len && strncasecmp(key, k, kl) == 0) {
+      return true;
     }
-    if (next_pos == 0) {
-      return -1;
-    }
-
-    pos += next_pos;
+    assert(next_pos != 0);
+    pos += (size_t)next_pos;
   }
-  return found;
+  return false;
+}
+
+int
+oc_ri_query_exists(const char *query, size_t query_len, const char *key)
+{
+  assert(key != NULL);
+  return oc_ri_query_exists_v1(query, query_len, key, strlen(key)) ? 1 : -1;
 }
 
 void
@@ -241,10 +259,10 @@ oc_iterate_query(const oc_request_t *request, const char **key, size_t *key_len,
 }
 
 bool
-oc_iterate_query_get_values(const oc_request_t *request, const char *key,
-                            const char **value, int *value_len)
+oc_iterate_query_get_values_v1(const oc_request_t *request, const char *key,
+                               size_t key_len, const char **value,
+                               int *value_len)
 {
-  size_t key_len = strlen(key);
   int pos = 0;
   do {
     const char *k = NULL;
@@ -254,6 +272,7 @@ oc_iterate_query_get_values(const oc_request_t *request, const char *key,
     pos = oc_iterate_query(request, &k, &k_len, &v, &v_len);
     if (pos != -1 && key_len == k_len && memcmp(key, k, k_len) == 0) {
       *value = v;
+      assert(v_len <= INT_MAX);
       *value_len = (int)v_len;
       goto more_or_done;
     }
@@ -263,21 +282,45 @@ more_or_done:
   return pos != -1 && (size_t)pos < request->query_len;
 }
 
+bool
+oc_iterate_query_get_values(const oc_request_t *request, const char *key,
+                            const char **value, int *value_len)
+{
+  return oc_iterate_query_get_values_v1(request, key, strlen(key), value,
+                                        value_len);
+}
+
+int
+oc_get_query_value_v1(const oc_request_t *request, const char *key,
+                      size_t key_len, const char **value)
+{
+  if (request == NULL) {
+    return -1;
+  }
+  return oc_ri_get_query_value_v1(request->query, request->query_len, key,
+                                  key_len, value);
+}
+
 int
 oc_get_query_value(const oc_request_t *request, const char *key,
                    const char **value)
 {
-  if (!request) {
-    return -1;
+  return oc_get_query_value_v1(request, key, strlen(key), value);
+}
+
+bool
+oc_query_value_exists_v1(const oc_request_t *request, const char *key,
+                         size_t key_len)
+{
+  if (request == NULL) {
+    return false;
   }
-  return oc_ri_get_query_value(request->query, request->query_len, key, value);
+  return oc_ri_query_exists_v1(request->query, request->query_len, key,
+                               key_len);
 }
 
 int
 oc_query_value_exists(const oc_request_t *request, const char *key)
 {
-  if (!request) {
-    return -1;
-  }
-  return oc_ri_query_exists(request->query, request->query_len, key);
+  return oc_query_value_exists_v1(request, key, strlen(key)) ? 1 : -1;
 }

--- a/api/oc_ri.c
+++ b/api/oc_ri.c
@@ -345,8 +345,8 @@ oc_ri_filter_request_by_device_id(size_t device, const char *query,
   oc_uuid_to_str(device_id, di, OC_UUID_LEN);
   for (size_t pos = 0; pos < query_len;) {
     const char *value = NULL;
-    int value_len =
-      oc_ri_get_query_value(query + pos, query_len - pos, "di", &value);
+    int value_len = oc_ri_get_query_value_v1(query + pos, query_len - pos, "di",
+                                             OC_CHAR_ARRAY_LEN("di"), &value);
     if (value_len == -1) {
       // pos == 0 key not found, otherwise device id not match the device.
       return pos == 0;
@@ -1256,8 +1256,8 @@ oc_ri_invoke_coap_entity_handler(coap_make_response_ctx_t *ctx,
     request_obj.query_len = uri_query_len;
     /* Check if query string includes interface selection. */
     const char *iface = NULL;
-    int iface_len =
-      oc_ri_get_query_value(uri_query, uri_query_len, "if", &iface);
+    int iface_len = oc_ri_get_query_value_v1(uri_query, uri_query_len, "if",
+                                             OC_CHAR_ARRAY_LEN("if"), &iface);
     if (iface_len != -1 && iface != NULL) {
       iface_query |= oc_ri_get_interface_mask(iface, (size_t)iface_len);
     }

--- a/api/unittest/discoverytest.cpp
+++ b/api/unittest/discoverytest.cpp
@@ -905,6 +905,34 @@ TEST_F(TestDiscoveryWithServer, GetRequestBatch)
 #endif /* OC_SECURITY */
 }
 
+TEST_F(TestDiscoveryWithServer, GetRequestBatchIncremental)
+{
+  // feature iba pre discovery res
+
+  // incChanges=<etag1 in base64>,<etag2 in base64>,..<etag20 in
+  // base64>&incChanges<etag21 in base64>,...&...
+
+  // batch discovery -> all resources except /oic/res, /.well-known/core, SVRs
+  // and secure resources without ACLs
+
+  // example -> etag0 + 3 etags in query
+  // 1. etag-0 -> try to find resource with etag0
+  //   -> if batch etag is equal: done, return VALID
+  //   -> not equal: continue
+  // 2. etag-1
+  //   -> check if etag-1 is in the resources -> store candidate etag
+  // 3. etag-2
+  //   -> if etag-2 is greater than current candidate etag -> check if etag-2 is
+  //   in the resources -> use it as candidate etag
+  //
+  // 4. etag-3
+  //
+  // if no candidate -> send all resources
+
+  // payload ako batch -> pole resourcov {"href": "...", "etag": "...", "rep":
+  // {...}} }
+}
+
 #endif /* OC_RES_BATCH_SUPPORT */
 
 #ifdef OC_DISCOVERY_RESOURCE_OBSERVABLE

--- a/api/unittest/etagtest.cpp
+++ b/api/unittest/etagtest.cpp
@@ -64,6 +64,19 @@ static constexpr std::string_view kDynamicResourceURI2{ "/dyn2" };
 
 using namespace std::chrono_literals;
 
+class TestETag : public ::testing::Test {
+public:
+  static void SetUpTestCase() { oc_log_set_level(OC_LOG_LEVEL_DEBUG); }
+
+  static void TearDownTestCase() { oc_log_set_level(OC_LOG_LEVEL_INFO); }
+};
+
+TEST_F(TestETag, IterateIncrementalUpdates)
+{
+  // std::string query = "";
+  // oc_etag_query_iterate_incremental_updates(query.c_str(), query.length());
+}
+
 class TestETagWithServer : public ::testing::Test {
 public:
   static void SetUpTestCase()

--- a/api/unittest/querytest.cpp
+++ b/api/unittest/querytest.cpp
@@ -28,7 +28,70 @@
 
 class TestQuery : public testing::Test {};
 
-TEST_F(TestQuery, RIGetQueryValueEmpty_N)
+TEST_F(TestQuery, RIGetQueryNthKeyValue_F)
+{
+  const char *k = NULL;
+  size_t klen = 0;
+  EXPECT_EQ(-1, oc_ri_get_query_nth_key_value(nullptr, 0, &k, &klen, nullptr,
+                                              nullptr, 1));
+  EXPECT_EQ(nullptr, k);
+  EXPECT_EQ(0, klen);
+
+  EXPECT_EQ(
+    -1, oc_ri_get_query_nth_key_value("", 0, &k, &klen, nullptr, nullptr, 1));
+  EXPECT_EQ(nullptr, k);
+  EXPECT_EQ(0, klen);
+
+  std::string key = "key=";
+  EXPECT_EQ(-1, oc_ri_get_query_nth_key_value(key.c_str(), key.length(), &k,
+                                              &klen, nullptr, nullptr, 2));
+  EXPECT_EQ(nullptr, k);
+  EXPECT_EQ(0, klen);
+}
+
+TEST_F(TestQuery, RIGetQueryNthKeyValue_P)
+{
+  std::string key1 = "key1";
+  std::string value1 = "value1";
+  std::string query = key1 + "=" + value1;
+  const char *k = nullptr;
+  size_t klen = 0;
+  EXPECT_EQ(query.length() + 1,
+            oc_ri_get_query_nth_key_value(query.c_str(), query.length(), &k,
+                                          &klen, nullptr, nullptr, 1));
+  EXPECT_EQ(key1.length(), klen);
+  EXPECT_EQ(0, memcmp(key1.c_str(), k, klen));
+
+  for (int i = 1; i <= 3; ++i) {
+    query = "";
+    std::vector<std::string> keys{};
+    std::vector<std::string> values{};
+    for (int j = 0; j < i; ++j) {
+      std::string key = "key" + std::to_string(j);
+      std::string value = "value" + std::to_string(j);
+      query += key + "=" + value;
+      keys.emplace_back(key);
+      values.emplace_back(value);
+      if (j < i - 1) {
+        query += "&";
+      }
+    }
+    for (int j = 0; j < i; ++j) {
+      k = nullptr;
+      klen = 0;
+      const char *v = nullptr;
+      size_t vlen = 0;
+      EXPECT_NE(-1, oc_ri_get_query_nth_key_value(query.c_str(), query.length(),
+                                                  &k, &klen, &v, &vlen, j + 1));
+      EXPECT_EQ(keys[j].length(), klen);
+      EXPECT_EQ(0, memcmp(keys[j].c_str(), k, klen));
+      EXPECT_EQ(values[j].length(), vlen);
+      EXPECT_EQ(0, memcmp(values[j].c_str(), v, vlen));
+    }
+  }
+}
+
+TEST_F(TestQuery, RIGetQueryValue_F)
 {
   const char *value;
   int ret = oc_ri_get_query_value(nullptr, 0, "key", &value);
@@ -38,6 +101,27 @@ TEST_F(TestQuery, RIGetQueryValueEmpty_N)
   ret = oc_ri_get_query_value("", 0, "key", &value);
   EXPECT_EQ(-1, ret) << "N input \"\" "
                      << "key";
+}
+
+TEST_F(TestQuery, RIGetQueryValueV1_F)
+{
+  std::string key1 = "key1";
+  const char *value = nullptr;
+  int ret =
+    oc_ri_get_query_value_v1(nullptr, 0, key1.c_str(), key1.length(), &value);
+  EXPECT_EQ(-1, ret) << "N input NULL " << key1;
+  EXPECT_EQ(nullptr, value);
+
+  ret = oc_ri_get_query_value_v1("", 0, key1.c_str(), key1.length(), &value);
+  EXPECT_EQ(-1, ret) << "N input \"\" " << key1;
+  EXPECT_EQ(nullptr, value);
+
+  std::string query = "key1=1";
+  std::string key2 = "key2";
+  ret = oc_ri_get_query_value_v1(query.c_str(), query.length(), key2.c_str(),
+                                 key2.length(), &value);
+  EXPECT_EQ(-1, ret) << "N input \"\" " << key2;
+  EXPECT_EQ(nullptr, value);
 }
 
 TEST_F(TestQuery, RIGetQueryValue_P)
@@ -75,6 +159,102 @@ TEST_F(TestQuery, RIGetQueryValue_P)
   }
 }
 
+TEST_F(TestQuery, RIGetQueryValueV1_P)
+{
+  using string_pair = std::pair<std::string, std::string>;
+  std::vector<string_pair> inputs = {
+    { "key", "" },
+    { "key=1337", "1337" },
+    { "data=1&key=22", "22" },
+    { "key=333&data=3", "333" },
+    { "x&key=42&data=3", "42" },
+    { "y&x&key=5225&data=3", "5225" },
+    { "y&x&key=6", "6" },
+    { "y&x&key=777&y", "777" },
+  };
+  std::string key = "key";
+  const char *v;
+  for (const auto &[query, exp] : inputs) {
+    int ret = oc_ri_get_query_value_v1(query.c_str(), query.length(),
+                                       key.c_str(), key.length(), &v);
+    EXPECT_EQ(exp.length(), ret) << "P input " << query << " " << key;
+    if (ret > 0) {
+      std::string value(v, ret);
+      EXPECT_STREQ(exp.c_str(), value.c_str())
+        << "P input " << query << " "
+        << "value " << exp << " vs " << value;
+    }
+  }
+
+  std::string key2 = "key2";
+  for (const auto &[query, _] : inputs) {
+    int ret = oc_ri_get_query_value_v1(query.c_str(), query.length(),
+                                       key2.c_str(), key2.length(), nullptr);
+    EXPECT_EQ(-1, ret) << "N input " << query << " " << key2;
+  }
+}
+
+TEST_F(TestQuery, RIQueryNthKeyExists_F)
+{
+  const char *k = nullptr;
+  size_t klen = 0;
+  EXPECT_EQ(-1, oc_ri_query_nth_key_exists(nullptr, 0, &k, &klen, 1));
+  EXPECT_EQ(nullptr, k);
+  EXPECT_EQ(0, klen);
+
+  EXPECT_EQ(-1, oc_ri_query_nth_key_exists("", 0, &k, &klen, 1));
+  EXPECT_EQ(nullptr, k);
+  EXPECT_EQ(0, klen);
+
+  EXPECT_EQ(-1, oc_ri_query_nth_key_exists("&&&", 0, &k, &klen, 1));
+  EXPECT_EQ(nullptr, k);
+  EXPECT_EQ(0, klen);
+}
+
+TEST_F(TestQuery, RIQueryNthKeyExists_P)
+{
+  for (int i = 1; i <= 3; ++i) {
+    std::string query = "";
+    std::vector<std::string> keys{};
+    for (int j = 0; j < i; ++j) {
+      std::string key = "key" + std::to_string(j);
+      query += key + "=" + std::to_string(j);
+      keys.emplace_back(key);
+      if (j < i - 1) {
+        query += "&";
+      }
+    }
+    for (int j = 0; j < i; ++j) {
+      const char *k = nullptr;
+      size_t klen = 0;
+      int vlen = oc_ri_query_nth_key_exists(query.c_str(), query.length(), &k,
+                                            &klen, j + 1);
+      EXPECT_NE(-1, vlen);
+      if (j == i - 1) {
+        EXPECT_EQ(query.length(), vlen);
+      }
+      EXPECT_EQ(keys[j].length(), klen);
+      EXPECT_EQ(0, memcmp(keys[j].c_str(), k, klen));
+    }
+  }
+}
+
+TEST_F(TestQuery, RIQueryExistsV1_F)
+{
+  EXPECT_FALSE(oc_ri_query_exists_v1(nullptr, 0, "", 0));
+
+  std::string query = "key1=1";
+  std::string key = "key";
+  EXPECT_FALSE(oc_ri_query_exists_v1(query.c_str(), query.length(), key.c_str(),
+                                     key.length()));
+  key = "key11";
+  EXPECT_FALSE(oc_ri_query_exists_v1(query.c_str(), query.length(), key.c_str(),
+                                     key.length()));
+  key = "1";
+  EXPECT_FALSE(oc_ri_query_exists_v1(query.c_str(), query.length(), key.c_str(),
+                                     key.length()));
+}
+
 TEST_F(TestQuery, RIQueryExists_P)
 {
   std::vector<std::string> inputs = { "key=1",
@@ -87,24 +267,56 @@ TEST_F(TestQuery, RIQueryExists_P)
                                       "y=&key=2&data=3",
                                       "y=1&x&key=2&data=3",
                                       "y=1&x&key" };
-  int ret;
   for (const auto &input : inputs) {
-    ret = oc_ri_query_exists(input.c_str(), input.length(), "key");
+    int ret = oc_ri_query_exists(input.c_str(), input.length(), "key");
     EXPECT_EQ(1, ret) << "P input " << input << " "
                       << "key";
   }
 
   inputs.emplace_back("");
   for (const auto &input : inputs) {
-    ret = oc_ri_query_exists(input.c_str(), input.length(), "key2");
+    int ret = oc_ri_query_exists(input.c_str(), input.length(), "key2");
     EXPECT_EQ(-1, ret) << "N input " << input << " "
                        << "key2";
+  }
+}
+
+TEST_F(TestQuery, RIQueryExistsV1_P)
+{
+  std::vector<std::string> inputs = { "key=1",
+                                      "key",
+                                      "data=1&key=2",
+                                      "data=2&key",
+                                      "key&data=3",
+                                      "key=2&data=3",
+                                      "x=1&key=2&data=3",
+                                      "y=&key=2&data=3",
+                                      "y=1&x&key=2&data=3",
+                                      "y=1&x&key" };
+  std::string key = "key";
+  for (const auto &input : inputs) {
+    bool ret = oc_ri_query_exists_v1(input.c_str(), input.length(), key.c_str(),
+                                     key.length());
+    EXPECT_TRUE(ret) << "P input " << input << " " << key;
+  }
+
+  inputs.emplace_back("");
+  std::string key2 = "key2";
+  for (const auto &input : inputs) {
+    bool ret = oc_ri_query_exists_v1(input.c_str(), input.length(),
+                                     key2.c_str(), key2.length());
+    EXPECT_FALSE(ret) << "N input " << input << " " << key2;
   }
 }
 
 TEST_F(TestQuery, GetValue_F)
 {
   EXPECT_EQ(-1, oc_get_query_value(nullptr, "", nullptr));
+}
+
+TEST_F(TestQuery, GetValueV1_F)
+{
+  EXPECT_EQ(-1, oc_get_query_value_v1(nullptr, "", 0, nullptr));
 }
 
 TEST_F(TestQuery, GetValueEmpty_N)
@@ -123,9 +335,138 @@ TEST_F(TestQuery, GetValueEmpty_N)
                      << "key";
 }
 
+TEST_F(TestQuery, GetValueV1Empty_N)
+{
+  const char *value = nullptr;
+  oc_request_t request{};
+  request.query = nullptr;
+  request.query_len = 0;
+  std::string key = "key";
+  int ret = oc_get_query_value_v1(&request, key.c_str(), key.length(), &value);
+  EXPECT_EQ(-1, ret) << "N input NULL " << key;
+
+  request.query = "";
+  ret = oc_get_query_value_v1(&request, key.c_str(), key.length(), &value);
+  EXPECT_EQ(-1, ret) << "N input \"\" " << key;
+}
+
+TEST_F(TestQuery, IterateValues_F)
+{
+  oc_init_query_iterator();
+  oc_request_t request{};
+  const char *v = nullptr;
+  int vlen = 0;
+  EXPECT_FALSE(oc_iterate_query_get_values(&request, "", &v, &vlen));
+  EXPECT_EQ(nullptr, v);
+  EXPECT_EQ(0, vlen);
+
+  oc_init_query_iterator();
+  std::string query = "key1=1&key2=2";
+  request.query = query.c_str();
+  request.query_len = query.length();
+  EXPECT_FALSE(oc_iterate_query_get_values(&request, "", &v, &vlen));
+  EXPECT_EQ(nullptr, v);
+  EXPECT_EQ(0, vlen);
+  EXPECT_FALSE(oc_iterate_query_get_values(&request, "key", &v, &vlen));
+  EXPECT_EQ(nullptr, v);
+  EXPECT_EQ(0, vlen);
+  EXPECT_FALSE(oc_iterate_query_get_values(&request, "key12", &v, &vlen));
+  EXPECT_EQ(nullptr, v);
+  EXPECT_EQ(0, vlen);
+  EXPECT_FALSE(oc_iterate_query_get_values(&request, "keyF", &v, &vlen));
+  EXPECT_EQ(nullptr, v);
+  EXPECT_EQ(0, vlen);
+}
+
+TEST_F(TestQuery, IterateValuesV1_F)
+{
+  oc_init_query_iterator();
+  oc_request_t request{};
+  const char *v = nullptr;
+  int vlen = 0;
+  EXPECT_FALSE(oc_iterate_query_get_values_v1(&request, "", 0, &v, &vlen));
+  EXPECT_EQ(nullptr, v);
+  EXPECT_EQ(0, vlen);
+
+  oc_init_query_iterator();
+  std::string query = "key1=1&key2=2";
+  request.query = query.c_str();
+  request.query_len = query.length();
+  EXPECT_FALSE(oc_iterate_query_get_values_v1(&request, "", 0, &v, &vlen));
+  EXPECT_EQ(nullptr, v);
+  EXPECT_EQ(0, vlen);
+  std::string key = "key";
+  EXPECT_FALSE(oc_iterate_query_get_values_v1(&request, key.c_str(),
+                                              key.length(), &v, &vlen));
+  EXPECT_EQ(nullptr, v);
+  EXPECT_EQ(0, vlen);
+  key = "key12";
+  EXPECT_FALSE(oc_iterate_query_get_values_v1(&request, key.c_str(),
+                                              key.length(), &v, &vlen));
+  EXPECT_EQ(nullptr, v);
+  EXPECT_EQ(0, vlen);
+  key = "keyF";
+  EXPECT_FALSE(oc_iterate_query_get_values_v1(&request, key.c_str(),
+                                              key.length(), &v, &vlen));
+  EXPECT_EQ(nullptr, v);
+  EXPECT_EQ(0, vlen);
+}
+
+TEST_F(TestQuery, IterateValuesV1_P)
+{
+  std::string query = "key1=1&key2=2&key3=3";
+  oc_request_t request{};
+  request.query = query.c_str();
+  request.query_len = query.length();
+  const char *v = nullptr;
+  int vlen = 0;
+
+  std::string key = "key1";
+  oc_init_query_iterator();
+  EXPECT_TRUE(oc_iterate_query_get_values_v1(&request, key.c_str(),
+                                             key.length(), &v, &vlen));
+  EXPECT_EQ(1, vlen);
+  EXPECT_EQ(0, memcmp("1", v, static_cast<size_t>(vlen)));
+
+  key = "key2";
+  oc_init_query_iterator();
+  EXPECT_TRUE(oc_iterate_query_get_values_v1(&request, key.c_str(),
+                                             key.length(), &v, &vlen));
+  EXPECT_EQ(1, vlen);
+  EXPECT_EQ(0, memcmp("2", v, static_cast<size_t>(vlen)));
+
+  key = "key3";
+  oc_init_query_iterator();
+  EXPECT_FALSE(oc_iterate_query_get_values_v1(&request, key.c_str(),
+                                              key.length(), &v, &vlen));
+  EXPECT_EQ(1, vlen);
+  EXPECT_EQ(0, memcmp("3", v, static_cast<size_t>(vlen)));
+
+  query = "key=1&key=2&key=3";
+  request.query = query.c_str();
+  request.query_len = query.length();
+  oc_init_query_iterator();
+  key = "key";
+  bool more = true;
+  int i = 1;
+  do {
+    more = oc_iterate_query_get_values_v1(&request, key.c_str(), key.length(),
+                                          &v, &vlen);
+    EXPECT_EQ(1, vlen);
+    EXPECT_EQ(0,
+              memcmp(std::to_string(i).c_str(), v, static_cast<size_t>(vlen)));
+    ++i;
+  } while (more);
+}
+
 TEST_F(TestQuery, Exists_F)
 {
   EXPECT_EQ(-1, oc_query_value_exists(nullptr, ""));
+}
+
+TEST_F(TestQuery, ExistsV1_F)
+{
+  EXPECT_FALSE(oc_query_value_exists_v1(nullptr, "", 0));
 }
 
 TEST_F(TestQuery, Exists_P)
@@ -140,12 +481,11 @@ TEST_F(TestQuery, Exists_P)
                                       "y=&key=2&data=3",
                                       "y=1&x&key=2&data=3",
                                       "y=1&x&key" };
-  int ret;
   for (const auto &input : inputs) {
     oc_request_t request;
     request.query = input.c_str();
     request.query_len = input.length();
-    ret = oc_query_value_exists(&request, "key");
+    int ret = oc_query_value_exists(&request, "key");
     EXPECT_EQ(1, ret) << "P input " << input << " "
                       << "key";
   }
@@ -155,9 +495,41 @@ TEST_F(TestQuery, Exists_P)
     oc_request_t request;
     request.query = input.c_str();
     request.query_len = input.length();
-    ret = oc_query_value_exists(&request, "key2");
+    int ret = oc_query_value_exists(&request, "key2");
     EXPECT_EQ(-1, ret) << "N input " << input << " "
                        << "key2";
+  }
+}
+
+TEST_F(TestQuery, ExistsV1_P)
+{
+  std::vector<std::string> inputs = { "key=1",
+                                      "key",
+                                      "data=1&key=2",
+                                      "data=2&key",
+                                      "key&data=3",
+                                      "key=2&data=3",
+                                      "x=1&key=2&data=3",
+                                      "y=&key=2&data=3",
+                                      "y=1&x&key=2&data=3",
+                                      "y=1&x&key" };
+  std::string key = "key";
+  for (const auto &input : inputs) {
+    oc_request_t request;
+    request.query = input.c_str();
+    request.query_len = input.length();
+    bool ret = oc_query_value_exists_v1(&request, key.c_str(), key.length());
+    EXPECT_TRUE(ret) << "P input " << input << " " << key;
+  }
+
+  inputs.emplace_back("");
+  std::string key2 = "key2";
+  for (const auto &input : inputs) {
+    oc_request_t request;
+    request.query = input.c_str();
+    request.query_len = input.length();
+    bool ret = oc_query_value_exists_v1(&request, key2.c_str(), key2.length());
+    EXPECT_FALSE(ret) << "N input " << input << " " << key2;
   }
 }
 

--- a/apps/cloud_proxy.c
+++ b/apps/cloud_proxy.c
@@ -197,6 +197,7 @@ static CRITICAL_SECTION cs;   /**< event loop variable */
 #endif
 
 #define btoa(x) ((x) ? "true" : "false")
+#define CHAR_ARRAY_LEN(x) (sizeof(x) - 1)
 
 #define MAX_STRING 30         /**< max size of the strings. */
 #define MAX_PAYLOAD_STRING 65 /**< max size strings in the payload */
@@ -682,7 +683,8 @@ post_d2dserverlist(oc_request_t *request, oc_interface_mask_t interfaces,
   const char *_scan = NULL; /* not null terminated  */
 
   /* do a scan to all devices */
-  int _scan_len = oc_get_query_value(request, "scan", &_scan);
+  int _scan_len =
+    oc_get_query_value_v1(request, "scan", CHAR_ARRAY_LEN("scan"), &_scan);
   if (_scan_len > 0) {
     OC_PRINTF("   Send multicast discovery\n");
     issue_requests_all();
@@ -690,7 +692,8 @@ post_d2dserverlist(oc_request_t *request, oc_interface_mask_t interfaces,
     return;
   }
 
-  int _di_len = oc_get_query_value(request, "di", &_di);
+  int _di_len =
+    oc_get_query_value_v1(request, "di", CHAR_ARRAY_LEN("di"), &_di);
   if (_di_len != -1) {
     /* input check
      * ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
@@ -770,7 +773,6 @@ STATIC void
 delete_d2dserverlist(oc_request_t *request, oc_interface_mask_t interfaces,
                      void *user_data)
 {
-  (void)request;
   (void)interfaces;
   (void)user_data;
   bool error_state = true;
@@ -780,7 +782,8 @@ delete_d2dserverlist(oc_request_t *request, oc_interface_mask_t interfaces,
 
   /* query name 'di' type: 'string'*/
   const char *_di = NULL; /* not null terminated  */
-  int _di_len = oc_get_query_value(request, "di", &_di);
+  int _di_len =
+    oc_get_query_value_v1(request, "di", CHAR_ARRAY_LEN("di"), &_di);
   if (_di_len != -1) {
     /* input check
      * ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$

--- a/apps/server_certification_tests.c
+++ b/apps/server_certification_tests.c
@@ -58,6 +58,8 @@ static const char *manufacturer = "OCF";
 #define btoa(x) ((x) ? "true" : "false")
 #define MAX_ARRAY 10 /* max size of the array */
 
+#define CHAR_ARRAY_LEN(x) (sizeof(x) - 1)
+
 /* global property variables for path: "/dali" */
 static const char *g_dali_RESOURCE_PROPERTY_NAME_pld =
   "pld"; /* the name for the attribute */
@@ -606,7 +608,8 @@ get_temp(oc_request_t *request, oc_interface_mask_t iface_mask, void *user_data)
   bool invalid_query = false;
   const char *units;
   units_t u = temp_units;
-  int units_len = oc_get_query_value(request, "units", &units);
+  int units_len =
+    oc_get_query_value_v1(request, "units", CHAR_ARRAY_LEN("units"), &units);
   if (units_len != -1) {
     if (units[0] == 'K') {
       u = K;
@@ -1633,7 +1636,8 @@ get_remotecontrol(oc_request_t *request, oc_interface_mask_t iface_mask,
   const char *action = NULL;
   int action_len = -1;
   oc_init_query_iterator();
-  oc_iterate_query_get_values(request, "action", &action, &action_len);
+  oc_iterate_query_get_values_v1(request, "action", CHAR_ARRAY_LEN("action"),
+                                 &action, &action_len);
 
   if (action_len > 0) {
     // An action parm was received
@@ -1678,7 +1682,8 @@ post_remotecontrol(oc_request_t *request, oc_interface_mask_t iface_mask,
   const char *action = NULL;
   int action_len = -1;
   oc_init_query_iterator();
-  oc_iterate_query_get_values(request, "action", &action, &action_len);
+  oc_iterate_query_get_values_v1(request, "action", CHAR_ARRAY_LEN("action"),
+                                 &action, &action_len);
 
   if (action_len > 0) {
     OC_PRINTF("POST action length = %d \n", action_len);

--- a/apps/simpleserver-TVAppAndAction.c
+++ b/apps/simpleserver-TVAppAndAction.c
@@ -32,6 +32,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#define CHAR_ARRAY_LEN(x) (sizeof(x) - 1)
+
 #ifdef __linux__
 #include <pthread.h>
 static pthread_mutex_t mutex;
@@ -228,7 +230,8 @@ get_remotecontrol(oc_request_t *request, oc_interface_mask_t iface_mask,
   const char *action = NULL;
   int action_len = -1;
   oc_init_query_iterator();
-  oc_iterate_query_get_values(request, "action", &action, &action_len);
+  oc_iterate_query_get_values_v1(request, "action", CHAR_ARRAY_LEN("action"),
+                                 &action, &action_len);
 
   if (action_len > 0) {
     // An action parm was received
@@ -273,7 +276,8 @@ post_remotecontrol(oc_request_t *request, oc_interface_mask_t iface_mask,
   const char *action = NULL;
   int action_len = -1;
   oc_init_query_iterator();
-  oc_iterate_query_get_values(request, "action", &action, &action_len);
+  oc_iterate_query_get_values_v1(request, "action", CHAR_ARRAY_LEN("action"),
+                                 &action, &action_len);
 
   if (action_len > 0) {
     printf("POST action length = %d \n", action_len);

--- a/apps/smart_home_server_linux.c
+++ b/apps/smart_home_server_linux.c
@@ -32,6 +32,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#define CHAR_ARRAY_LEN(x) (sizeof(x) - 1)
+
 static pthread_mutex_t mutex;
 static pthread_cond_t cv;
 
@@ -134,7 +136,8 @@ get_temp(oc_request_t *request, oc_interface_mask_t iface_mask, void *user_data)
   bool invalid_query = false;
   const char *units;
   units_t u = temp_units;
-  int units_len = oc_get_query_value(request, "units", &units);
+  int units_len =
+    oc_get_query_value_v1(request, "units", CHAR_ARRAY_LEN("units"), &units);
   if (units_len != -1) {
     if (units[0] == 'K') {
       u = K;

--- a/include/oc_api.h
+++ b/include/oc_api.h
@@ -1383,9 +1383,9 @@ int oc_iterate_query(const oc_request_t *request, const char **key,
   OC_NONNULL(1, 2, 3);
 
 /**
- * Iterate though the URI query parameters for a specific key.
+ * @brief Iterate though the URI query parameters for a specific key.
  *
- * Before calling oc_iterate_query_get_values() the first time
+ * Before calling oc_iterate_query_get_values_v1() the first time
  * oc_init_query_iterator() must be called to reset the query iterator to the
  * first query parameter.
  *
@@ -1396,13 +1396,13 @@ int oc_iterate_query(const oc_request_t *request, const char **key,
  * Example:
  * ```
  * bool more_query_params = false;
- * const char* expected_value = "world"
- * char *value = NULL;
+ * const char* expected_value = "world";
+ * const char *value = NULL;
  * int value_len = -1;
  * oc_init_query_iterator();
  * do {
- * more_query_params = oc_iterate_query_get_values(request, "hello",
- *                                                 &value, &value_len);
+ *   more_query_params = oc_iterate_query_get_values_v1(request, "hello",
+ *                         strlen("hello"), &value, &value_len);
  *   if (rt_len > 0) {
  *     printf("Found %s = %.*s\n", "hello", value_len, value);
  *   }
@@ -1412,6 +1412,7 @@ int oc_iterate_query(const oc_request_t *request, const char **key,
  * @param[in] request the oc_request_t that contains the query parameters
  * (cannot be NULL)
  * @param[in] key the key being searched for (cannot be NULL)
+ * @param[in] key_len the length of the key
  * @param[out] value pointer to the value string for to the key=value pair
  * (cannot be NULL)
  * @param[out] value_len the length of the value string (cannot be NULL)
@@ -1419,13 +1420,25 @@ int oc_iterate_query(const oc_request_t *request, const char **key,
  * @return True if there are more query parameters to iterate through
  */
 OC_API
-bool oc_iterate_query_get_values(const oc_request_t *request, const char *key,
-                                 const char **value, int *value_len)
+bool oc_iterate_query_get_values_v1(const oc_request_t *request,
+                                    const char *key, size_t key_len,
+                                    const char **value, int *value_len)
   OC_NONNULL();
 
 /**
- * Get a pointer to the start of the value in a URL query parameter key=value
- * pair.
+ * @brief Iterate though the URI query parameters for a specific key.
+ *
+ * @deprecated replaced by oc_iterate_query_get_values_v1 in v2.2.5.8
+ */
+OC_API
+bool oc_iterate_query_get_values(const oc_request_t *request, const char *key,
+                                 const char **value, int *value_len)
+  OC_NONNULL()
+    OC_DEPRECATED("replaced by oc_iterate_query_get_values_v1 in v2.2.5.8");
+
+/**
+ * @brief Get a pointer to the start of the value in a URL query parameter
+ * key=value pair.
  *
  * @note The char pointer returned is pointing to the string location in the
  *       query string. Do not rely on a nul terminator to find the end of the
@@ -1433,6 +1446,7 @@ bool oc_iterate_query_get_values(const oc_request_t *request, const char *key,
  *
  * @param[in] request the oc_request_t that contains the query parameters
  * @param[in] key the key being searched for (cannot be NULL)
+ * @param[in] key_len the length of the key
  * @param[out] value pointer to the value string assigned to the key
  *
  * @return
@@ -1440,22 +1454,46 @@ bool oc_iterate_query_get_values(const oc_request_t *request, const char *key,
  *   - `-1` if there are no additional query parameters
  */
 OC_API
-int oc_get_query_value(const oc_request_t *request, const char *key,
-                       const char **value) OC_NONNULL(2);
+int oc_get_query_value_v1(const oc_request_t *request, const char *key,
+                          size_t key_len, const char **value) OC_NONNULL(2);
 
 /**
- * Checks if a query parameter 'key' exist in the URL query parameter
+ * @brief Get a pointer to the start of the value in a URL query parameter
+ * key=value pair.
  *
- * @param[in] request the oc_request_t that contains the query parameters
- * @param[in] key the key being searched for (cannot be NULL)
+ * @deprecated replaced by oc_get_query_value_v1 in v2.2.5.8
+ */
+OC_API
+int oc_get_query_value(const oc_request_t *request, const char *key,
+                       const char **value) OC_NONNULL(2)
+  OC_DEPRECATED("replaced by oc_get_query_value_v1 in v2.2.5.8");
+
+/**
+ * @brief Checks if a query parameter 'key' exist in the URL query parameter
  *
- * @return
- *   - 1 exist
- *   - -1 does not exist
+ * @param request the oc_request_t that contains the query parameters
+ * @param key the key being searched for (cannot be NULL)
+ * @param key_len the length of the key
+ *
+ * @return true if the key exist in the query parameter
+ * @return false if the key does not exist in the query parameter
+ */
+OC_API
+bool oc_query_value_exists_v1(const oc_request_t *request, const char *key,
+                              size_t key_len) OC_NONNULL(2);
+
+/**
+ * @brief Checks if a query parameter 'key' exist in the URL query parameter
+ *
+ * @return 1 if the key exist in the query parameter
+ * @return -1 if the key does not exist in the query parameter
+ *
+ * @deprecated replaced by oc_query_value_exists_v1 in v2.2.5.8
  */
 OC_API
 int oc_query_value_exists(const oc_request_t *request, const char *key)
-  OC_NONNULL(2);
+  OC_NONNULL(2)
+    OC_DEPRECATED("replaced by oc_query_value_exists_v1 in v2.2.5.8");
 
 /**
  * Called after the response to a GET, PUT, POST or DELETE call has been

--- a/include/oc_ri.h
+++ b/include/oc_ri.h
@@ -626,7 +626,7 @@ bool oc_ri_on_delete_resource_remove_callback(oc_ri_delete_resource_cb_t cb)
  * @param[out] key_len the length of the key (cannot be NULL)
  * @param[out] value the value belonging to the key
  * @param[out] value_len the length of the value
- * @param n the position to query
+ * @param n the position to query (must be > 0)
  * @return int the position of the next key value pair in the query
  * @return int -1 on failure
  */
@@ -641,23 +641,46 @@ int oc_ri_get_query_nth_key_value(const char *query, size_t query_len,
  * @param query the input query
  * @param query_len the query lenght
  * @param key the wanted key (cannot be NULL)
+ * @param key_len the length of the wanted key
  * @param value the returned value
- * @return int the lenght of the value
+ * @return -1 if the key is not found
+ * @return the length of the value
  */
-int oc_ri_get_query_value(const char *query, size_t query_len, const char *key,
-                          const char **value) OC_NONNULL(3);
+int oc_ri_get_query_value_v1(const char *query, size_t query_len,
+                             const char *key, size_t key_len,
+                             const char **value) OC_NONNULL(3);
 
 /**
- * @brief checks if key exist in query
+ * @brief retrieve the value of the query parameter "key"
  *
- * @param[in] query the query to inspect
- * @param[in] query_len the lenght of the query
- * @param[in] key the key to be checked if exist, key is null terminated (cannot
+ * @deprecated replaced by oc_ri_get_query_value_v1 in v2.2.5.8
+ */
+int oc_ri_get_query_value(const char *query, size_t query_len, const char *key,
+                          const char **value) OC_NONNULL(3)
+  OC_DEPRECATED("replaced by oc_ri_get_query_value_v1 in v2.2.5.8");
+
+/**
+ * @brief Checks if key exist in query
+ *
+ * @param query the query to inspect
+ * @param query_len the length of the query
+ * @param key the key to be checked if exist, key is null terminated (cannot
  * be NULL)
- * @return int -1 = not exists
+ * @param key_len the key length
+ * @return true if key exists
+ */
+bool oc_ri_query_exists_v1(const char *query, size_t query_len, const char *key,
+                           size_t key_len) OC_NONNULL(3);
+
+/**
+ * @brief Checks if key exist in query
+ *
+ * @return -1 if key does not exist
+ *
+ * @deprecated replaced by oc_ri_query_exists_v1 in v2.2.5.8
  */
 int oc_ri_query_exists(const char *query, size_t query_len, const char *key)
-  OC_NONNULL(3);
+  OC_NONNULL(3) OC_DEPRECATED("replaced by oc_ri_query_exists_v1 in v2.2.5.8");
 
 /**
  * @brief check if the nth key exists
@@ -667,8 +690,10 @@ int oc_ri_query_exists(const char *query, size_t query_len, const char *key)
  * @param key the key to be checked if exist, key is not null terminated (cannot
  * be NULL)
  * @param key_len the key length (cannot be NULL)
- * @param n index of the key
- * @return int -1 = not exists
+ * @param n index of the key (must be > 0)
+ * @return -1 if key does not exist
+ * @return >= 0 if key exists and the value is the position of the next key in
+ * the query or query_len if it is the last key
  */
 int oc_ri_query_nth_key_exists(const char *query, size_t query_len,
                                const char **key, size_t *key_len, size_t n)

--- a/security/oc_acl.c
+++ b/security/oc_acl.c
@@ -1364,7 +1364,8 @@ delete_acl(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
 
   bool success = false;
   const char *query_param = 0;
-  int ret = oc_get_query_value(request, "aceid", &query_param);
+  int ret = oc_get_query_value_v1(request, "aceid", OC_CHAR_ARRAY_LEN("aceid"),
+                                  &query_param);
   int aceid = 0;
   if (ret != -1) {
     aceid = (int)strtoul(query_param, NULL, 10);

--- a/security/oc_cred.c
+++ b/security/oc_cred.c
@@ -1832,7 +1832,8 @@ cred_resource_delete(oc_request_t *request, oc_interface_mask_t iface_mask,
   }
 
   const char *query_param = NULL;
-  int ret = oc_get_query_value(request, "credid", &query_param);
+  int ret = oc_get_query_value_v1(request, "credid",
+                                  OC_CHAR_ARRAY_LEN("credid"), &query_param);
   if (ret != -1) {
     errno = 0;
     long credid =

--- a/security/oc_doxm.c
+++ b/security/oc_doxm.c
@@ -289,7 +289,8 @@ get_doxm(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
   case OC_IF_RW:
   case OC_IF_BASELINE: {
     const char *q;
-    int ql = oc_get_query_value(request, OC_DOXM_OWNED, &q);
+    int ql = oc_get_query_value_v1(request, OC_DOXM_OWNED,
+                                   OC_CHAR_ARRAY_LEN(OC_DOXM_OWNED), &q);
     size_t device = request->resource->device;
 
     if (ql > 0 &&
@@ -313,7 +314,8 @@ get_doxm(oc_request_t *request, oc_interface_mask_t iface_mask, void *data)
     // FOR DEVELOPMENT USE ONLY
 #ifdef OC_DOXM_UUID_FILTER
     const char *q2;
-    int ql2 = oc_get_query_value(request, OC_DOXM_DEVICEUUID, &q2);
+    int ql2 = oc_get_query_value_v1(request, OC_DOXM_DEVICEUUID,
+                                    OC_CHAR_ARRAY_LEN(OC_DOXM_DEVICEUUID), &q2);
 
     // q2 is not null terminated, so we subtract 1 from the comparison length
     if (ql2 > 0) {

--- a/security/oc_roles.c
+++ b/security/oc_roles.c
@@ -371,7 +371,8 @@ roles_resource_delete(oc_request_t *request, oc_interface_mask_t iface_mask,
   (void)data;
   const oc_tls_peer_t *client = oc_tls_get_peer(request->origin);
   const char *query_param = NULL;
-  int ret = oc_get_query_value(request, "credid", &query_param);
+  int ret = oc_get_query_value_v1(request, "credid",
+                                  OC_CHAR_ARRAY_LEN("credid"), &query_param);
   if (ret == -1) {
     // no query param, delete all roles
     oc_sec_free_roles(client);

--- a/swig/swig_interfaces/oc_api.i
+++ b/swig/swig_interfaces/oc_api.i
@@ -901,7 +901,9 @@ void jni_oc_con_callback(size_t device_index, const oc_rep_t *rep)
 %ignore oc_init_query_iterator;
 %ignore oc_iterate_query;
 %ignore oc_get_query_value;
+%ignore oc_get_query_value_v1;
 %ignore oc_iterate_query_get_values;
+%ignore oc_iterate_query_get_values_v1;
 
 %typemap(jni)    jobject getQueryValues "jobject";
 %typemap(jtype)  jobject getQueryValues "java.util.List<OCQueryValue>";

--- a/swig/swig_interfaces/oc_ri.i
+++ b/swig/swig_interfaces/oc_ri.i
@@ -167,6 +167,7 @@ struct oc_response_s
 %ignore oc_ri_free_resource_properties;
 %ignore oc_ri_get_query_nth_key_value;
 %ignore oc_ri_get_query_value;
+%ignore oc_ri_get_query_value_v1;
 %ignore oc_ri_get_interface_mask;
 
 #define OC_API


### PR DESCRIPTION
Extend the function signature to include the include the length of the key. If the length of the key is known then a call to strlen can be avoided.

Added:
  - oc_iterate_query_get_values_v1
  - oc_get_query_value_v1
  - oc_query_value_exists_v1
  - oc_ri_get_query_value_v1
  - oc_ri_query_exists_v1

Deprecated:
  - oc_iterate_query_get_values
  - oc_get_query_value
  - oc_query_value_exists
  - oc_ri_get_query_value
  - oc_ri_query_exists