### PR TITLE
Check iotivity-lite stack init before processing requests

### DIFF
--- a/api/oc_main.c
+++ b/api/oc_main.c
@@ -313,7 +313,7 @@ main_load_resources(void)
 int
 oc_main_init(const oc_handler_t *handler)
 {
-  if (g_initialized == true) {
+  if (g_initialized) {
     return 0;
   }
 
@@ -367,7 +367,6 @@ oc_main_init(const oc_handler_t *handler)
 #endif /* OC_SERVER */
 
   OC_DBG("oc_main: stack initialized");
-
   g_initialized = true;
 
 #ifdef OC_CLIENT
@@ -420,10 +419,9 @@ oc_main_needs_poll(void)
 void
 oc_main_shutdown(void)
 {
-  if (g_initialized == false) {
+  if (!g_initialized) {
     return;
   }
-
   g_initialized = false;
 
 #if defined(OC_CLIENT) && defined(OC_SERVER) && defined(OC_CLOUD)

--- a/messaging/coap/engine.c
+++ b/messaging/coap/engine.c
@@ -521,6 +521,11 @@ coap_receive_method_payload(coap_receive_ctx_t *ctx, const char *href,
   }
 #endif /* OC_SECURITY */
 
+  if (!oc_main_initialized()) {
+    COAP_DBG("cannot process new requests during shutdown iotivity-lite stack");
+    return COAP_RECEIVE_ERROR;
+  }
+
 #ifdef OC_TCP
   bool is_valid_size =
     ((endpoint->flags & TCP) != 0 &&

--- a/messaging/coap/engine.c
+++ b/messaging/coap/engine.c
@@ -488,11 +488,9 @@ coap_receive_blockwise_block2(coap_receive_ctx_t *ctx, const char *href,
 }
 
 static coap_receive_status_t
-coap_receive_method_payload(coap_receive_ctx_t *ctx, const char *href,
-                            size_t href_len, const oc_endpoint_t *endpoint)
+coap_receive_blockwise(coap_receive_ctx_t *ctx, const char *href,
+                       size_t href_len, const oc_endpoint_t *endpoint)
 {
-  assert(ctx->request->code >= COAP_GET && ctx->request->code <= COAP_DELETE);
-
   // block1 and block2 options are expected to be used with UDP protocol
   if (ctx->block1.enabled &&
       // block1 is expected only for POST/PUT requests
@@ -504,14 +502,27 @@ coap_receive_method_payload(coap_receive_ctx_t *ctx, const char *href,
       ctx->request->code == COAP_GET) {
     return coap_receive_blockwise_block2(ctx, href, href_len, endpoint);
   }
+
+  COAP_ERR("unexpected block1 or block2 option(s)");
+  return COAP_RECEIVE_ERROR;
+}
+
+static coap_receive_status_t
+coap_receive_method_payload(coap_receive_ctx_t *ctx, const char *href,
+                            size_t href_len, const oc_endpoint_t *endpoint)
+{
+  assert(ctx->request->code >= COAP_GET && ctx->request->code <= COAP_DELETE);
+
   if (ctx->block1.enabled || ctx->block2.enabled) {
-    COAP_ERR("unexpected block1 and block2 options");
+    return coap_receive_blockwise(ctx, href, href_len, endpoint);
+  }
+  COAP_DBG("no block options; processing regular request");
+
+  if (!oc_main_initialized()) {
+    COAP_DBG("cannot process new requests during shutdown iotivity-lite stack");
     return COAP_RECEIVE_ERROR;
   }
 
-  COAP_DBG("no block options; processing regular request");
-  const uint8_t *incoming_block;
-  uint32_t incoming_block_len = coap_get_payload(ctx->request, &incoming_block);
 #ifdef OC_SECURITY
   // Drop unsecured (unicast/multicast) requests during reset the device.
   if (oc_reset_in_progress(endpoint->device) &&
@@ -521,11 +532,8 @@ coap_receive_method_payload(coap_receive_ctx_t *ctx, const char *href,
   }
 #endif /* OC_SECURITY */
 
-  if (!oc_main_initialized()) {
-    COAP_DBG("cannot process new requests during shutdown iotivity-lite stack");
-    return COAP_RECEIVE_ERROR;
-  }
-
+  const uint8_t *incoming_block;
+  uint32_t incoming_block_len = coap_get_payload(ctx->request, &incoming_block);
 #ifdef OC_TCP
   bool is_valid_size =
     ((endpoint->flags & TCP) != 0 &&


### PR DESCRIPTION
check if the iotivity-lite stack is initialized before processing new requests during shutdown.

```
#0  0x00007f5052dfa213 in ...
#1  0x00007f505306325f in ...
#2  0x00007f50527d1935 in oc_core_device_handler () from target:/lib/libiotivity-lite-client-server.so.2
#3  0x00007f50527e0fb1 in oc_ri_invoke_coap_entity_handler () from target:/lib/libiotivity-lite-client-server.so.2
#4  0x00007f50527eb799 in coap_receive () from target:/lib/libiotivity-lite-client-server.so.2
#5  0x00007f50527ec5b1 in process_thread_g_coap_engine () from target:/lib/libiotivity-lite-client-server.so.2
#6  0x00007f50527c8bb4 in call_process () from target:/lib/libiotivity-lite-client-server.so.2
#7  0x00007f50527c8f16 in do_event () from target:/lib/libiotivity-lite-client-server.so.2
#8  0x00007f50527c8f36 in oc_process_run () from target:/lib/libiotivity-lite-client-server.so.2
#9  0x00007f50527d8c96 in oc_main_poll () from target:/lib/libiotivity-lite-client-server.so.2
#10 0x00007f50527e26dc in oc_ri_shutdown () from target:/lib/libiotivity-lite-client-server.so.2
#11 0x00007f50527d8cc7 in oc_main_shutdown () from target:/lib/libiotivity-lite-client-server.so.2
```