### PR TITLE
Establish separate cloud connections for each device

### DIFF
--- a/api/cloud/oc_cloud_apis.c
+++ b/api/cloud/oc_cloud_apis.c
@@ -63,6 +63,10 @@ conv_cloud_endpoint(oc_cloud_context_t *ctx)
   int ret = 0;
   if (ctx->cloud_ep != NULL && oc_endpoint_is_empty(ctx->cloud_ep)) {
     ret = oc_string_to_endpoint(&ctx->store.ci_server, ctx->cloud_ep, NULL);
+    if (ret == 0) {
+      // set device id to cloud endpoint for multiple servers
+      ctx->cloud_ep->device = ctx->device;
+    }
 #ifdef OC_DNS_CACHE
     oc_dns_clear_cache();
 #endif /* OC_DNS_CACHE */

--- a/security/oc_tls.c
+++ b/security/oc_tls.c
@@ -2038,7 +2038,7 @@ tls_is_valid_doc(size_t device)
     OC_ERR("oc_tls: DOC not valid: oxmsel not set");
     return false;
   }
-  if (oc_list_length(g_tls_peers) != 0) {
+  if (oc_tls_num_peers(device) != 0) {
     OC_ERR("oc_tls: DOC not valid: multiple DOC peers not allowed");
     /* Allow only a single DOC */
     return false;


### PR DESCRIPTION
Also, handle ownership transfer for the second device when the first device is already connected to the hub. Extend the cloud server to accommodate multiple servers and enhance the check for empty endpoints.

Fixes #531 