### PR TITLE
Extend base64 module

### DIFF
--- a/api/oc_base64.c
+++ b/api/oc_base64.c
@@ -18,50 +18,69 @@
 
 #include "oc_base64.h"
 
+#include <assert.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+
 /* This module implements routines for Base64 encoding/decoding
- * based on their definitions in RFC 4648.
- */
+ * based on their definitions in RFC 4648. */
+
+size_t
+oc_base64_encoded_output_size(size_t size, bool padding)
+{
+  if (padding) {
+    size_t output_size = (size / 3) * 4;
+    if (size % 3 != 0) {
+      output_size += 4;
+    }
+    return output_size;
+  }
+  return (size * 4 + 2) / 3;
+}
 
 int
-oc_base64_encode(const uint8_t *input, size_t input_len, uint8_t *output_buffer,
-                 size_t output_buffer_len)
+oc_base64_encode_v1(oc_base64_encoding_t encoding, bool padding,
+                    const uint8_t *input, size_t input_size,
+                    uint8_t *output_buffer, size_t output_buffer_size)
 {
+  /* handle the case that an empty input is provided */
+  if (input_size == 0) {
+    return 0;
+  }
+
   /* The Base64 alphabet. This table provides a mapping from 6-bit binary
-   * values to Base64 characters.
-   */
-  const uint8_t alphabet[65] = {
+   * values to Base64 characters. */
+  uint8_t alphabet[64] = {
     'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
     'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
     'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
     'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
-    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/', '=',
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/',
   };
+  /** For URLs the '+' and '/' are replaced */
+  if (encoding == OC_BASE64_ENCODING_URL) {
+    alphabet[62] = '-';
+    alphabet[63] = '_';
+  }
 
   /* Calculate the length of the Base64 encoded output.
    * Every sequence of 3 bytes (with padding, if necessary)
    * is represented as 4 bytes (characters) in Base64.
    */
-  size_t output_len = (input_len / 3) * 4;
-  if (input_len % 3 != 0) {
-    output_len += 4;
-  }
-
+  size_t output_len = oc_base64_encoded_output_size(input_size, padding);
   /* If the output buffer provided was not large enough, return an error. */
-  if (output_buffer_len < output_len) {
+  if (output_buffer_size < output_len) {
     return -1;
   }
 
-  /* handle the case that an empty input is provided */
-  if (input_len == 0) {
-    output_buffer[0] = '\0';
-  }
   size_t i;
   int j = 0;
   uint8_t val = 0;
   /* Process every byte of input by keeping state across 3 byte blocks
    * to capture 4 6-bit binary blocks that each map to a Base64 character.
    */
-  for (i = 0; i < input_len; i++) {
+  for (i = 0; i < input_size; i++) {
     /* This is the first byte of a 3 byte block of input. Its first
      * 6 bits would be encoded into a character from the Base64 alphabet.
      * Its last 2 bits would be the first 2 bits of the following 6-bit binary
@@ -102,72 +121,139 @@ oc_base64_encode(const uint8_t *input, size_t input_len, uint8_t *output_buffer,
     }
   }
 
-  /* If the input size wasn't a multiple of 3, we would
-   * have leftover bits to encode into the next Base64 character.
-   */
+  /* If the input size wasn't a multiple of 3, we would have leftover bits to
+   * encode into the next Base64 character. */
   if (i % 3 != 0) {
     output_buffer[j++] = alphabet[val];
   }
 
-  /* Any leftover space in the encoded string is padded with the
-   * = character.
-   */
+  if (!padding) {
+    assert(j == (int)output_len);
+    return j;
+  }
+
+  /* Any leftover space in the encoded string is padded with the '='
+   * character.*/
   while (j < (int)output_len) {
     output_buffer[j++] = '=';
   }
-
   return j;
 }
 
 int
-oc_base64_decode(uint8_t *str, size_t len)
+oc_base64_encode(const uint8_t *input, size_t input_size,
+                 uint8_t *output_buffer, size_t output_buffer_size)
 {
-  /* All valid Base64 encoded strings will be multiples of 4 */
-  if (0 != (len % 4)) {
+  return oc_base64_encode_v1(OC_BASE64_ENCODING_STD, true, input, input_size,
+                             output_buffer, output_buffer_size);
+}
+
+static int
+base64_decode_char(oc_base64_encoding_t encoding, unsigned char c)
+{
+  if (c >= 'A' && c <= 'Z') {
+    return c - 65;
+  }
+  if (c >= 'a' && c <= 'z') {
+    return c - 71;
+  }
+  if (c >= '0' && c <= '9') {
+    return c + 4;
+  }
+  if (encoding == OC_BASE64_ENCODING_STD) {
+    if (c == '+') {
+      return 62;
+    }
+    if (c == '/') {
+      return 63;
+    }
+  } else {
+    if (c == '-') {
+      return 62;
+    }
+    if (c == '_') {
+      return 63;
+    }
+  }
+  return -1;
+}
+
+int
+oc_base64_decoded_output_size(const uint8_t *input, size_t input_size,
+                              bool padding)
+{
+  if (input_size == 0) {
+    return 0;
+  }
+
+  size_t padding_count = 0;
+  if (padding) {
+    /* All valid padded Base64 encoded strings will be multiples of 4 */
+    if (input_size % 4 != 0) {
+      return -1;
+    }
+    for (size_t i = input_size - 2; i < input_size; ++i) {
+      if (input[i] == '=') {
+        ++padding_count;
+      }
+    }
+  } else {
+    /* All valid non-padded Base64 encoded strings will be multiples of 4, or
+     * would be multiples of 4 with 1 or 2 padding characters, missing 3 padding
+     * characters is invalid */
+    if (input_size % 4 == 1) {
+      return -1;
+    }
+    // simulate valid padding for the calculation
+    padding_count = (input_size % 4) != 0 ? 4 - (input_size % 4) : 0;
+    input_size += padding_count;
+  }
+
+  size_t output_size = (input_size * 3) / 4 - padding_count;
+  assert(output_size <= INT_MAX);
+  return (int)output_size;
+}
+
+int
+oc_base64_decode_v1(oc_base64_encoding_t encoding, bool padding,
+                    const uint8_t *input, size_t input_size,
+                    uint8_t *output_buffer, size_t output_buffer_size)
+{
+  /* Check if the output buffer is large enough */
+  int size = oc_base64_decoded_output_size(input, input_size, padding);
+  if (size < 0 || output_buffer_size < (size_t)size) {
     return -1;
   }
+
   /* The Base64 input string is decoded in-place. */
-  size_t i = 0;
   int j = 0;
   unsigned char val_c = 0;
   unsigned char val_s = 0;
 
   /* Process every input character */
-  for (i = 0; i < len; i++) {
-    val_s = str[i];
+  for (size_t i = 0; i < input_size; i++) {
+    val_s = input[i];
 
-    /* Perform a reverse-mapping from Base64 character to
-     * a 6-bit binary sequence.
-     */
-    if (val_s >= 'A' && val_s <= 'Z')
-      val_s -= 65;
-    else if (val_s >= 'a' && val_s <= 'z')
-      val_s -= 71;
-    else if (val_s >= '0' && val_s <= '9')
-      val_s += 4;
-    else if (val_s == '+')
-      val_s = 62;
-    else if (val_s == '/')
-      val_s = 63;
     /* Break if we encounter the padding character.
      * The input buffer str now contains the fully decoded string.
      */
-    else if (val_s == '=') {
+    if (padding && val_s == '=') {
       /* Padding character "=" can only show up as last 2 characters */
-      if (i < len - 2) {
+      if (i < input_size - 2) {
         return -1;
       }
-      if (i == len - 2 && '=' != str[i + 1]) {
+      if (i == input_size - 2 && '=' != input[i + 1]) {
         return -1;
       }
       break;
     }
-    /* Return an error if we encounter a character that is outside
-     * of the Base64 alphabet.
-     */
-    else {
+
+    /* Convert the Base64 character to its 6-bit binary value */
+    int val = base64_decode_char(encoding, val_s);
+    if (val < 0) {
       return -1;
     }
+    val_s = (unsigned char)val;
 
     /* Decode all 4 byte blocks to 3 bytes of binary output by
      * laying out their 6-bit blocks into a sequence of 3 bytes.
@@ -179,26 +265,37 @@ oc_base64_decode(uint8_t *str, size_t len)
     } else if (i % 4 == 1) {
       /* Last 2 bits of output byte 1 */
       val_c |= (val_s >> 4);
-      str[j++] = val_c;
+      output_buffer[j++] = val_c;
       /* 1st 4 bits of output byte 2 */
       val_c = (uint8_t)(val_s << 4);
       val_c &= 0xF0;
     } else if (i % 4 == 2) {
       /* Last 4 bits of output byte 2 */
       val_c |= (val_s >> 2);
-      str[j++] = val_c;
+      output_buffer[j++] = val_c;
       /* 1st 2 bits of output byte 3 */
       val_c = (uint8_t)(val_s << 6);
       val_c &= 0xD0;
     } else {
       /* Last 6 bits of output byte 3 */
       val_c |= val_s;
-      str[j++] = val_c;
+      output_buffer[j++] = val_c;
     }
   }
 
+  return j;
+}
+
+int
+oc_base64_decode(uint8_t *str, size_t len)
+{
+  int j = oc_base64_decode_v1(OC_BASE64_ENCODING_STD, true, str, len, str, len);
+  if (j < 0) {
+    return j;
+  }
+
   /* zero out the remaining bytes */
-  for (i = j; i < len; i++) {
+  for (size_t i = j; i < len; i++) {
     str[i] = 0;
   }
 

--- a/api/unittest/base64test.cpp
+++ b/api/unittest/base64test.cpp
@@ -17,6 +17,7 @@
  ******************************************************************/
 
 #include "oc_base64.h"
+#include "oc_helpers.h"
 
 #include <algorithm>
 #include <array>
@@ -68,49 +69,44 @@ TEST(B64Test, RFC4648_EncodeFail)
   });
 }
 
+TEST(B64Test, RFC4648_EncodeV1Fail)
+{
+  std::vector<std::string> inputs = {
+    "foo",
+    "foobar",
+  };
+
+  std::for_each(inputs.begin(), inputs.end(), [](const std::string &str) {
+    auto toEncode = fromString<uint8_t>(str);
+    EXPECT_EQ(-1,
+              oc_base64_encode_v1(OC_BASE64_ENCODING_STD, true, toEncode.data(),
+                                  toEncode.size(), nullptr, 0));
+    EXPECT_EQ(-1, oc_base64_encode_v1(OC_BASE64_ENCODING_STD, false,
+                                      toEncode.data(), toEncode.size(), nullptr,
+                                      0));
+    EXPECT_EQ(-1,
+              oc_base64_encode_v1(OC_BASE64_ENCODING_URL, true, toEncode.data(),
+                                  toEncode.size(), nullptr, 0));
+    EXPECT_EQ(-1, oc_base64_encode_v1(OC_BASE64_ENCODING_URL, false,
+                                      toEncode.data(), toEncode.size(), nullptr,
+                                      0));
+  });
+}
+
 /*
  * Expected input and output comes from section 10 of RFC4648
  */
 TEST(B64Test, RFC4648_EncodeTestVectors)
 {
-  // clang-format off
-  std::vector<std::string> input =
-  {
-    "",
-    "f",
-    "fo",
-    "foo",
-    "foob",
-    "fooba",
-    "foobar",
+  std::vector<std::string> input = {
+    "", "f", "fo", "foo", "foob", "fooba", "foobar",
   };
 
-  std::vector<std::string> output =
-  {
-    "",
-    "Zg==",
-    "Zm8=",
-    "Zm9v",
-    "Zm9vYg==",
-    "Zm9vYmE=",
-    "Zm9vYmFy",
+  std::vector<std::string> output = {
+    "", "Zg==", "Zm8=", "Zm9v", "Zm9vYg==", "Zm9vYmE=", "Zm9vYmFy",
   };
-
-  std::vector<size_t> expectedOutputLenth =
-  {
-    0,
-    4,
-    4,
-    4,
-    8,
-    8,
-    8,
-  };
-  // clang-format on
 
   ASSERT_EQ(input.size(), output.size())
-    << "Input test data and output test data missmatch.";
-  ASSERT_EQ(input.size(), expectedOutputLenth.size())
     << "Input test data and output test data missmatch.";
 
   std::array<uint8_t, 64> buf{};
@@ -126,50 +122,115 @@ TEST(B64Test, RFC4648_EncodeTestVectors)
     EXPECT_STREQ(output[i].c_str(), str.c_str())
       << "Failed to Base64 encode \"" << input[i] << "\" to \"" << output[i]
       << "\"";
-    EXPECT_EQ(expectedOutputLenth[i], outputLength);
+    EXPECT_EQ(output[i].length(), outputLength);
+  }
+}
+
+static std::vector<uint8_t>
+hexConvert(const std::string &input)
+{
+  std::vector<uint8_t> buf{};
+  buf.resize(input.length());
+  size_t bufLen = buf.size();
+  if (oc_conv_hex_string_to_byte_array(input.c_str(), input.length(),
+                                       buf.data(), &bufLen) != 0) {
+    throw std::string("Failed to convert hex string to byte array");
+  }
+  buf.resize(bufLen);
+  return buf;
+}
+
+TEST(B64Test, RFC4648_EncodeV1TestVectors)
+{
+  std::vector<std::vector<uint8_t>> input = {
+    {},
+    hexConvert("D"),
+    hexConvert("FF"),
+    hexConvert("123"),
+    hexConvert("F8F9"),
+    hexConvert("BCDEFF"),
+    hexConvert("FEFDCDEFF"),
+  };
+
+  std::vector<std::string> output = {
+    "", "DQ==", "/w==", "ASM=", "+Pk=", "vN7/", "D+/c3v8=",
+  };
+
+  std::vector<std::string> urlOutput = {
+    "", "DQ==", "_w==", "ASM=", "-Pk=", "vN7_", "D-_c3v8=",
+  };
+
+  ASSERT_EQ(input.size(), output.size())
+    << "Input test data and output test data missmatch.";
+  ASSERT_EQ(input.size(), urlOutput.size())
+    << "Input test data and URL output test data missmatch.";
+
+  std::array<uint8_t, 64> buf{};
+  for (size_t i = 0; i < input.size(); ++i) {
+    auto toEncode = input[i];
+    int outputLength =
+      oc_base64_encode_v1(OC_BASE64_ENCODING_STD, true, toEncode.data(),
+                          toEncode.size(), buf.data(), buf.size() - 1);
+    ASSERT_NE(-1, outputLength);
+    EXPECT_EQ(output[i].length(), outputLength);
+    auto str = toString(buf.data(), outputLength);
+    EXPECT_STREQ(output[i].c_str(), str.c_str());
+
+    outputLength =
+      oc_base64_encode_v1(OC_BASE64_ENCODING_STD, false, toEncode.data(),
+                          toEncode.size(), buf.data(), buf.size() - 1);
+    ASSERT_NE(-1, outputLength);
+    std::string expOutput = output[i];
+    // remove padding
+    expOutput.erase(std::remove(expOutput.begin(), expOutput.end(), '='),
+                    expOutput.end());
+    EXPECT_EQ(expOutput.length(), outputLength);
+    str = toString(buf.data(), outputLength);
+    EXPECT_STREQ(expOutput.c_str(), str.c_str());
+
+    outputLength =
+      oc_base64_encode_v1(OC_BASE64_ENCODING_URL, true, toEncode.data(),
+                          toEncode.size(), buf.data(), buf.size() - 1);
+    ASSERT_NE(-1, outputLength);
+    EXPECT_EQ(urlOutput[i].length(), outputLength);
+    str = toString(buf.data(), outputLength);
+    EXPECT_STREQ(urlOutput[i].c_str(), str.c_str());
+  }
+}
+
+TEST(B64Test, RFC4648_EncodeCalculateSize)
+{
+  std::vector<std::string> input = {
+    "", "f", "fo", "foo", "foob", "fooba", "foobar",
+  };
+  std::vector<std::string> output = {
+    "", "Zg==", "Zm8=", "Zm9v", "Zm9vYg==", "Zm9vYmE=", "Zm9vYmFy",
+  };
+  ASSERT_EQ(input.size(), output.size())
+    << "Input test data and output test data missmatch.";
+
+  for (size_t i = 0; i < input.size(); ++i) {
+    auto toEncode = fromString<uint8_t>(input[i]);
+    size_t outputLength = oc_base64_encoded_output_size(toEncode.size(), true);
+    EXPECT_EQ(output[i].length(), outputLength);
+    outputLength = oc_base64_encoded_output_size(toEncode.size(), false);
+    std::string expOutput = output[i];
+    // remove padding
+    expOutput.erase(std::remove(expOutput.begin(), expOutput.end(), '='),
+                    expOutput.end());
+    EXPECT_EQ(expOutput.length(), outputLength);
   }
 }
 
 TEST(B64Test, RFC4648_DecodeTestVectors)
 {
-  // clang-format off
-  std::vector<std::string> input =
-  {
-    "",
-    "Zg==",
-    "Zm8=",
-    "Zm9v",
-    "Zm9vYg==",
-    "Zm9vYmE=",
-    "Zm9vYmFy"
+  std::vector<std::string> input = {
+    "", "Zg==", "Zm8=", "Zm9v", "Zm9vYg==", "Zm9vYmE=", "Zm9vYmFy",
   };
-
-  std::vector<std::string> output =
-  {
-    "",
-    "f",
-    "fo",
-    "foo",
-    "foob",
-    "fooba",
-    "foobar"
+  std::vector<std::string> output = {
+    "", "f", "fo", "foo", "foob", "fooba", "foobar",
   };
-
-  std::vector<size_t> expectedOutputLenth =
-  {
-    0,
-    1,
-    2,
-    3,
-    4,
-    5,
-    6
-  };
-  // clang-format on
-
   ASSERT_EQ(input.size(), output.size())
-    << "Input test data and output test data missmatch.";
-  ASSERT_EQ(input.size(), expectedOutputLenth.size())
     << "Input test data and output test data missmatch.";
 
   std::array<uint8_t, 64> buf{};
@@ -180,7 +241,7 @@ TEST(B64Test, RFC4648_DecodeTestVectors)
     int outputLength = oc_base64_decode(buf.data(), bufLen);
     EXPECT_NE(-1, outputLength) << "Failed to Base64 decode \"" << input[i]
                                 << "\" to \"" << output[i] << "\"";
-    EXPECT_EQ(expectedOutputLenth[i], outputLength);
+    EXPECT_EQ(output[i].length(), outputLength);
     auto str = toString(buf.data(), outputLength);
     EXPECT_STREQ(output[i].c_str(), str.c_str())
       << "Failed to Base64 decode \"" << input[i] << "\" to \"" << output[i]
@@ -188,15 +249,148 @@ TEST(B64Test, RFC4648_DecodeTestVectors)
   }
 }
 
+TEST(B64Test, RFC4648_DecodeV1TestStdVectors)
+{
+  std::vector<std::string> input = {
+    "", "DQ==", "/w==", "ASM=", "+Pk=", "vN7/", "D+/c3v8=",
+  };
+
+  std::vector<std::vector<uint8_t>> output = {
+    {},
+    hexConvert("D"),
+    hexConvert("FF"),
+    hexConvert("123"),
+    hexConvert("F8F9"),
+    hexConvert("BCDEFF"),
+    hexConvert("FEFDCDEFF"),
+  };
+
+  ASSERT_EQ(input.size(), output.size())
+    << "Input test data and output test data missmatch.";
+
+  std::array<uint8_t, 64> buf{};
+  for (size_t i = 0; i < input.size(); ++i) {
+    auto toDecode = fromString<uint8_t>(input[i]);
+    int outputLength =
+      oc_base64_decode_v1(OC_BASE64_ENCODING_STD, true, toDecode.data(),
+                          toDecode.size(), buf.data(), buf.size());
+    EXPECT_NE(-1, outputLength);
+    EXPECT_EQ(output[i].size(), outputLength);
+    EXPECT_EQ(output[i].size(), oc_base64_decoded_output_size(
+                                  toDecode.data(), toDecode.size(), true));
+    auto str1 = toString(buf.data(), outputLength);
+    auto str2 = toString(output[i].data(), output[i].size());
+    EXPECT_STREQ(str2.c_str(), str1.c_str());
+  }
+}
+
+TEST(B64Test, RFC4648_DecodeV1TestUrlVectors)
+{
+  std::vector<std::string> input = {
+    "", "DQ==", "_w==", "ASM=", "-Pk=", "vN7_", "D-_c3v8=",
+  };
+
+  std::vector<std::vector<uint8_t>> output = {
+    {},
+    hexConvert("D"),
+    hexConvert("FF"),
+    hexConvert("123"),
+    hexConvert("F8F9"),
+    hexConvert("BCDEFF"),
+    hexConvert("FEFDCDEFF"),
+  };
+
+  ASSERT_EQ(input.size(), output.size())
+    << "Input test data and output test data missmatch.";
+
+  std::array<uint8_t, 64> buf{};
+  for (size_t i = 0; i < input.size(); ++i) {
+    auto toDecode = fromString<uint8_t>(input[i]);
+    int outputLength =
+      oc_base64_decode_v1(OC_BASE64_ENCODING_URL, true, toDecode.data(),
+                          toDecode.size(), buf.data(), buf.size());
+    EXPECT_NE(-1, outputLength);
+    EXPECT_EQ(output[i].size(), outputLength);
+    EXPECT_EQ(output[i].size(), oc_base64_decoded_output_size(
+                                  toDecode.data(), toDecode.size(), true));
+    auto str1 = toString(buf.data(), outputLength);
+    auto str2 = toString(output[i].data(), output[i].size());
+    EXPECT_STREQ(str2.c_str(), str1.c_str());
+  }
+}
+
+TEST(B64Test, DecodeV1BufferTooSmall)
+{
+  std::vector<std::string> input = {
+    "cA==",     "cGw=",     "cGxn",         "cGxnZA==",
+    "cGxnZC4=", "cGxnZC5k", "cGxnZC5kZQ==", "cGxnZC5kZXY=",
+  };
+  std::vector<std::string> output = {
+    "p", "pl", "plg", "plgd", "plgd.", "plgd.d", "plgd.de", "plgd.dev",
+  };
+  ASSERT_EQ(input.size(), output.size())
+    << "Input test data and output test data missmatch.";
+
+  for (size_t i = 0; i < input.size(); ++i) {
+    auto toDecode = fromString<uint8_t>(input[i]);
+    ASSERT_EQ(output[i].length(), oc_base64_decoded_output_size(
+                                    toDecode.data(), toDecode.size(), true));
+
+    std::vector<uint8_t> buf{};
+    buf.resize(output[i].length() - 1);
+    int outputLength =
+      oc_base64_decode_v1(OC_BASE64_ENCODING_STD, true, toDecode.data(),
+                          toDecode.size(), buf.data(), buf.size());
+    EXPECT_EQ(-1, outputLength);
+    outputLength =
+      oc_base64_decode_v1(OC_BASE64_ENCODING_URL, true, toDecode.data(),
+                          toDecode.size(), buf.data(), buf.size());
+    EXPECT_EQ(-1, outputLength);
+
+    // remove padding
+    toDecode.erase(std::remove(toDecode.begin(), toDecode.end(), '='),
+                   toDecode.end());
+    ASSERT_EQ(output[i].length(), oc_base64_decoded_output_size(
+                                    toDecode.data(), toDecode.size(), false));
+    outputLength =
+      oc_base64_decode_v1(OC_BASE64_ENCODING_STD, false, toDecode.data(),
+                          toDecode.size(), buf.data(), buf.size());
+    EXPECT_EQ(-1, outputLength);
+    outputLength =
+      oc_base64_decode_v1(OC_BASE64_ENCODING_URL, false, toDecode.data(),
+                          toDecode.size(), buf.data(), buf.size());
+    EXPECT_EQ(-1, outputLength);
+  }
+}
+
+TEST(B64Test, DecodeV1InvalidNonPaddedString)
+{
+  std::vector<std::string> inputs = {
+    "A",
+    "AAAAA",
+    "AAAAAAAAA",
+    "AAAAAAAAAAAAA",
+  };
+
+  std::for_each(inputs.begin(), inputs.end(), [&](const std::string &in) {
+    std::array<uint8_t, 64> buf{};
+    auto toDecode = fromString<uint8_t>(in);
+    EXPECT_EQ(-1, oc_base64_decoded_output_size(toDecode.data(),
+                                                toDecode.size(), true));
+    EXPECT_EQ(-1, oc_base64_decode_v1(OC_BASE64_ENCODING_STD, false,
+                                      toDecode.data(), toDecode.size(),
+                                      buf.data(), buf.size()));
+    EXPECT_EQ(-1, oc_base64_decode_v1(OC_BASE64_ENCODING_URL, false,
+                                      toDecode.data(), toDecode.size(),
+                                      buf.data(), buf.size()));
+  });
+}
+
 TEST(B64Test, DecodeInputMissingPadding)
 {
-  // clang-format off
-  std::vector<std::string> input =
-  {
-    "Zg",
-    "Zg="
+  std::vector<std::string> input = {
+    "Zg", "Zg=", "Zm9vYg", "Zm9vYg=", "Zm9vYmE",
   };
-  // clang-format on
 
   std::array<uint8_t, 64> buf{};
   for (size_t i = 0; i < input.size(); ++i) {
@@ -206,6 +400,60 @@ TEST(B64Test, DecodeInputMissingPadding)
     int outputLength = oc_base64_decode(buf.data(), bufLen);
     EXPECT_EQ(-1, outputLength)
       << "Base64 decode for \"" << input[i] << "\" did not fail as expected.";
+  }
+}
+
+TEST(B64Test, DecodeInputV1MissingPadding)
+{
+  std::vector<std::string> inputs = {
+    "Zg", "Zg=", "Zm9vYg", "Zm9vYg=", "Zm9vYmE",
+  };
+
+  // when padding is expected in the output the decoding should fail
+  std::for_each(inputs.begin(), inputs.end(), [&](const std::string &in) {
+    auto toDecode = fromString<uint8_t>(in);
+    std::array<uint8_t, 64> buf{};
+    int outputLength =
+      oc_base64_decode_v1(OC_BASE64_ENCODING_STD, true, toDecode.data(),
+                          toDecode.size(), buf.data(), buf.size());
+    EXPECT_EQ(-1, outputLength);
+
+    outputLength =
+      oc_base64_decode_v1(OC_BASE64_ENCODING_URL, true, toDecode.data(),
+                          toDecode.size(), buf.data(), buf.size());
+    EXPECT_EQ(-1, outputLength);
+  });
+
+  // when padding is not expected in the output the decoding should succeed
+  inputs = {
+    "Zg",
+    "Zm9vYg",
+    "Zm9vYmE",
+  };
+  std::vector<std::string> outputs = {
+    "f",
+    "foob",
+    "fooba",
+  };
+  ASSERT_EQ(inputs.size(), outputs.size())
+    << "Input test data and output test data missmatch.";
+
+  for (size_t i = 0; i < inputs.size(); ++i) {
+    auto toDecode = fromString<uint8_t>(inputs[i]);
+    std::array<uint8_t, 64> buf{};
+    int outputLength =
+      oc_base64_decode_v1(OC_BASE64_ENCODING_STD, false, toDecode.data(),
+                          toDecode.size(), buf.data(), buf.size());
+    EXPECT_NE(-1, outputLength);
+
+    outputLength =
+      oc_base64_decode_v1(OC_BASE64_ENCODING_URL, false, toDecode.data(),
+                          toDecode.size(), buf.data(), buf.size());
+    EXPECT_NE(-1, outputLength);
+    EXPECT_EQ(outputs[i].length(), outputLength);
+    auto str1 = toString(buf.data(), outputLength);
+    auto str2 = toString(outputs[i].data(), outputs[i].size());
+    EXPECT_STREQ(str2.c_str(), str1.c_str());
   }
 }
 
@@ -220,7 +468,9 @@ TEST(B64Test, DecodeInputInvalidCharacters)
     "-a==",
     "_a==",
     "&a==",
-    "<>=="
+    "<>==",
+    "{a==",
+    "}a==",
   };
   // clang-format on
 
@@ -235,6 +485,54 @@ TEST(B64Test, DecodeInputInvalidCharacters)
   }
 }
 
+TEST(B64Test, DecodeV1InputInvalidStdCharacters)
+{
+  std::vector<std::string> input = {
+    "-a==", "_a==", "&a==", "<>==", "{a==", "}a==",
+  };
+
+  std::for_each(input.begin(), input.end(), [&](const std::string &in) {
+    auto toDecode = fromString<uint8_t>(in);
+    std::array<uint8_t, 64> buf{};
+    int outputLength =
+      oc_base64_decode_v1(OC_BASE64_ENCODING_STD, true, toDecode.data(),
+                          toDecode.size(), buf.data(), buf.size());
+    EXPECT_EQ(-1, outputLength);
+
+    // remove padding
+    toDecode.erase(std::remove(toDecode.begin(), toDecode.end(), '='),
+                   toDecode.end());
+    outputLength =
+      oc_base64_decode_v1(OC_BASE64_ENCODING_STD, false, toDecode.data(),
+                          toDecode.size(), buf.data(), buf.size());
+    EXPECT_EQ(-1, outputLength);
+  });
+}
+
+TEST(B64Test, DecodeV1InputInvalidUrlCharacters)
+{
+  std::vector<std::string> input = {
+    "+a==", "/a==", "&a==", "<>==", "{a==", "}a==",
+  };
+
+  std::for_each(input.begin(), input.end(), [&](const std::string &in) {
+    auto toDecode = fromString<uint8_t>(in);
+    std::array<uint8_t, 64> buf{};
+    int outputLength =
+      oc_base64_decode_v1(OC_BASE64_ENCODING_URL, true, toDecode.data(),
+                          toDecode.size(), buf.data(), buf.size());
+    EXPECT_EQ(-1, outputLength);
+
+    // remove padding
+    toDecode.erase(std::remove(toDecode.begin(), toDecode.end(), '='),
+                   toDecode.end());
+    outputLength =
+      oc_base64_decode_v1(OC_BASE64_ENCODING_URL, false, toDecode.data(),
+                          toDecode.size(), buf.data(), buf.size());
+    EXPECT_EQ(-1, outputLength);
+  });
+}
+
 TEST(B64Test, DecodeInputInvalidPadding)
 {
   // clang-format off
@@ -244,7 +542,7 @@ TEST(B64Test, DecodeInputInvalidPadding)
     "Zm8=Zm8=", // Invalid padding in middle of encoded string
     "Z===", // Invalid padding max padding for Base64 string is two '=='
     "====", // Invalid padding max padding for Base64 string is two '=='
-    "Zm=v" // Invalid padding no characters should follow padding
+    "Zm=v", // Invalid padding no characters should follow padding
   };
   // clang-format on
 
@@ -257,6 +555,37 @@ TEST(B64Test, DecodeInputInvalidPadding)
     EXPECT_EQ(-1, outputLength)
       << "Base64 decode for \"" << input[i] << "\" did not fail as expected.";
   }
+}
+
+TEST(B64Test, DecodeV1InputInvalidPadding)
+{
+  // clang-format off
+  std::vector<std::string> input =
+  {
+    "Zg==Zg==", // Invalid padding in middle of encoded string
+    "Zm8=Zm8=", // Invalid padding in middle of encoded string
+    "Z===", // Invalid padding max padding for Base64 string is two '=='
+    "====", // Invalid padding max padding for Base64 string is two '=='
+    "Zm=v", // Invalid padding no characters should follow padding
+  };
+  // clang-format on
+
+  std::for_each(input.begin(), input.end(), [&](const std::string &in) {
+    auto toDecode = fromString<uint8_t>(in);
+    std::array<uint8_t, 64> buf{};
+    EXPECT_EQ(-1,
+              oc_base64_decode_v1(OC_BASE64_ENCODING_STD, true, toDecode.data(),
+                                  toDecode.size(), buf.data(), buf.size()));
+    EXPECT_EQ(-1, oc_base64_decode_v1(OC_BASE64_ENCODING_STD, false,
+                                      toDecode.data(), toDecode.size(),
+                                      buf.data(), buf.size()));
+    EXPECT_EQ(-1,
+              oc_base64_decode_v1(OC_BASE64_ENCODING_URL, true, toDecode.data(),
+                                  toDecode.size(), buf.data(), buf.size()));
+    EXPECT_EQ(-1, oc_base64_decode_v1(OC_BASE64_ENCODING_URL, false,
+                                      toDecode.data(), toDecode.size(),
+                                      buf.data(), buf.size()));
+  });
 }
 
 /*
@@ -276,34 +605,16 @@ TEST(B64Test, DecodeInputInvalidPadding)
  * The second for loop verifies that adding '\0' to outputLength position in
  * the array will work with the string.
  *
- * For this test to work the first encoded value must be larger than the second.
- * This test is also coded to only expect two values.
+ * For this test to work the first encoded value must be larger than the
+ * second. This test is also coded to only expect two values.
  */
-TEST(B64Test, encoder_does_not_null_terminate)
+TEST(B64Test, EncoderDoesNotNullTerminate)
 {
-  // clang-format off
-  std::vector<std::string> input =
-  {
-    "foobar",
-    "foo"
-  };
+  std::vector<std::string> input = { "foobar", "foo" };
 
-  std::vector<std::string> output =
-  {
-    "Zm9vYmFy",
-    "Zm9v"
-  };
-
-  std::vector<size_t> expectedOutputLenth =
-  {
-    8,
-    4
-  };
-  // clang-format on
+  std::vector<std::string> output = { "Zm9vYmFy", "Zm9v" };
 
   ASSERT_EQ(input.size(), output.size())
-    << "Input test data and output test data missmatch.";
-  ASSERT_EQ(input.size(), expectedOutputLenth.size())
     << "Input test data and output test data missmatch.";
 
   std::array<uint8_t, 64> buf{};
@@ -318,6 +629,7 @@ TEST(B64Test, encoder_does_not_null_terminate)
 
     std::array<char, buf.size()> strBuf;
     std::copy(buf.begin(), buf.end(), strBuf.data());
+    EXPECT_EQ(output[i].length(), outputLength);
     if (i == 0) {
       /* expect to pass on first encode due to zero initialized buf */
       EXPECT_STREQ(output[i].c_str(), strBuf.data())
@@ -329,7 +641,6 @@ TEST(B64Test, encoder_does_not_null_terminate)
         << "Failed to Base64 encode \"" << input[i] << "\" to \"" << output[i]
         << "\"";
     }
-    EXPECT_EQ(expectedOutputLenth[i], outputLength);
   }
 
   for (size_t i = 0; i < input.size(); ++i) {
@@ -340,11 +651,11 @@ TEST(B64Test, encoder_does_not_null_terminate)
                                 << "\" to \"" << output[i] << "\"";
     ASSERT_EQ(0u, outputLength % 4) << "The return size for all b64Encode "
                                        "operations should be a multiple of 4. ";
+    EXPECT_EQ(output[i].length(), outputLength);
     auto str = toString(buf.data(), outputLength);
     EXPECT_STREQ(output[i].c_str(), str.c_str())
       << "Failed to Base64 encode \"" << input[i] << "\" to \"" << output[i]
       << "\"";
-    EXPECT_EQ(expectedOutputLenth[i], outputLength);
   }
 }
 
@@ -377,4 +688,34 @@ TEST(B64Test, EncodeThenDecode)
   EXPECT_EQ(toEncode.size(), outputLength);
   auto str = toString(b64Buf.data(), outputLength);
   EXPECT_STREQ(input.c_str(), str.c_str());
+}
+
+TEST(B64Test, EncodeV1ThenDecodeV1)
+{
+  auto test = [](oc_base64_encoding_t enc, bool padding) {
+    std::string input = "This is a string that will be passed into  the Base64 "
+                        "encoder.  After it is encoded the encoded result will "
+                        "be passed into the Base64 decoded and the result will "
+                        "be checked with the original input to make sure the "
+                        "round trip results are as expected.";
+    auto toEncode = fromString<uint8_t>(input, true);
+    size_t b64BufSize = oc_base64_encoded_output_size(toEncode.size(), padding);
+    std::vector<uint8_t> b64Buf(b64BufSize, '\0');
+
+    int outputLength =
+      oc_base64_encode_v1(enc, padding, toEncode.data(), toEncode.size(),
+                          b64Buf.data(), b64Buf.size());
+    ASSERT_NE(-1, outputLength);
+    outputLength = oc_base64_decode_v1(
+      enc, padding, b64Buf.data(), outputLength, b64Buf.data(), b64Buf.size());
+    ASSERT_NE(-1, outputLength);
+    EXPECT_EQ(toEncode.size(), outputLength);
+    auto str = toString(b64Buf.data(), outputLength);
+    EXPECT_STREQ(input.c_str(), str.c_str());
+  };
+
+  test(OC_BASE64_ENCODING_STD, true);
+  test(OC_BASE64_ENCODING_STD, false);
+  test(OC_BASE64_ENCODING_URL, true);
+  test(OC_BASE64_ENCODING_URL, false);
 }

--- a/include/oc_base64.h
+++ b/include/oc_base64.h
@@ -21,7 +21,9 @@
 #ifndef OC_BASE64_H
 #define OC_BASE64_H
 
+#include "oc_export.h"
 #include "util/oc_compiler.h"
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -30,7 +32,7 @@ extern "C" {
 #endif
 
 /**
- * encode byte buffer to base64 string. The base64 encoder does not NUL
+ * Encode byte buffer to base64 string. The base64 encoder does not NUL
  * terminate its output. User the return value to add '\0' to the end of the
  * string.
  *
@@ -54,17 +56,18 @@ extern "C" {
  *    // append NUL character to end of string.
  *    b64Buf[output_len] = '\0';
  *
- * @param[in]  input pointer to input byte array to be encoded
- * @param[in]  input_len size of input byte array
+ * @param[in] input pointer to input byte array to be encoded
+ * @param[in] input_size size of input byte array
  * @param[out] output_buffer buffer to hold the base 64 encoded string
- * @param[in]  output_buffer_len size of the output_buffer
+ * @param[in] output_buffer_size size of the output_buffer
  *
  * @return
  *    - the size of the base64 encoded string
  *    - `-1` if the output buffer provided was not large enough
  */
-int oc_base64_encode(const uint8_t *input, size_t input_len,
-                     uint8_t *output_buffer, size_t output_buffer_len);
+OC_API
+int oc_base64_encode(const uint8_t *input, size_t input_size,
+                     uint8_t *output_buffer, size_t output_buffer_size);
 
 /**
  * In place decoding of base 64 string. Size of a base 64 input string will
@@ -84,7 +87,81 @@ int oc_base64_encode(const uint8_t *input, size_t input_len,
  *   - '-1' if unable to decode string. This should only happen if the string
  *     is not a properly encoded base64 string.
  */
+OC_API
 int oc_base64_decode(uint8_t *str, size_t len);
+
+typedef enum {
+  OC_BASE64_ENCODING_STD, // encode using standard base64 encoding
+  OC_BASE64_ENCODING_URL, // encode using URL safe base64 encoding
+} oc_base64_encoding_t;
+
+/**
+ * Calculate the size of the output buffer required to encode a byte array to
+ * base64.
+ *
+ * @param size size of the input byte array
+ * @param padding true if padding should be used
+ *
+ * @return size of the output buffer required to encode the input byte array
+ */
+OC_API
+size_t oc_base64_encoded_output_size(size_t size, bool padding);
+
+/**
+ * Encode byte buffer to base64 string. The base64 encoder does not NUL
+ * terminate its output. User the return value to add '\0' to the end of the
+ * string.
+ *
+ * @param encoding type of encoding to use
+ * @param padding true if padding should be used
+ * @param input pointer to input byte array to be encoded
+ * @param input_size size of input byte array
+ * @param[out] output_buffer buffer to hold the base 64 encoded string
+ * @param output_buffer_size size of the output_buffer
+ *
+ * @return
+ *    - the size of the base64 encoded string
+ *    - `-1` if the output buffer provided was not large enough
+ */
+OC_API
+int oc_base64_encode_v1(oc_base64_encoding_t encoding, bool padding,
+                        const uint8_t *input, size_t input_size,
+                        uint8_t *output_buffer, size_t output_buffer_size);
+
+/**
+ * Calculate the size of the output buffer required to store a decoded base64
+ * array.
+ *
+ * @param input input base64-encoded array
+ * @param input_size size of the input base64-encoded array
+ * @param padding true if the input array is padded with '=' characters at the
+ * end
+ *
+ * @return -1 if the input array is not a valid base64-encoded array
+ * @return size of the output buffer required to decode the input array
+ */
+OC_API
+int oc_base64_decoded_output_size(const uint8_t *input, size_t input_size,
+                                  bool padding);
+
+/**
+ * Decode a base64 array to a byte array.
+ *
+ * @param encoding type of encoding to use
+ * @param padding true if the input array is padded with '=' characters at the
+ * end
+ * @param input pointer to base64 encoded string
+ * @param input_size size of base64 encoded string
+ * @param[out] output_buffer buffer to hold the decoded byte array
+ * @param output_buffer_size size of the output_buffer
+ *
+ * @return -1 on failure
+ * @return >=0 the size of the decoded byte array on success
+ */
+OC_API
+int oc_base64_decode_v1(oc_base64_encoding_t encoding, bool padding,
+                        const uint8_t *input, size_t input_size,
+                        uint8_t *output_buffer, size_t output_buffer_size);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Extended the base64 to support encoding and decoding:
  - using URL-safe characters
  - with and without padding '=' at the end