### PR TITLE
Configure IPv4 multicast ttl for discovery

### DIFF
--- a/port/linux/ipadapter.c
+++ b/port/linux/ipadapter.c
@@ -1181,6 +1181,12 @@ send_ipv4_discovery_request(oc_message_t *message,
     OC_ERR("setting socket option for default IP_MULTICAST_IF: %d", (int)errno);
     return SEND_DISCOVERY_ERROR;
   }
+  int ttl = OC_IPV4_MULTICAST_TTL;
+  if (setsockopt(server_sock, IPPROTO_IP, IP_MULTICAST_TTL, &ttl,
+                 sizeof(int)) == -1) {
+    OC_ERR("setting socket option for default IP_MULTICAST_TTL: %d", errno);
+    return SEND_DISCOVERY_ERROR;
+  }
   unsigned if_index = if_nametoindex(interface->ifa_name);
   if (if_index == 0) {
     OC_ERR("could not get interface index for %s (error: %d)",

--- a/port/linux/oc_config.h
+++ b/port/linux/oc_config.h
@@ -27,6 +27,8 @@ typedef uint64_t oc_clock_time_t;
 
 /* Maximum wait time for select function */
 #define SELECT_TIMEOUT_SEC (1)
+/* Time-to-live value of outgoing multicast packets */
+#define OC_IPV4_MULTICAST_TTL (1)
 
 /* Add support for passing network up/down events to the app */
 #define OC_NETWORK_MONITOR

--- a/port/windows/ipadapter.c
+++ b/port/windows/ipadapter.c
@@ -1229,7 +1229,7 @@ oc_send_discovery_request(oc_message_t *message)
       }
       DWORD ttl = OC_IPV4_MULTICAST_TTL;
       if (setsockopt(dev->server4_sock, IPPROTO_IP, IP_MULTICAST_TTL,
-                     (char*)&ttl, sizeof(DWORD)) == -1) {
+                     (char *)&ttl, sizeof(DWORD)) == -1) {
         OC_ERR("setting socket option for default IP_MULTICAST_TTL: %d",
                WSAGetLastError());
         goto done;

--- a/port/windows/ipadapter.c
+++ b/port/windows/ipadapter.c
@@ -1227,9 +1227,9 @@ oc_send_discovery_request(oc_message_t *message)
                WSAGetLastError());
         goto done;
       }
-      int ttl = OC_IPV4_MULTICAST_TTL;
-      if (setsockopt(server_sock, IPPROTO_IP, IP_MULTICAST_TTL, &ttl,
-                     sizeof(int)) == -1) {
+      DWORD ttl = OC_IPV4_MULTICAST_TTL;
+      if (setsockopt(dev->server4_sock, IPPROTO_IP, IP_MULTICAST_TTL, (char*)&ttl),
+                     sizeof(DWORD)) == -1) {
         OC_ERR("setting socket option for default IP_MULTICAST_TTL: %d",
                WSAGetLastError());
         goto done;

--- a/port/windows/ipadapter.c
+++ b/port/windows/ipadapter.c
@@ -1228,8 +1228,8 @@ oc_send_discovery_request(oc_message_t *message)
         goto done;
       }
       DWORD ttl = OC_IPV4_MULTICAST_TTL;
-      if (setsockopt(dev->server4_sock, IPPROTO_IP, IP_MULTICAST_TTL, (char*)&ttl,
-                     sizeof(DWORD)) == -1) {
+      if (setsockopt(dev->server4_sock, IPPROTO_IP, IP_MULTICAST_TTL,
+                     (char*)&ttl, sizeof(DWORD)) == -1) {
         OC_ERR("setting socket option for default IP_MULTICAST_TTL: %d",
                WSAGetLastError());
         goto done;

--- a/port/windows/ipadapter.c
+++ b/port/windows/ipadapter.c
@@ -1227,6 +1227,13 @@ oc_send_discovery_request(oc_message_t *message)
                WSAGetLastError());
         goto done;
       }
+      int ttl = OC_IPV4_MULTICAST_TTL;
+      if (setsockopt(server_sock, IPPROTO_IP, IP_MULTICAST_TTL, &ttl,
+                     sizeof(int)) == -1) {
+        OC_ERR("setting socket option for default IP_MULTICAST_TTL: %d",
+               WSAGetLastError());
+        goto done;
+      }
       message->endpoint.interface_index = ifaddr->if_index;
       memcpy(message->endpoint.addr_local.ipv4.address,
              &addr->sin_addr.S_un.S_addr, 4);

--- a/port/windows/ipadapter.c
+++ b/port/windows/ipadapter.c
@@ -1228,7 +1228,7 @@ oc_send_discovery_request(oc_message_t *message)
         goto done;
       }
       DWORD ttl = OC_IPV4_MULTICAST_TTL;
-      if (setsockopt(dev->server4_sock, IPPROTO_IP, IP_MULTICAST_TTL, (char*)&ttl),
+      if (setsockopt(dev->server4_sock, IPPROTO_IP, IP_MULTICAST_TTL, (char*)&ttl,
                      sizeof(DWORD)) == -1) {
         OC_ERR("setting socket option for default IP_MULTICAST_TTL: %d",
                WSAGetLastError());

--- a/port/windows/oc_config.h
+++ b/port/windows/oc_config.h
@@ -22,6 +22,9 @@ typedef uint64_t oc_clock_time_t;
 /* jitter added to response to some multicast requests */
 #define OC_MULTICAST_RESPONSE_JITTER_MS (2000)
 
+/* Time-to-live value of outgoing multicast packets */
+#define OC_IPV4_MULTICAST_TTL (1)
+
 /* Security Layer */
 /* Max inactivity timeout before tearing down DTLS connection */
 #define OC_DTLS_INACTIVITY_TIMEOUT (300)


### PR DESCRIPTION
IPv4 resource discovery uses a TTL (time-to-live) value of 1 (system default) for the multicast packets.
This prevents resources from being discovered when there are multiple routers in the local network where resources shall be discovered.

This PR allows to configure the TTL for IPv4 discovery at compile time with a new `OC_IPV4_MULTICAST_TTL` constant added to the `port/<platform>/oc_config.h` header. I have done it this way in order to not need to change the function signatures of the discovery functions.