### PR TITLE
Cloud: Trigger user callback upon cloud manager startup

### DIFF
--- a/api/cloud/oc_cloud.c
+++ b/api/cloud/oc_cloud.c
@@ -72,6 +72,7 @@ start_manager(void *user_data)
   ctx->cloud_ep = oc_new_endpoint();
   ctx->store.status &= ~OC_CLOUD_LOGGED_IN;
   cloud_manager_start(ctx);
+  cloud_manager_cb(ctx);
   return OC_EVENT_DONE;
 }
 


### PR DESCRIPTION
Upon loss of connection, the OC_CLOUD_LOGGED_IN bit is now removed. This implementation ensures that users receive a notification indicating the loss of connection.