### PR TITLE
cloud: add support for multiple servers for a single cloud

### DIFF
--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -52,10 +52,10 @@ jobs:
           - args: "-DOC_TCP_ENABLED=ON"
           # ipv4 on, tcp on
           - args: "-DOC_IPV4_ENABLED=ON -DOC_TCP_ENABLED=ON"
-          # ipv4 on, tcp on, dynamic allocation off
-          - args: "-DOC_IPV4_ENABLED=ON -DOC_TCP_ENABLED=ON -DOC_DYNAMIC_ALLOCATION_ENABLED=OFF"
           # ipv4 on, tcp on, pki off
           - args: "-DOC_IPV4_ENABLED=ON -DOC_TCP_ENABLED=ON -DOC_PKI_ENABLED=OFF"
+          # cloud on (ipv4+tcp on), dynamic allocation off
+          - args: "-DOC_CLOUD_ENABLED=ON -DOC_DYNAMIC_ALLOCATION_ENABLED=OFF"
           # cloud on (ipv4+tcp on), collections create on
           - args: "-DOC_CLOUD_ENABLED=ON -DOC_COLLECTIONS_IF_CREATE_ENABLED=ON"
           # cloud on (ipv4+tcp on), collections create on, custom message buffer size, custom message buffer pool size, custom app data buffer size, custom app data buffer pool size

--- a/.github/workflows/sonar-cloud-analysis.yml
+++ b/.github/workflows/sonar-cloud-analysis.yml
@@ -31,8 +31,8 @@ jobs:
           - build_args: "-DOC_SECURITY_ENABLED=OFF -DOC_IPV4_ENABLED=ON -DOC_COLLECTIONS_IF_CREATE_ENABLED=ON -DOC_PUSH_ENABLED=ON"
           # ipv6 dns on, oscore off, rep realloc on, json encoder on
           - build_args: "-DOC_DNS_LOOKUP_IPV6_ENABLED=ON -DOC_OSCORE_ENABLED=OFF -DOC_REPRESENTATION_REALLOC_ENCODING_ENABLED=ON -DOC_JSON_ENCODER_ENABLED=ON"
-          # ipv4 on, tcp on, dynamic allocation off, rfotm on, push off (because it forces dynamic allocation)
-          - build_args: "-DOC_IPV4_ENABLED=ON -DOC_TCP_ENABLED=ON -DOC_DYNAMIC_ALLOCATION_ENABLED=OFF -DOC_RESOURCE_ACCESS_IN_RFOTM_ENABLED=ON"
+          # cloud (ipv4+tcp) on, dynamic allocation off, rfotm on, push off (because it forces dynamic allocation)
+          - build_args: "-DOC_CLOUD_ENABLED=ON -DOC_DYNAMIC_ALLOCATION_ENABLED=OFF -DOC_RESOURCE_ACCESS_IN_RFOTM_ENABLED=ON"
           # security off, dynamic allocation off, push off (because it forces dynamic allocation), json encoder on
           - build_args: "-DOC_SECURITY_ENABLED=OFF -DOC_DYNAMIC_ALLOCATION_ENABLED=OFF -DOC_JSON_ENCODER_ENABLED=ON"
           # security off, cloud (ipv4+tcp), collection create on, introspection IDD off

--- a/api/client/unittest/clientcbtest.cpp
+++ b/api/client/unittest/clientcbtest.cpp
@@ -259,7 +259,7 @@ TEST_F(TestClientCBWithServer, RemoveAsync)
 
   oc_set_delayed_callback(cb, &oc_client_cb_remove_async, 0);
   EXPECT_TRUE(oc_has_delayed_callback(cb, &oc_client_cb_remove_async, false));
-  oc::TestDevice::PoolEventsMsV1(1s);
+  oc::TestDevice::PoolEventsMsV1(50ms);
 
   EXPECT_FALSE(oc_ri_is_client_cb_valid(cb));
 }
@@ -275,7 +275,7 @@ TEST_F(TestClientCBWithServer, RemoveWithTimeoutAsync)
                              0);
   EXPECT_TRUE(oc_has_delayed_callback(
     cb, &oc_client_cb_remove_with_notify_timeout_async, false));
-  oc::TestDevice::PoolEventsMsV1(1s);
+  oc::TestDevice::PoolEventsMsV1(50ms);
 
   EXPECT_TRUE(TestClientCB::responseHandlerInvoked);
   EXPECT_FALSE(oc_ri_is_client_cb_valid(cb));

--- a/api/cloud/oc_cloud.c
+++ b/api/cloud/oc_cloud.c
@@ -234,7 +234,7 @@ oc_cloud_provision_conf_resource(oc_cloud_context_t *ctx, const char *server,
   oc_cloud_close_endpoint(ctx->cloud_ep);
   memset(ctx->cloud_ep, 0, sizeof(oc_endpoint_t));
   ctx->cloud_ep_state = OC_SESSION_DISCONNECTED;
-  oc_cloud_store_initialize(&ctx->store);
+  oc_cloud_store_reinitialize(&ctx->store);
   cloud_manager_stop(ctx);
   oc_cloud_deregister_stop(ctx);
 
@@ -286,7 +286,7 @@ oc_cloud_update_by_resource(oc_cloud_context_t *ctx,
   oc_cloud_close_endpoint(ctx->cloud_ep);
   memset(ctx->cloud_ep, 0, sizeof(oc_endpoint_t));
   ctx->cloud_ep_state = OC_SESSION_DISCONNECTED;
-  oc_cloud_store_initialize(&ctx->store);
+  oc_cloud_store_reinitialize(&ctx->store);
   cloud_manager_stop(ctx);
   oc_cloud_deregister_stop(ctx);
 
@@ -460,7 +460,7 @@ oc_cloud_manager_stop(oc_cloud_context_t *ctx)
   oc_remove_delayed_callback(ctx, start_manager);
   cloud_rd_reset_context(ctx);
   cloud_manager_stop(ctx);
-  oc_cloud_store_initialize(&ctx->store);
+  oc_cloud_store_reinitialize(&ctx->store);
   oc_cloud_close_endpoint(ctx->cloud_ep);
   memset(ctx->cloud_ep, 0, sizeof(oc_endpoint_t));
   ctx->cloud_ep_state = OC_SESSION_DISCONNECTED;

--- a/api/cloud/oc_cloud_access.c
+++ b/api/cloud/oc_cloud_access.c
@@ -148,6 +148,7 @@ void
 cloud_access_deregister_query(const char *uid, const char *access_token,
                               size_t device, oc_string_t *query)
 {
+  assert(uid != NULL);
   assert(query != NULL);
   oc_string_t q_uid;
   oc_concat_strings(&q_uid, "uid=", uid);

--- a/api/cloud/oc_cloud_apis_internal.h
+++ b/api/cloud/oc_cloud_apis_internal.h
@@ -1,0 +1,99 @@
+/****************************************************************************
+ *
+ * Copyright (c) 2019 Intel Corporation
+ * Copyright 2019 Jozef Kralik All Rights Reserved.
+ * Copyright 2018 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"),
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifndef OC_CLOUD_APIS_INTERNAL_H
+#define OC_CLOUD_APIS_INTERNAL_H
+
+#include "api/cloud/oc_cloud_context_internal.h"
+#include "oc_cloud.h"
+#include "oc_cloud_access.h"
+#include "oc_endpoint.h"
+#include "util/oc_compiler.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct
+{
+  oc_cloud_context_t *ctx;
+  oc_cloud_cb_t cb;
+  void *data;
+  uint16_t timeout;
+} cloud_api_param_t;
+
+/** @brief Allocate and initialize cloud API parameter */
+cloud_api_param_t *oc_cloud_api_new_param(oc_cloud_context_t *ctx,
+                                          oc_cloud_cb_t cb, void *data,
+                                          uint16_t timeout) OC_NONNULL(1);
+
+/** @brief Free cloud API parameter */
+void oc_cloud_api_free_param(cloud_api_param_t *p) OC_NONNULL();
+
+/**
+ * @brief Set cloud access configuration
+ *
+ * @param ctx cloud context (cannot be NULL)
+ * @param handler the response handler (cannot be NULL)
+ * @param user_data the user data to be conveyed to the response handler
+ * @param timeout the timeout for the request
+ * @param[out] conf cloud access configuration to be set (cannot be NULL)
+ *
+ * @return true on success
+ */
+bool oc_cloud_set_access_conf(oc_cloud_context_t *ctx,
+                              oc_response_handler_t handler, void *user_data,
+                              uint16_t timeout, oc_cloud_access_conf_t *conf)
+  OC_NONNULL(1, 2, 5);
+
+/** Execute cloud sign up */
+int oc_cloud_do_register(oc_cloud_context_t *ctx, oc_cloud_cb_t cb, void *data,
+                         uint16_t timeout) OC_NONNULL(1, 2);
+/** Execute cloud sign in */
+int oc_cloud_do_login(oc_cloud_context_t *ctx, oc_cloud_cb_t cb, void *data,
+                      uint16_t timeout) OC_NONNULL(1, 2);
+/** Execute cloud sign out */
+int oc_cloud_do_logout(oc_cloud_context_t *ctx, oc_cloud_cb_t cb, void *data,
+                       uint16_t timeout) OC_NONNULL(1, 2);
+/** Execute refreshing of the cloud access token */
+int oc_cloud_do_refresh_token(oc_cloud_context_t *ctx, oc_cloud_cb_t cb,
+                              void *data, uint16_t timeout) OC_NONNULL(1, 2);
+
+/**
+ * @brief Send a ping over the cloud connected connection
+ *
+ * @param endpoint endpoint to be used (cannot be NULL)
+ * @param timeout_seconds timeout for the ping
+ * @param handler the response handler (cannot be NULL)
+ * @param user_data the user data to be conveyed to the response handler
+ * @return true on success
+ */
+bool cloud_send_ping(const oc_endpoint_t *endpoint, uint16_t timeout_seconds,
+                     oc_response_handler_t handler, void *user_data)
+  OC_NONNULL(1, 3);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OC_CLOUD_APIS_INTERNAL_H */

--- a/api/cloud/oc_cloud_context.c
+++ b/api/cloud/oc_cloud_context.c
@@ -86,7 +86,6 @@ cloud_context_init(size_t device)
   // remain on the device when the device is shut down during de-registration.
   reinitialize_cloud_storage(ctx);
   ctx->time_to_live = RD_PUBLISH_TTL_UNLIMITED;
-  ctx->cloud_conf = oc_core_get_resource_by_index(OCF_COAPCLOUDCONF, device);
   ctx->cloud_manager = false;
   ctx->keepalive.ping_timeout = 4;
   oc_list_add(g_cloud_context_list, ctx);
@@ -116,6 +115,42 @@ oc_cloud_get_context(size_t device)
     ctx = ctx->next;
   }
   return ctx;
+}
+
+size_t
+oc_cloud_get_device(const oc_cloud_context_t *ctx)
+{
+  return ctx->device;
+}
+
+const char *
+oc_cloud_get_apn(const oc_cloud_context_t *ctx)
+{
+  return oc_string(ctx->store.auth_provider);
+}
+
+const char *
+oc_cloud_get_at(const oc_cloud_context_t *ctx)
+{
+  return oc_string(ctx->store.access_token);
+}
+
+const char *
+oc_cloud_get_cis(const oc_cloud_context_t *ctx)
+{
+  return oc_string(ctx->store.ci_server);
+}
+
+const char *
+oc_cloud_get_sid(const oc_cloud_context_t *ctx)
+{
+  return oc_string(ctx->store.sid);
+}
+
+const char *
+oc_cloud_get_uid(const oc_cloud_context_t *ctx)
+{
+  return oc_string(ctx->store.uid);
 }
 
 void
@@ -165,8 +200,7 @@ cloud_context_size(void)
 bool
 cloud_context_has_access_token(const oc_cloud_context_t *ctx)
 {
-  return oc_string(ctx->store.access_token) != NULL &&
-         oc_string_len(ctx->store.access_token) > 0;
+  return !oc_string_is_empty(&ctx->store.access_token);
 }
 
 bool
@@ -185,8 +219,7 @@ cloud_context_clear_access_token(oc_cloud_context_t *ctx)
 bool
 cloud_context_has_refresh_token(const oc_cloud_context_t *ctx)
 {
-  return oc_string(ctx->store.refresh_token) != NULL &&
-         oc_string_len(ctx->store.refresh_token) > 0;
+  return !oc_string_is_empty(&ctx->store.refresh_token);
 }
 
 void

--- a/api/cloud/oc_cloud_context_internal.h
+++ b/api/cloud/oc_cloud_context_internal.h
@@ -19,6 +19,7 @@
 #ifndef OC_CLOUD_CONTEXT_INTERNAL_H
 #define OC_CLOUD_CONTEXT_INTERNAL_H
 
+#include "api/cloud/oc_cloud_endpoint_internal.h"
 #include "api/cloud/oc_cloud_store_internal.h"
 #include "oc_cloud.h"
 #include "util/oc_compiler.h"
@@ -59,6 +60,15 @@ typedef struct oc_cloud_schedule_action_t
   uint16_t timeout; /**< Timeout for the action in seconds. */
 } oc_cloud_schedule_action_t;
 
+typedef struct
+{
+  uint8_t count;
+  uint8_t refresh_token_count;
+} oc_cloud_retry_t;
+
+/** Reset the retry counters */
+void cloud_retry_reset(oc_cloud_retry_t *retry) OC_NONNULL(1);
+
 struct oc_cloud_context_t
 {
   struct oc_cloud_context_t *next;
@@ -66,6 +76,8 @@ struct oc_cloud_context_t
   size_t device;
   oc_cloud_on_status_change_cb_t on_status_change;
   oc_cloud_store_t store;
+
+  oc_cloud_retry_t retry; /**< Retry configuration */
 
   oc_cloud_keepalive_t keepalive; /**< Keepalive configuration */
   oc_cloud_schedule_action_t
@@ -85,9 +97,6 @@ struct oc_cloud_context_t
   uint32_t time_to_live; /**< Time to live of published resources in seconds */
 
   bool cloud_manager; /**< cloud manager has been started */
-
-  uint8_t retry_count;
-  uint8_t retry_refresh_token_count;
 };
 
 /**

--- a/api/cloud/oc_cloud_deregister_internal.h
+++ b/api/cloud/oc_cloud_deregister_internal.h
@@ -35,6 +35,10 @@ extern "C" {
 /// Error when attempting to multiple deregistrations concurrently
 #define CLOUD_DEREGISTER_ERROR_ALREADY_DEREGISTERING (-2)
 
+/** Check if the access tokens fits inside the deregister request */
+bool oc_cloud_check_accesstoken_for_deregister(const oc_cloud_context_t *ctx)
+  OC_NONNULL();
+
 /**
  * @brief Execute cloud deregister
  *
@@ -55,8 +59,8 @@ extern "C" {
  * being executed for given device
  * @return -1 on other errors
  */
-int cloud_deregister(oc_cloud_context_t *ctx, bool sync, uint16_t timeout,
-                     oc_cloud_cb_t cb, void *data) OC_NONNULL(1);
+int oc_cloud_do_deregister(oc_cloud_context_t *ctx, bool sync, uint16_t timeout,
+                           oc_cloud_cb_t cb, void *data) OC_NONNULL(1);
 
 /**
  * @brief Execute cloud deregister triggered by cloud_reset.
@@ -68,15 +72,15 @@ int cloud_deregister(oc_cloud_context_t *ctx, bool sync, uint16_t timeout,
  * @return true on success
  * @return false on failure
  */
-bool cloud_deregister_on_reset(oc_cloud_context_t *ctx, bool sync,
-                               uint16_t timeout) OC_NONNULL();
+bool oc_cloud_deregister_on_reset(oc_cloud_context_t *ctx, bool sync,
+                                  uint16_t timeout) OC_NONNULL();
 
 /**
  * @brief Clean-up all events by deregister.
  *
  * @param ctx device context (cannot be NULL);
  */
-void cloud_deregister_stop(const oc_cloud_context_t *ctx) OC_NONNULL();
+void oc_cloud_deregister_stop(const oc_cloud_context_t *ctx) OC_NONNULL();
 
 #ifdef __cplusplus
 }

--- a/api/cloud/oc_cloud_endpoint.c
+++ b/api/cloud/oc_cloud_endpoint.c
@@ -1,0 +1,377 @@
+/******************************************************************
+ *
+ * Copyright (c) 2024 plgd.dev s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"),
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************/
+
+#include "oc_cloud_endpoint_internal.h"
+#include "port/oc_log_internal.h"
+#include "util/oc_list.h"
+#include "util/oc_memb.h"
+
+#include <string.h>
+
+// max two endpoint addresses per device with static allocation
+OC_MEMB(g_cloud_endpoint_s, oc_cloud_endpoint_t,
+        OC_CLOUD_MAX_ENDPOINT_ADDRESSES);
+
+static bool
+cloud_endpoint_uri_is_valid(oc_string_view_t uri)
+{
+  return uri.length > 0 && uri.length < OC_ENDPOINT_MAX_ENDPOINT_URI_LENGTH;
+}
+
+static void
+cloud_endpoints_set_selected(oc_cloud_endpoints_t *ce,
+                             const oc_cloud_endpoint_t *selected)
+{
+  if (ce->selected == selected) {
+    return;
+  }
+  ce->selected = selected;
+  if (ce->on_selected_change != NULL) {
+    ce->on_selected_change(ce->on_selected_change_data);
+  }
+}
+
+static oc_cloud_endpoint_t *
+cloud_endpoint_item_allocate_and_add(oc_cloud_endpoints_t *ce,
+                                     oc_string_view_t uri, oc_uuid_t id)
+{
+  if (!cloud_endpoint_uri_is_valid(uri)) {
+    return NULL;
+  }
+
+  oc_cloud_endpoint_t *cei = oc_memb_alloc(&g_cloud_endpoint_s);
+  if (cei == NULL) {
+    return NULL;
+  }
+  oc_new_string(&cei->uri, uri.data, uri.length);
+  if (oc_string(cei->uri) == NULL) {
+    oc_memb_free(&g_cloud_endpoint_s, cei);
+    return NULL;
+  }
+  cei->id = id;
+
+  // automatically select the first endpoint added
+  if (ce->selected == NULL) {
+    assert(oc_list_length(ce->endpoints) == 0);
+    cloud_endpoints_set_selected(ce, cei);
+  }
+
+  oc_list_add(ce->endpoints, cei);
+  return cei;
+}
+
+static void
+cloud_endpoint_item_free(oc_cloud_endpoint_t *cei)
+{
+  oc_free_string(&cei->uri);
+  oc_memb_free(&g_cloud_endpoint_s, cei);
+}
+
+const oc_string_t *
+oc_cloud_endpoint_uri(const oc_cloud_endpoint_t *endpoint)
+{
+  return &endpoint->uri;
+}
+
+void
+oc_cloud_endpoint_set_id(oc_cloud_endpoint_t *ce, oc_uuid_t id)
+{
+  ce->id = id;
+}
+
+oc_uuid_t
+oc_cloud_endpoint_id(const oc_cloud_endpoint_t *ce)
+{
+  return ce->id;
+}
+
+bool
+oc_cloud_endpoints_init(oc_cloud_endpoints_t *ce,
+                        on_selected_change_fn_t on_selected_change,
+                        void *on_selected_change_data,
+                        oc_string_view_t default_uri, oc_uuid_t default_id)
+{
+  memset(ce, 0, sizeof(oc_cloud_endpoints_t));
+  OC_LIST_STRUCT_INIT(ce, endpoints);
+
+  if (default_uri.length > 0) {
+    const oc_cloud_endpoint_t *cei =
+      cloud_endpoint_item_allocate_and_add(ce, default_uri, default_id);
+    if (cei == NULL) {
+      return false;
+    }
+  }
+
+  ce->on_selected_change = on_selected_change;
+  ce->on_selected_change_data = on_selected_change_data;
+  return true;
+}
+
+void
+oc_cloud_endpoints_deinit(oc_cloud_endpoints_t *ce)
+{
+  if (ce->endpoints == NULL) {
+    return;
+  }
+  oc_cloud_endpoint_t *cei = oc_list_pop(ce->endpoints);
+  while (cei != NULL) {
+    cloud_endpoint_item_free(cei);
+    cei = oc_list_pop(ce->endpoints);
+  }
+}
+
+bool
+oc_cloud_endpoints_reinit(oc_cloud_endpoints_t *ce,
+                          oc_string_view_t default_uri, oc_uuid_t default_id)
+{
+  oc_cloud_endpoints_deinit(ce);
+  return oc_cloud_endpoints_init(ce, ce->on_selected_change,
+                                 ce->on_selected_change_data, default_uri,
+                                 default_id);
+}
+
+size_t
+oc_cloud_endpoints_size(const oc_cloud_endpoints_t *ce)
+{
+  return ce->endpoints == NULL ? 0 : oc_list_length(ce->endpoints);
+}
+
+bool
+oc_cloud_endpoints_is_empty(const oc_cloud_endpoints_t *ce)
+{
+  return oc_cloud_endpoints_size(ce) == 0;
+}
+
+void
+oc_cloud_endpoints_iterate(const oc_cloud_endpoints_t *ce,
+                           oc_cloud_endpoints_iterate_fn_t fn, void *data)
+{
+  if (ce->endpoints == NULL) {
+    return;
+  }
+  oc_cloud_endpoint_t *cei = (oc_cloud_endpoint_t *)oc_list_head(ce->endpoints);
+  while (cei != NULL) {
+    oc_cloud_endpoint_t *next = cei->next;
+    if (!fn(cei, data)) {
+      return;
+    }
+    cei = next;
+  }
+}
+
+void
+oc_cloud_endpoints_clear(oc_cloud_endpoints_t *ce)
+{
+  oc_cloud_endpoint_t *cei = oc_list_pop(ce->endpoints);
+  while (cei != NULL) {
+    cloud_endpoint_item_free(cei);
+    cei = oc_list_pop(ce->endpoints);
+  }
+  cloud_endpoints_set_selected(ce, NULL);
+}
+
+typedef struct
+{
+  oc_string_view_t uri;
+  oc_cloud_endpoint_t *found;
+} cloud_endpoint_item_match_t;
+
+static bool
+cloud_endpoint_item_match(oc_cloud_endpoint_t *cei, void *data)
+{
+  cloud_endpoint_item_match_t *match = (cloud_endpoint_item_match_t *)data;
+  if (oc_string_view_is_equal(oc_string_view2(&cei->uri), match->uri)) {
+    match->found = cei;
+    return false;
+  }
+  return true;
+}
+
+oc_cloud_endpoint_t *
+oc_cloud_endpoint_find(const oc_cloud_endpoints_t *ce, oc_string_view_t uri)
+{
+  cloud_endpoint_item_match_t match = {
+    .uri = uri,
+    .found = NULL,
+  };
+  oc_cloud_endpoints_iterate(ce, cloud_endpoint_item_match, &match);
+  return match.found;
+}
+
+bool
+oc_cloud_endpoint_contains(const oc_cloud_endpoints_t *ce, oc_string_view_t uri)
+{
+  if (ce->endpoints == NULL) {
+    return false;
+  }
+  const oc_cloud_endpoint_t *cei =
+    (oc_cloud_endpoint_t *)oc_list_head(ce->endpoints);
+  while (cei != NULL) {
+    if (oc_string_view_is_equal(oc_string_view2(&cei->uri), uri)) {
+      return true;
+    }
+    cei = cei->next;
+  }
+  return false;
+}
+
+oc_cloud_endpoint_t *
+oc_cloud_endpoint_add(oc_cloud_endpoints_t *ce, oc_string_view_t uri,
+                      oc_uuid_t id)
+{
+  if (!cloud_endpoint_uri_is_valid(uri)) {
+    OC_DBG("oc_cloud_endpoint_add: invalid uri(%s)",
+           uri.data != NULL ? uri.data : "null");
+    return NULL;
+  }
+  if (oc_cloud_endpoint_contains(ce, uri)) {
+    OC_DBG("oc_cloud_endpoint_add: uri already exists");
+    return NULL;
+  }
+
+  return cloud_endpoint_item_allocate_and_add(ce, uri, id);
+}
+
+static const oc_cloud_endpoint_t *
+cloud_endpoint_item_next(const oc_cloud_endpoints_t *ce,
+                         const oc_cloud_endpoint_t *item,
+                         const oc_cloud_endpoint_t *item_next)
+{
+  assert(item != NULL);
+  if (item_next != NULL || oc_list_head(ce->endpoints) == item) {
+    return item_next;
+  }
+  return oc_list_head(ce->endpoints);
+}
+
+bool
+oc_cloud_endpoint_remove(oc_cloud_endpoints_t *ce,
+                         const oc_cloud_endpoint_t *ep)
+{
+  const oc_cloud_endpoint_t *ep_next = ep->next;
+  oc_cloud_endpoint_t *found =
+    (oc_cloud_endpoint_t *)oc_list_remove2(ce->endpoints, ep);
+  if (found == NULL) {
+    return false;
+  }
+  if (ce->selected == ep) {
+    cloud_endpoints_set_selected(
+      ce, cloud_endpoint_item_next(ce, ce->selected, ep_next));
+  }
+  cloud_endpoint_item_free(found);
+  return true;
+}
+
+bool
+oc_cloud_endpoint_remove_by_uri(oc_cloud_endpoints_t *ce, oc_string_view_t uri)
+{
+  const oc_cloud_endpoint_t *ep = oc_cloud_endpoint_find(ce, uri);
+  if (ep == NULL) {
+    return false;
+  }
+  return oc_cloud_endpoint_remove(ce, ep);
+}
+
+bool
+oc_cloud_endpoint_select_by_uri(oc_cloud_endpoints_t *ce, oc_string_view_t uri)
+{
+  const oc_cloud_endpoint_t *found = oc_cloud_endpoint_find(ce, uri);
+  if (found == NULL) {
+    return false;
+  }
+  cloud_endpoints_set_selected(ce, found);
+  return true;
+}
+
+bool
+oc_cloud_endpoint_is_selected(const oc_cloud_endpoints_t *ce,
+                              oc_string_view_t uri)
+{
+  return ce->selected != NULL &&
+         oc_string_view_is_equal(oc_string_view2(&ce->selected->uri), uri);
+}
+
+const oc_string_t *
+oc_cloud_endpoint_selected_address(const oc_cloud_endpoints_t *ce)
+{
+  if (ce->selected == NULL) {
+    return NULL;
+  }
+  return &ce->selected->uri;
+}
+
+const oc_uuid_t *
+oc_cloud_endpoint_selected_id(const oc_cloud_endpoints_t *ce)
+{
+  if (ce->selected == NULL) {
+    return NULL;
+  }
+  return &ce->selected->id;
+}
+
+typedef struct
+{
+  CborEncoder *ci_servers;
+  CborError error;
+} cloud_endpoint_encoder_t;
+
+static bool
+cloud_encode_server(oc_cloud_endpoint_t *endpoint, void *data)
+{
+  cloud_endpoint_encoder_t *encoder = (cloud_endpoint_encoder_t *)data;
+  oc_string_view_t uri = oc_string_view2(&endpoint->uri);
+
+  CborEncoder endpoint_map;
+  memset(&endpoint_map, 0, sizeof(endpoint_map));
+  encoder->error |= oc_rep_encoder_create_map(
+    encoder->ci_servers, &endpoint_map, CborIndefiniteLength);
+  oc_rep_object_set_text_string(&endpoint_map, "uri", OC_CHAR_ARRAY_LEN("uri"),
+                                uri.data, uri.length);
+  char sid_str[OC_UUID_LEN] = { 0 };
+  int sid_str_len = oc_uuid_to_str_v1(&endpoint->id, sid_str, OC_UUID_LEN);
+  assert(sid_str_len > 0);
+  oc_rep_object_set_text_string(&endpoint_map, "id", OC_CHAR_ARRAY_LEN("id"),
+                                sid_str, (size_t)sid_str_len);
+
+  encoder->error |=
+    oc_rep_encoder_close_container(encoder->ci_servers, &endpoint_map);
+  return true;
+}
+
+CborError
+oc_cloud_endpoints_encode(CborEncoder *encoder, const oc_cloud_endpoints_t *ce,
+                          oc_string_view_t key, bool skipIfSingleAndSelected)
+{
+  if (oc_cloud_endpoints_size(ce) == 0) {
+    return CborNoError;
+  }
+
+  if (skipIfSingleAndSelected && oc_cloud_endpoints_size(ce) == 1) {
+    // when there is a single element in the list, it should always be selected
+    assert(ce->selected != NULL);
+    return CborNoError;
+  }
+
+  cloud_endpoint_encoder_t enc = { 0 };
+  enc.error = oc_rep_encode_text_string(encoder, key.data, key.length);
+  oc_rep_begin_array(encoder, ci_servers);
+  enc.ci_servers = oc_rep_array(ci_servers);
+  oc_cloud_endpoints_iterate(ce, cloud_encode_server, &enc);
+  oc_rep_end_array(encoder, ci_servers);
+  return enc.error;
+}

--- a/api/cloud/oc_cloud_endpoint_internal.h
+++ b/api/cloud/oc_cloud_endpoint_internal.h
@@ -131,13 +131,22 @@ bool oc_cloud_endpoint_remove_by_uri(oc_cloud_endpoints_t *ce,
  * @brief Select a cloud server endpoint from the list of endpoints
  *
  * @param ce cloud endpoints (cannot be NULL)
- * @param uri cloud endpoint URI to select
+ * @param selected cloud endpoint to select (cannot be NULL, must be in the list
+ * of endpoints)
  *
  * @return true if the endpoint was selected
- * @return false if the endpoint was not found (the previous selection remains)
+ * @return false if the endpoint was not found in the list of endpoints (the
+ * previous selection remains)
  */
+bool oc_cloud_endpoint_select(oc_cloud_endpoints_t *ce,
+                              const oc_cloud_endpoint_t *selected) OC_NONNULL();
+
+/** Select a cloud server endpoint by URI from the list of endpoints */
 bool oc_cloud_endpoint_select_by_uri(oc_cloud_endpoints_t *ce,
                                      oc_string_view_t uri) OC_NONNULL();
+
+/** Select the next cloud server endpoint from the list of endpoints */
+void oc_cloud_endpoint_select_next(oc_cloud_endpoints_t *ce) OC_NONNULL();
 
 /** Check if a cloud server endpoint matching the given URI is selected */
 bool oc_cloud_endpoint_is_selected(const oc_cloud_endpoints_t *ce,

--- a/api/cloud/oc_cloud_endpoint_internal.h
+++ b/api/cloud/oc_cloud_endpoint_internal.h
@@ -1,0 +1,188 @@
+/******************************************************************
+ *
+ * Copyright (c) 2024 plgd.dev s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"),
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************/
+
+#ifndef OC_CLOUD_ENDPOINT_INTERNAL_H
+#define OC_CLOUD_ENDPOINT_INTERNAL_H
+
+#include "api/oc_helpers_internal.h"
+#include "oc_cloud.h"
+#include "oc_helpers.h"
+#include "oc_rep.h"
+#include "oc_uuid.h"
+#include "util/oc_compiler.h"
+#include "util/oc_features.h"
+#include "util/oc_list.h"
+#include "util/oc_secure_string_internal.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef OC_CLOUD_MAX_ENDPOINT_ADDRESSES
+// max two endpoint addresses per device with static allocation
+#define OC_CLOUD_MAX_ENDPOINT_ADDRESSES (2 * OC_MAX_NUM_DEVICES)
+#endif /* OC_CLOUD_MAX_ENDPOINT_ADDRESSES */
+
+struct oc_cloud_endpoint_t
+{
+  struct oc_cloud_endpoint_t *next;
+  oc_string_t uri;
+  oc_uuid_t id; ///< identity of the cloud server
+};
+
+typedef void (*on_selected_change_fn_t)(void *data);
+
+typedef struct
+{
+  const oc_cloud_endpoint_t *selected; ///< currently selected server endpoint
+  on_selected_change_fn_t
+    on_selected_change; ///< callback invoked when the selected endpoint changes
+  void *
+    on_selected_change_data; ///< data passed to the on_selected_change callback
+  OC_LIST_STRUCT(endpoints); ///< list of server endpoints
+} oc_cloud_endpoints_t;
+
+/** Initialize cloud server endpoints
+ *
+ * @param ce cloud endpoints (cannot be NULL)
+ * @param on_selected_change callback invoked when the selected endpoint changes
+ * @param on_selected_change_data data passed to the on_selected_change callback
+ * @param default_uri URI of the default endpoint to add (if the URI is empty
+ * the list will remain empty)
+ * @param default_id identity of the default endpoint to add
+ * @return true on success
+ * @return false on failure
+ */
+bool oc_cloud_endpoints_init(oc_cloud_endpoints_t *ce,
+                             on_selected_change_fn_t on_selected_change,
+                             void *on_selected_change_data,
+                             oc_string_view_t default_uri, oc_uuid_t default_id)
+  OC_NONNULL(1);
+
+/** Deinitialize cloud server endpoints */
+void oc_cloud_endpoints_deinit(oc_cloud_endpoints_t *ce) OC_NONNULL();
+
+/** Deinitialize and reinitialize cloud server endpoints */
+bool oc_cloud_endpoints_reinit(oc_cloud_endpoints_t *ce,
+                               oc_string_view_t default_uri,
+                               oc_uuid_t default_id) OC_NONNULL(1);
+
+/** Get the number of cloud server endpoints */
+size_t oc_cloud_endpoints_size(const oc_cloud_endpoints_t *ce) OC_NONNULL();
+
+/** Check if the list of cloud server endpoints is empty */
+bool oc_cloud_endpoints_is_empty(const oc_cloud_endpoints_t *ce) OC_NONNULL();
+
+/**
+ * Allocate and add a cloud server endpoint to the list of endpoints
+ *
+ * @param ce cloud endpoints (cannot be NULL)
+ * @param uri cloud endpoint URI to add
+ * @param id cloud endpoint identity
+ *
+ * @return new endpoint item on success
+ * @return NULL on failure
+ * */
+oc_cloud_endpoint_t *oc_cloud_endpoint_add(oc_cloud_endpoints_t *ce,
+                                           oc_string_view_t uri, oc_uuid_t id)
+  OC_NONNULL();
+
+/**
+ * @brief Remove a cloud server endpoint from the list of endpoints
+ *
+ * @param ce cloud endpoints (cannot be NULL)
+ * @param ep cloud endpoint to remove (cannot be NULL)
+ *
+ * @return true if the endpoint was removed
+ * @return false if the endpoint was not found
+ */
+bool oc_cloud_endpoint_remove(oc_cloud_endpoints_t *ce,
+                              const oc_cloud_endpoint_t *ep) OC_NONNULL();
+
+/**
+ * @brief Remove a cloud server endpoint with given URI from the list of
+ * endpoints
+ *
+ * @param ce cloud endpoints (cannot be NULL)
+ * @param uri cloud endpoint URI to remove
+ *
+ * @return true if the endpoint was removed
+ * @return false if the endpoint was not found
+ */
+bool oc_cloud_endpoint_remove_by_uri(oc_cloud_endpoints_t *ce,
+                                     oc_string_view_t uri) OC_NONNULL();
+
+/**
+ * @brief Select a cloud server endpoint from the list of endpoints
+ *
+ * @param ce cloud endpoints (cannot be NULL)
+ * @param uri cloud endpoint URI to select
+ *
+ * @return true if the endpoint was selected
+ * @return false if the endpoint was not found (the previous selection remains)
+ */
+bool oc_cloud_endpoint_select_by_uri(oc_cloud_endpoints_t *ce,
+                                     oc_string_view_t uri) OC_NONNULL();
+
+/** Check if a cloud server endpoint matching the given URI is selected */
+bool oc_cloud_endpoint_is_selected(const oc_cloud_endpoints_t *ce,
+                                   oc_string_view_t uri) OC_NONNULL();
+
+/** Get address of the currently selected cloud server endpoint */
+const oc_string_t *oc_cloud_endpoint_selected_address(
+  const oc_cloud_endpoints_t *ce) OC_NONNULL();
+
+/** Get id of the currently selected cloud server endpoint */
+const oc_uuid_t *oc_cloud_endpoint_selected_id(const oc_cloud_endpoints_t *ce)
+  OC_NONNULL();
+
+/** Iterate the list of cloud server endpoints. */
+void oc_cloud_endpoints_iterate(const oc_cloud_endpoints_t *ce,
+                                oc_cloud_endpoints_iterate_fn_t fn, void *data)
+  OC_NONNULL(1, 2);
+
+/** Clear the list of cloud server endpoints */
+void oc_cloud_endpoints_clear(oc_cloud_endpoints_t *ce) OC_NONNULL();
+
+/** Find an endpoint in the list of endpoints */
+oc_cloud_endpoint_t *oc_cloud_endpoint_find(const oc_cloud_endpoints_t *ce,
+                                            oc_string_view_t uri) OC_NONNULL();
+
+/** Check if the list of endpoints contains an endpoint with the given URL */
+bool oc_cloud_endpoint_contains(const oc_cloud_endpoints_t *ce,
+                                oc_string_view_t uri) OC_NONNULL();
+
+/**
+ * Encode cloud server endpoints array to an encoder
+ *
+ * @param encoder encoder to write to (cannot be NULL)
+ * @param ce cloud endpoints (cannot be NULL)
+ * @param key key to use for encoding
+ * @param skipIfSingleAndSelected if true, skip encoding if there a single
+ * endpoint in the list and it is selected
+ */
+CborError oc_cloud_endpoints_encode(CborEncoder *encoder,
+                                    const oc_cloud_endpoints_t *ce,
+                                    oc_string_view_t key,
+                                    bool skipIfSingleAndSelected) OC_NONNULL();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OC_CLOUD_ENDPOINT_INTERNAL_H */

--- a/api/cloud/oc_cloud_manager_internal.h
+++ b/api/cloud/oc_cloud_manager_internal.h
@@ -36,6 +36,9 @@ extern "C" {
 #define USER_ID_KEY "uid"
 #define EXPIRESIN_KEY "expiresin"
 
+/** Set timeout intervals for the default retry action */
+void oc_cloud_manager_set_retry_timeouts(const uint16_t *timeouts, size_t size);
+
 /**
  * @brief Parse sign-up response retrieved from the server and store the data to
  * cloud context.

--- a/api/cloud/oc_cloud_manager_internal.h
+++ b/api/cloud/oc_cloud_manager_internal.h
@@ -88,6 +88,10 @@ void cloud_manager_start(oc_cloud_context_t *ctx) OC_NONNULL();
  */
 void cloud_manager_stop(const oc_cloud_context_t *ctx) OC_NONNULL();
 
+void oc_cloud_register_handler(oc_client_response_t *data) OC_NONNULL();
+void oc_cloud_login_handler(oc_client_response_t *data) OC_NONNULL();
+void oc_cloud_refresh_token_handler(oc_client_response_t *data) OC_NONNULL();
+
 #ifdef __cplusplus
 }
 #endif

--- a/api/cloud/oc_cloud_rd.c
+++ b/api/cloud/oc_cloud_rd.c
@@ -15,11 +15,13 @@
  * limitations under the License.
  *
  ******************************************************************/
+
 #ifdef OC_CLOUD
 
 #include "api/cloud/oc_cloud_context_internal.h"
 #include "api/cloud/oc_cloud_internal.h"
 #include "api/cloud/oc_cloud_log_internal.h"
+#include "api/cloud/oc_cloud_rd_internal.h"
 #include "api/oc_link_internal.h"
 #include "api/oc_ri_internal.h"
 #include "oc_api.h"

--- a/api/cloud/oc_cloud_rd.c
+++ b/api/cloud/oc_cloud_rd.c
@@ -17,11 +17,12 @@
  ******************************************************************/
 #ifdef OC_CLOUD
 
+#include "api/cloud/oc_cloud_context_internal.h"
+#include "api/cloud/oc_cloud_internal.h"
+#include "api/cloud/oc_cloud_log_internal.h"
 #include "api/oc_link_internal.h"
 #include "api/oc_ri_internal.h"
 #include "oc_api.h"
-#include "oc_cloud_internal.h"
-#include "oc_cloud_log_internal.h"
 #include "oc_collection.h"
 #include "rd_client_internal.h"
 

--- a/api/cloud/oc_cloud_rd_internal.h
+++ b/api/cloud/oc_cloud_rd_internal.h
@@ -1,0 +1,70 @@
+/****************************************************************************
+ *
+ * Copyright 2019 Jozef Kralik All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"),
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************/
+
+#ifndef OC_CLOUD_RD_INTERNAL_H
+#define OC_CLOUD_RD_INTERNAL_H
+
+#include "api/cloud/oc_cloud_context_internal.h"
+#include "util/oc_compiler.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Update resource links after manager status change.
+ *
+ * If cloud is in logged in state the function executes several resource links
+ * updates: deletes links scheduled to be deleted, publishes links scheduled
+ * to be published and republishes links that were already published.
+ * Additionally, if Time to Live property is not equal to
+ * RD_PUBLISH_TTL_UNLIMITED then published links are scheduled to be republished
+ * each hour. (If cloud_rd_manager_status_changed function is triggered again
+ * before the scheduled time passes the republishing is rescheduled with updated
+ * time.)
+ *
+ * @param ctx Cloud context, must not be NULL
+ */
+void cloud_rd_manager_status_changed(oc_cloud_context_t *ctx) OC_NONNULL();
+
+/**
+ * @brief Deallocate all resource directory context member variables.
+ *
+ * Deallocate the list of to be published resources, the list of published
+ * resources and the list of to be deleted resources. Remove delayed callback
+ * that republishes resources (if it's active).
+ *
+ * @param ctx Cloud context, must not be NULL
+ */
+void cloud_rd_deinit(oc_cloud_context_t *ctx) OC_NONNULL();
+
+/**
+ * @brief Reset resource directory context member variables.
+ *
+ * Items in the list of published resources are moved to the list of to be
+ * published resources. The list of to be deleted resources is cleared.
+ *
+ * @param ctx Cloud context, must not be NULL
+ */
+void cloud_rd_reset_context(oc_cloud_context_t *ctx) OC_NONNULL();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OC_CLOUD_INTERNAL_H */

--- a/api/cloud/oc_cloud_resource_internal.h
+++ b/api/cloud/oc_cloud_resource_internal.h
@@ -22,6 +22,8 @@
 #include "api/oc_helpers_internal.h"
 #include "oc_cloud.h"
 #include "oc_ri.h"
+#include "oc_uuid.h"
+#include "util/oc_compiler.h"
 
 #include <stddef.h>
 
@@ -34,12 +36,29 @@ extern "C" {
 #define OCF_COAPCLOUDCONF_IF_MASK (OC_IF_RW | OC_IF_BASELINE)
 #define OCF_COAPCLOUDCONF_DEFAULT_IF (OC_IF_RW)
 
+/// Default cis value from OCF Device to Cloud Services Specification
 #define OCF_COAPCLOUDCONF_DEFAULT_CIS "coaps+tcp://127.0.0.1"
-#define OCF_COAPCLOUDCONF_DEFAULT_SID "00000000-0000-0000-0000-000000000000"
+
+/// Default sid value from OCF Device to Cloud Services Specification,
+/// equivalent to "00000000-0000-0000-0000-000000000000"
+#ifdef __cplusplus
+#define OCF_COAPCLOUDCONF_DEFAULT_SID                                          \
+  oc_uuid_t                                                                    \
+  {                                                                            \
+    0                                                                          \
+  }
+#else /* !__cplusplus */
+#define OCF_COAPCLOUDCONF_DEFAULT_SID                                          \
+  (oc_uuid_t)                                                                  \
+  {                                                                            \
+    0                                                                          \
+  }
+#endif /* __cplusplus */
 
 #define OCF_COAPCLOUDCONF_PROP_ACCESSTOKEN "at"
 #define OCF_COAPCLOUDCONF_PROP_AUTHPROVIDER "apn"
 #define OCF_COAPCLOUDCONF_PROP_CISERVER "cis"
+#define OCF_COAPCLOUDCONF_PROP_CISERVERS "x.org.iotivity.servers"
 #define OCF_COAPCLOUDCONF_PROP_SERVERID "sid"
 #define OCF_COAPCLOUDCONF_PROP_LASTERRORCODE "clec"
 #define OCF_COAPCLOUDCONF_PROP_PROVISIONINGSTATUS "cps"
@@ -56,6 +75,9 @@ oc_string_view_t oc_cps_to_string(oc_cps_t cps);
 
 /// Create CoAPCloudConf resource
 void oc_create_cloudconf_resource(size_t device);
+
+/// Encode CoAPCloudConf resource to global encoder
+bool oc_cloud_encode(const oc_cloud_context_t *ctx) OC_NONNULL();
 
 #ifdef __cplusplus
 }

--- a/api/cloud/oc_cloud_resource_internal.h
+++ b/api/cloud/oc_cloud_resource_internal.h
@@ -19,11 +19,40 @@
 #ifndef OC_CLOUD_RESOURCE_INTERNAL_H
 #define OC_CLOUD_RESOURCE_INTERNAL_H
 
+#include "api/oc_helpers_internal.h"
+#include "oc_cloud.h"
+#include "oc_ri.h"
+
 #include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#define OCF_COAPCLOUDCONF_URI "/CoapCloudConfResURI"
+#define OCF_COAPCLOUDCONF_RT "oic.r.coapcloudconf"
+#define OCF_COAPCLOUDCONF_IF_MASK (OC_IF_RW | OC_IF_BASELINE)
+#define OCF_COAPCLOUDCONF_DEFAULT_IF (OC_IF_RW)
+
+#define OCF_COAPCLOUDCONF_DEFAULT_CIS "coaps+tcp://127.0.0.1"
+#define OCF_COAPCLOUDCONF_DEFAULT_SID "00000000-0000-0000-0000-000000000000"
+
+#define OCF_COAPCLOUDCONF_PROP_ACCESSTOKEN "at"
+#define OCF_COAPCLOUDCONF_PROP_AUTHPROVIDER "apn"
+#define OCF_COAPCLOUDCONF_PROP_CISERVER "cis"
+#define OCF_COAPCLOUDCONF_PROP_SERVERID "sid"
+#define OCF_COAPCLOUDCONF_PROP_LASTERRORCODE "clec"
+#define OCF_COAPCLOUDCONF_PROP_PROVISIONINGSTATUS "cps"
+
+#define OC_CPS_UNINITIALIZED_STR "uninitialized"
+#define OC_CPS_READYTOREGISTER_STR "readytoregister"
+#define OC_CPS_REGISTERING_STR "registering"
+#define OC_CPS_REGISTERED_STR "registered"
+#define OC_CPS_FAILED_STR "failed"
+#define OC_CPS_DEREGISTERING_STR "deregistering"
+
+/// Convert oc_cps_t to string
+oc_string_view_t oc_cps_to_string(oc_cps_t cps);
 
 /// Create CoAPCloudConf resource
 void oc_create_cloudconf_resource(size_t device);

--- a/api/cloud/oc_cloud_store_internal.h
+++ b/api/cloud/oc_cloud_store_internal.h
@@ -54,7 +54,12 @@ typedef struct oc_cloud_store_t
 } oc_cloud_store_t;
 
 /** @brief Set store data to default values */
-void oc_cloud_store_initialize(oc_cloud_store_t *store) OC_NONNULL();
+void oc_cloud_store_initialize(oc_cloud_store_t *store,
+                               on_selected_change_fn_t on_cloud_server_change,
+                               void *on_cloud_server_change_dat) OC_NONNULL(1);
+
+/** @brief Reinitialize store data */
+void oc_cloud_store_reinitialize(oc_cloud_store_t *store) OC_NONNULL();
 
 /** @brief Deallocate allocated data */
 void oc_cloud_store_deinitialize(oc_cloud_store_t *store) OC_NONNULL();

--- a/api/cloud/oc_cloud_store_internal.h
+++ b/api/cloud/oc_cloud_store_internal.h
@@ -28,14 +28,39 @@
 extern "C" {
 #endif
 
+typedef struct oc_cloud_store_t
+{
+  oc_string_t ci_server;     ///< URL of the OCF Cloud.
+  oc_string_t auth_provider; ///< The name of the Authorisation Provider through
+                             // which access token was obtained.
+  oc_string_t uid;           ///< Unique OCF Cloud User identifier
+  oc_string_t access_token;  ///< Access token which is returned by an
+                             ///< Authorisation Provider or OCF Cloud.
+  oc_string_t refresh_token; ///< Refresh token used to refresh the access token
+                             ///< before it expires.
+  oc_string_t sid;           ///< The identity of the OCF Cloud
+  int64_t expires_in; ///< The time in seconds for which the access token is
+                      ///< valid.
+  uint8_t status;
+  oc_cps_t cps; ///< Cloud provisioning status of the device.
+  size_t device;
+} oc_cloud_store_t;
+
+/**  @brief Encode cloud store to the global encoder. */
+void cloud_store_encode(const oc_cloud_store_t *store) OC_NONNULL();
+
+/** @brief Decode representation to store. */
+bool cloud_store_decode(const oc_rep_t *rep, oc_cloud_store_t *store)
+  OC_NONNULL(2);
+
 /**
  * @brief Load store data from storage
  *
  * @param[out] store store to save data to (cannot be NULL)
- * @return 0 on success
- * @return <0 on failure
+ * @return true on success
+ * @return false on failure
  */
-int cloud_store_load(oc_cloud_store_t *store) OC_NONNULL();
+bool cloud_store_load(oc_cloud_store_t *store) OC_NONNULL();
 
 /**
  * @brief Save store data to storage

--- a/api/cloud/oc_cloud_store_internal.h
+++ b/api/cloud/oc_cloud_store_internal.h
@@ -21,16 +21,24 @@
 #ifndef OC_CLOUD_STORE_INTERNAL_H
 #define OC_CLOUD_STORE_INTERNAL_H
 
+#include "api/cloud/oc_cloud_endpoint_internal.h"
 #include "oc_cloud.h"
+#include "oc_helpers.h"
+#include "oc_rep.h"
 #include "util/oc_compiler.h"
+
+#include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+#define OC_CLOUD_STORE_NAME "cloud"
+
 typedef struct oc_cloud_store_t
 {
-  oc_string_t ci_server;     ///< URL of the OCF Cloud.
+  oc_cloud_endpoints_t ci_servers; ///< ([URL, id] pairs of the OCF Cloud.
   oc_string_t auth_provider; ///< The name of the Authorisation Provider through
                              // which access token was obtained.
   oc_string_t uid;           ///< Unique OCF Cloud User identifier
@@ -38,19 +46,24 @@ typedef struct oc_cloud_store_t
                              ///< Authorisation Provider or OCF Cloud.
   oc_string_t refresh_token; ///< Refresh token used to refresh the access token
                              ///< before it expires.
-  oc_string_t sid;           ///< The identity of the OCF Cloud
   int64_t expires_in; ///< The time in seconds for which the access token is
                       ///< valid.
-  uint8_t status;
-  oc_cps_t cps; ///< Cloud provisioning status of the device.
   size_t device;
+  oc_cps_t cps; ///< Cloud provisioning status of the device.
+  uint8_t status;
 } oc_cloud_store_t;
 
+/** @brief Set store data to default values */
+void oc_cloud_store_initialize(oc_cloud_store_t *store) OC_NONNULL();
+
+/** @brief Deallocate allocated data */
+void oc_cloud_store_deinitialize(oc_cloud_store_t *store) OC_NONNULL();
+
 /**  @brief Encode cloud store to the global encoder. */
-void cloud_store_encode(const oc_cloud_store_t *store) OC_NONNULL();
+void oc_cloud_store_encode(const oc_cloud_store_t *store) OC_NONNULL();
 
 /** @brief Decode representation to store. */
-bool cloud_store_decode(const oc_rep_t *rep, oc_cloud_store_t *store)
+bool oc_cloud_store_decode(const oc_rep_t *rep, oc_cloud_store_t *store)
   OC_NONNULL(2);
 
 /**
@@ -60,7 +73,7 @@ bool cloud_store_decode(const oc_rep_t *rep, oc_cloud_store_t *store)
  * @return true on success
  * @return false on failure
  */
-bool cloud_store_load(oc_cloud_store_t *store) OC_NONNULL();
+bool oc_cloud_store_load(oc_cloud_store_t *store) OC_NONNULL();
 
 /**
  * @brief Save store data to storage
@@ -69,7 +82,7 @@ bool cloud_store_load(oc_cloud_store_t *store) OC_NONNULL();
  * @return >=0 amount of bytes written to storage
  * @return <0 on failure
  */
-long cloud_store_dump(const oc_cloud_store_t *store) OC_NONNULL();
+long oc_cloud_store_dump(const oc_cloud_store_t *store) OC_NONNULL();
 
 /**
  * @brief Schedule delayed saving of store data to storage
@@ -79,21 +92,7 @@ long cloud_store_dump(const oc_cloud_store_t *store) OC_NONNULL();
  * @warning You must ensure that the store pointer is still valid in the delayed
  * execution
  */
-void cloud_store_dump_async(const oc_cloud_store_t *store) OC_NONNULL();
-
-/**
- * @brief Set store data to default values
- *
- * @param store store
- */
-void cloud_store_initialize(oc_cloud_store_t *store) OC_NONNULL();
-
-/**
- * @brief Deallocate allocated data
- *
- * @param store store
- */
-void cloud_store_deinitialize(oc_cloud_store_t *store) OC_NONNULL();
+void oc_cloud_store_dump_async(const oc_cloud_store_t *store) OC_NONNULL();
 
 #ifdef __cplusplus
 }

--- a/api/cloud/unittest/cloud_context_test.cpp
+++ b/api/cloud/unittest/cloud_context_test.cpp
@@ -1,0 +1,120 @@
+/****************************************************************************
+ *
+ * Copyright (c) 2024 plgd.dev s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"),
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+#include "api/cloud/oc_cloud_context_internal.h"
+#include "api/oc_helpers_internal.h"
+
+#include <gtest/gtest.h>
+
+class TestCloudContext : public testing::Test {};
+
+TEST_F(TestCloudContext, GetDevice)
+{
+  oc_cloud_context_t ctx{};
+  ctx.device = 42;
+  EXPECT_EQ(42, oc_cloud_get_device(&ctx));
+}
+
+TEST_F(TestCloudContext, GetApn)
+{
+  oc_cloud_context_t ctx{};
+  ctx.store.auth_provider = OC_STRING_LOCAL("apn");
+  EXPECT_STREQ("apn", oc_cloud_get_apn(&ctx));
+}
+
+TEST_F(TestCloudContext, GetCis)
+{
+  oc_cloud_context_t ctx{};
+  ctx.store.ci_server = OC_STRING_LOCAL("cis");
+  EXPECT_STREQ("cis", oc_cloud_get_cis(&ctx));
+}
+
+TEST_F(TestCloudContext, GetUid)
+{
+  oc_cloud_context_t ctx{};
+  ctx.store.uid = OC_STRING_LOCAL("uid");
+  EXPECT_STREQ("uid", oc_cloud_get_uid(&ctx));
+}
+
+TEST_F(TestCloudContext, GetAccessToken)
+{
+  oc_cloud_context_t ctx{};
+  ctx.store.access_token = OC_STRING_LOCAL("access_token");
+  EXPECT_STREQ("access_token", oc_cloud_get_at(&ctx));
+}
+
+TEST_F(TestCloudContext, GetSid)
+{
+  oc_cloud_context_t ctx{};
+  ctx.store.sid = OC_STRING_LOCAL("sid");
+  EXPECT_STREQ("sid", oc_cloud_get_sid(&ctx));
+}
+
+TEST_F(TestCloudContext, HasAccesToken)
+{
+  oc_cloud_context_t ctx{};
+
+  EXPECT_FALSE(cloud_context_has_access_token(&ctx));
+  EXPECT_FALSE(cloud_context_has_permanent_access_token(&ctx));
+
+  ctx.store.access_token = OC_STRING_LOCAL("");
+  EXPECT_FALSE(cloud_context_has_access_token(&ctx));
+  EXPECT_FALSE(cloud_context_has_permanent_access_token(&ctx));
+
+  ctx.store.access_token = OC_STRING_LOCAL("access_token");
+  EXPECT_TRUE(cloud_context_has_access_token(&ctx));
+  EXPECT_FALSE(cloud_context_has_permanent_access_token(&ctx));
+
+  ctx.store.expires_in = -1;
+  EXPECT_TRUE(cloud_context_has_access_token(&ctx));
+  EXPECT_TRUE(cloud_context_has_permanent_access_token(&ctx));
+}
+
+TEST_F(TestCloudContext, HasRefreshToken)
+{
+  oc_cloud_context_t ctx{};
+
+  EXPECT_FALSE(cloud_context_has_refresh_token(&ctx));
+
+  ctx.store.refresh_token = OC_STRING_LOCAL("");
+  EXPECT_FALSE(cloud_context_has_refresh_token(&ctx));
+
+  ctx.store.refresh_token = OC_STRING_LOCAL("refresh_token");
+  EXPECT_TRUE(cloud_context_has_refresh_token(&ctx));
+}
+
+TEST_F(TestCloudContext, SetIdentityCertChain)
+{
+  oc_cloud_context_t ctx{};
+  EXPECT_EQ(0, oc_cloud_get_identity_cert_chain(&ctx));
+
+  oc_cloud_set_identity_cert_chain(&ctx, 42);
+  EXPECT_EQ(42, oc_cloud_get_identity_cert_chain(&ctx));
+}
+
+TEST_F(TestCloudContext, SetKeepalive)
+{
+  oc_cloud_context_t ctx{};
+
+  auto on_response = [](bool, uint64_t *, uint16_t *, void *) { return true; };
+  int user_data = 42;
+  oc_cloud_set_keepalive(&ctx, on_response, &user_data);
+
+  EXPECT_EQ(&user_data, ctx.keepalive.user_data);
+  EXPECT_EQ(on_response, ctx.keepalive.on_response);
+}

--- a/api/cloud/unittest/cloud_context_test.cpp
+++ b/api/cloud/unittest/cloud_context_test.cpp
@@ -48,7 +48,7 @@ TEST_F(TestCloudContext, GetCisAndSid)
 {
   oc_cloud_context_t ctx{};
 
-  oc_cloud_store_initialize(&ctx.store);
+  oc_cloud_store_initialize(&ctx.store, nullptr, nullptr);
   auto cis = OC_STRING_VIEW("cis");
   oc_uuid_t sid;
   oc_gen_uuid(&sid);

--- a/api/cloud/unittest/cloud_endpoint_test.cpp
+++ b/api/cloud/unittest/cloud_endpoint_test.cpp
@@ -1,0 +1,398 @@
+/****************************************************************************
+ *
+ * Copyright (c) 2024 plgd.dev s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"),
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+#include "api/cloud/oc_cloud_endpoint_internal.h"
+#include "api/cloud/oc_cloud_resource_internal.h"
+#include "api/oc_helpers_internal.h"
+#include "oc_uuid.h"
+#include "port/oc_log_internal.h"
+#include "port/oc_random.h"
+#include "tests/gtest/RepPool.h"
+
+#include <array>
+#include <gtest/gtest.h>
+#include <string>
+
+class TestCloudEndpoint : public testing::Test {
+public:
+  static void SetUpTestCase() { oc_random_init(); }
+
+  static void TearDownTestCase() { oc_random_destroy(); }
+
+  void SetUp() override
+  {
+    ASSERT_TRUE(
+      oc_cloud_endpoints_init(&ce, nullptr, nullptr, OC_STRING_VIEW_NULL, {}));
+  }
+
+  void TearDown() override { oc_cloud_endpoints_deinit(&ce); }
+
+  oc_cloud_endpoints_t &getCloudEndpoints() { return ce; }
+
+private:
+  oc_cloud_endpoints_t ce;
+};
+
+static std::string
+encodeCloudEndpointItem(const std::string &uri, oc_uuid_t id)
+{
+  std::array<char, OC_UUID_LEN> id_str{};
+  oc_uuid_to_str(&id, &id_str[0], id_str.size());
+  return std::string(R"({"uri":")") + uri.c_str() + R"(","id":")" +
+         id_str.data() + R"("})";
+}
+
+TEST_F(TestCloudEndpoint, InitWithDefault)
+{
+  oc_cloud_endpoints_t ce{};
+  ASSERT_TRUE(oc_cloud_endpoints_init(
+    &ce, nullptr, nullptr, OC_STRING_VIEW(OCF_COAPCLOUDCONF_DEFAULT_CIS),
+    OCF_COAPCLOUDCONF_DEFAULT_SID));
+  EXPECT_TRUE(oc_cloud_endpoint_contains(
+    &ce, OC_STRING_VIEW(OCF_COAPCLOUDCONF_DEFAULT_CIS)));
+  auto *selected = ce.selected;
+  ASSERT_NE(nullptr, selected);
+  EXPECT_STREQ(OCF_COAPCLOUDCONF_DEFAULT_CIS, oc_string(selected->uri));
+  EXPECT_TRUE(oc_uuid_is_equal(OCF_COAPCLOUDCONF_DEFAULT_SID, selected->id));
+  oc_cloud_endpoints_deinit(&ce);
+}
+
+TEST_F(TestCloudEndpoint, Init_FailInvalidDefault)
+{
+  oc_cloud_endpoints_t ce{};
+  std::string tooLong(OC_ENDPOINT_MAX_ENDPOINT_URI_LENGTH + 1, 'a');
+  EXPECT_FALSE(oc_cloud_endpoints_init(
+    &ce, nullptr, nullptr, oc_string_view(tooLong.c_str(), tooLong.length()),
+    {}));
+  oc_cloud_endpoints_deinit(&ce);
+}
+
+TEST_F(TestCloudEndpoint, IsEmpty)
+{
+  oc_cloud_endpoints_t ceEmpty{};
+  EXPECT_TRUE(oc_cloud_endpoints_is_empty(&ceEmpty));
+  EXPECT_EQ(0, oc_cloud_endpoints_size(&ceEmpty));
+
+  const oc_cloud_endpoints_t &ce{ getCloudEndpoints() };
+  EXPECT_TRUE(oc_cloud_endpoints_is_empty(&ce));
+  EXPECT_EQ(0, oc_cloud_endpoints_size(&ce));
+}
+
+TEST_F(TestCloudEndpoint, Contains)
+{
+  oc_cloud_endpoints_t ceEmpty{};
+  EXPECT_FALSE(oc_cloud_endpoint_contains(&ceEmpty, OC_STRING_VIEW_NULL));
+
+  const oc_cloud_endpoints_t &ce{ getCloudEndpoints() };
+  EXPECT_FALSE(oc_cloud_endpoint_contains(&ce, OC_STRING_VIEW_NULL));
+}
+
+TEST_F(TestCloudEndpoint, AddAndRemove)
+{
+  oc_cloud_endpoints_t &ce{ getCloudEndpoints() };
+
+  auto uri1 = OC_STRING_VIEW("/uri/1");
+  EXPECT_FALSE(oc_cloud_endpoint_contains(&ce, uri1));
+  auto *ep1 = oc_cloud_endpoint_add(&ce, uri1, {});
+  EXPECT_NE(nullptr, ep1);
+  EXPECT_TRUE(oc_cloud_endpoint_contains(&ce, uri1));
+  EXPECT_EQ(1, oc_cloud_endpoints_size(&ce));
+
+  auto uri2 = OC_STRING_VIEW("/uri/2");
+  EXPECT_FALSE(oc_cloud_endpoint_contains(&ce, uri2));
+  EXPECT_NE(nullptr, oc_cloud_endpoint_add(&ce, uri2, {}));
+  EXPECT_TRUE(oc_cloud_endpoint_contains(&ce, uri2));
+  EXPECT_EQ(2, oc_cloud_endpoints_size(&ce));
+
+  EXPECT_TRUE(oc_cloud_endpoint_remove_by_uri(&ce, uri2));
+  EXPECT_FALSE(oc_cloud_endpoint_contains(&ce, uri2));
+  EXPECT_EQ(1, oc_cloud_endpoints_size(&ce));
+
+  EXPECT_TRUE(oc_cloud_endpoint_remove(&ce, ep1));
+  EXPECT_FALSE(oc_cloud_endpoint_contains(&ce, uri1));
+  EXPECT_EQ(0, oc_cloud_endpoints_size(&ce));
+}
+
+TEST_F(TestCloudEndpoint, Add_Fail)
+{
+  oc_cloud_endpoints_t &ce{ getCloudEndpoints() };
+
+  ASSERT_FALSE(oc_cloud_endpoint_add(&ce, OC_STRING_VIEW_NULL, {}));
+  std::string tooLong(OC_ENDPOINT_MAX_ENDPOINT_URI_LENGTH + 1, 'a');
+  ASSERT_FALSE(oc_cloud_endpoint_add(
+    &ce, oc_string_view(tooLong.c_str(), tooLong.length()), {}));
+
+#ifndef OC_DYNAMIC_ALLOCATION
+  for (size_t i = 0; i < OC_CLOUD_MAX_ENDPOINT_ADDRESSES; i++) {
+    auto uri = std::string("/uri/") + std::to_string(i);
+    ASSERT_NE(nullptr, oc_cloud_endpoint_add(
+                         &ce, oc_string_view(uri.c_str(), uri.length()), {}));
+  }
+
+  auto uri = OC_STRING_VIEW("/fail");
+  EXPECT_EQ(nullptr, oc_cloud_endpoint_add(&ce, uri, {}));
+#endif /* !OC_DYNAMIC_ALLOCATION */
+}
+
+TEST_F(TestCloudEndpoint, Add_DuplicateFail)
+{
+  oc_cloud_endpoints_t &ce{ getCloudEndpoints() };
+
+  auto uri1 = OC_STRING_VIEW("/uri/1");
+  ASSERT_NE(nullptr, oc_cloud_endpoint_add(&ce, uri1, {}));
+  EXPECT_EQ(nullptr, oc_cloud_endpoint_add(&ce, uri1, {}));
+}
+
+TEST_F(TestCloudEndpoint, Remove_Fail)
+{
+  oc_cloud_endpoints_t &ce{ getCloudEndpoints() };
+
+  auto uri1 = OC_STRING_VIEW("/uri/1");
+  ASSERT_NE(nullptr, oc_cloud_endpoint_add(&ce, uri1, {}));
+
+  // element not in the list
+  oc_cloud_endpoint_t ep{};
+  EXPECT_FALSE(oc_cloud_endpoint_remove(&ce, &ep));
+
+  // no element with the given URI
+  EXPECT_FALSE(oc_cloud_endpoint_remove_by_uri(&ce, OC_STRING_VIEW_NULL));
+  EXPECT_FALSE(oc_cloud_endpoint_remove_by_uri(&ce, OC_STRING_VIEW("/fail")));
+}
+
+TEST_F(TestCloudEndpoint, Select)
+{
+  oc_cloud_endpoints_t &ce{ getCloudEndpoints() };
+
+  auto uri1 = OC_STRING_VIEW("/uri/1");
+  oc_uuid_t id1;
+  oc_gen_uuid(&id1);
+  ASSERT_NE(nullptr, oc_cloud_endpoint_add(&ce, uri1, id1));
+
+  // when adding to an empty list, the first added item is automatically
+  // selected
+  EXPECT_TRUE(oc_cloud_endpoint_is_selected(&ce, uri1));
+  auto *selected_addr = oc_cloud_endpoint_selected_address(&ce);
+  ASSERT_NE(nullptr, selected_addr);
+  EXPECT_STREQ(uri1.data, oc_string(*selected_addr));
+  auto *selected_id = oc_cloud_endpoint_selected_id(&ce);
+  ASSERT_NE(nullptr, selected_id);
+  EXPECT_TRUE(oc_uuid_is_equal(id1, *selected_id));
+
+  // non-existing URI shouldn't change the selection
+  EXPECT_FALSE(oc_cloud_endpoint_select_by_uri(&ce, OC_STRING_VIEW("/fail")));
+  EXPECT_FALSE(oc_cloud_endpoint_is_selected(&ce, OC_STRING_VIEW("/fail")));
+  EXPECT_TRUE(oc_cloud_endpoint_is_selected(&ce, uri1));
+  selected_addr = oc_cloud_endpoint_selected_address(&ce);
+  ASSERT_NE(nullptr, selected_addr);
+  EXPECT_STREQ(uri1.data, oc_string(*selected_addr));
+
+#ifdef OC_DYNAMIC_ALLOCATION
+  auto uri2 = OC_STRING_VIEW("/uri/2");
+  oc_uuid_t id2;
+  oc_gen_uuid(&id2);
+  ASSERT_NE(nullptr, oc_cloud_endpoint_add(&ce, uri2, id2));
+  EXPECT_FALSE(oc_cloud_endpoint_is_selected(&ce, uri2));
+  auto uri3 = OC_STRING_VIEW("/uri/3");
+  oc_uuid_t id3;
+  oc_gen_uuid(&id3);
+  ASSERT_NE(nullptr, oc_cloud_endpoint_add(&ce, uri3, id3));
+  EXPECT_FALSE(oc_cloud_endpoint_is_selected(&ce, uri3));
+
+  EXPECT_TRUE(oc_cloud_endpoint_select_by_uri(&ce, uri2));
+  EXPECT_TRUE(oc_cloud_endpoint_is_selected(&ce, uri2));
+  selected_addr = oc_cloud_endpoint_selected_address(&ce);
+  ASSERT_NE(nullptr, selected_addr);
+  EXPECT_STREQ(uri2.data, oc_string(*selected_addr));
+  selected_id = oc_cloud_endpoint_selected_id(&ce);
+  ASSERT_NE(nullptr, selected_id);
+  EXPECT_TRUE(oc_uuid_is_equal(id2, *selected_id));
+
+  EXPECT_TRUE(oc_cloud_endpoint_select_by_uri(&ce, uri3));
+  EXPECT_TRUE(oc_cloud_endpoint_is_selected(&ce, uri3));
+  selected_addr = oc_cloud_endpoint_selected_address(&ce);
+  ASSERT_NE(nullptr, selected_addr);
+  EXPECT_STREQ(uri3.data, oc_string(*selected_addr));
+  selected_id = oc_cloud_endpoint_selected_id(&ce);
+  ASSERT_NE(nullptr, selected_id);
+  EXPECT_TRUE(oc_uuid_is_equal(id3, *selected_id));
+#endif /* OC_DYNAMIC_ALLOCATION */
+}
+
+TEST_F(TestCloudEndpoint, RemoveSelected)
+{
+  oc_cloud_endpoints_t &ce{ getCloudEndpoints() };
+  auto selected_addr = oc_cloud_endpoint_selected_address(&ce);
+  ASSERT_EQ(nullptr, selected_addr);
+  auto selected_id = oc_cloud_endpoint_selected_id(&ce);
+  ASSERT_EQ(nullptr, selected_id);
+
+  auto uri1 = OC_STRING_VIEW("/uri/1");
+  oc_uuid_t id1;
+  oc_gen_uuid(&id1);
+  auto *ep1 = oc_cloud_endpoint_add(&ce, uri1, id1);
+  ASSERT_NE(nullptr, ep1);
+
+#ifdef OC_DYNAMIC_ALLOCATION
+  auto uri2 = OC_STRING_VIEW("/uri/2");
+  oc_uuid_t id2;
+  oc_gen_uuid(&id2);
+  auto *ep2 = oc_cloud_endpoint_add(&ce, uri2, id2);
+  ASSERT_NE(nullptr, ep2);
+  auto uri3 = OC_STRING_VIEW("/uri/3");
+  oc_uuid_t id3;
+  oc_gen_uuid(&id3);
+  ASSERT_NE(nullptr, oc_cloud_endpoint_add(&ce, uri3, id3));
+  EXPECT_TRUE(oc_cloud_endpoint_select_by_uri(&ce, uri2));
+  selected_addr = oc_cloud_endpoint_selected_address(&ce);
+  ASSERT_NE(nullptr, selected_addr);
+  ASSERT_STREQ(uri2.data, oc_string(*selected_addr));
+  selected_id = oc_cloud_endpoint_selected_id(&ce);
+  EXPECT_TRUE(oc_uuid_is_equal(id2, *selected_id));
+
+  EXPECT_TRUE(oc_cloud_endpoint_remove(&ce, ep2));
+  selected_addr = oc_cloud_endpoint_selected_address(&ce);
+  // uri3 is next, so it should be selected
+  ASSERT_NE(nullptr, selected_addr);
+  ASSERT_STREQ(uri3.data, oc_string(*selected_addr));
+  selected_id = oc_cloud_endpoint_selected_id(&ce);
+  EXPECT_TRUE(oc_uuid_is_equal(id3, *selected_id));
+
+  EXPECT_TRUE(oc_cloud_endpoint_remove_by_uri(&ce, uri3));
+  // the list should rotate back to uri1 after uri3 is removed
+  selected_addr = oc_cloud_endpoint_selected_address(&ce);
+  ASSERT_NE(nullptr, selected_addr);
+  ASSERT_STREQ(uri1.data, oc_string(*selected_addr));
+  selected_id = oc_cloud_endpoint_selected_id(&ce);
+  EXPECT_TRUE(oc_uuid_is_equal(id1, *selected_id));
+#endif /* OC_DYNAMIC_ALLOCATION */
+
+  EXPECT_TRUE(oc_cloud_endpoint_remove(&ce, ep1));
+  EXPECT_EQ(0, oc_cloud_endpoints_size(&ce));
+  EXPECT_FALSE(oc_cloud_endpoint_is_selected(&ce, uri1));
+  selected_addr = oc_cloud_endpoint_selected_address(&ce);
+  ASSERT_EQ(nullptr, selected_addr);
+  selected_id = oc_cloud_endpoint_selected_id(&ce);
+  ASSERT_EQ(nullptr, selected_id);
+}
+
+TEST_F(TestCloudEndpoint, Find)
+{
+  oc_cloud_endpoints_t &ce{ getCloudEndpoints() };
+
+  auto uri1 = OC_STRING_VIEW("/uri/1");
+  auto ce1 = oc_cloud_endpoint_add(&ce, uri1, {});
+  ASSERT_NE(nullptr, ce1);
+  auto uri2 = OC_STRING_VIEW("/uri/2");
+  auto ce2 = oc_cloud_endpoint_add(&ce, uri2, {});
+  ASSERT_NE(nullptr, ce2);
+  auto uri3 = OC_STRING_VIEW("/uri/3");
+
+  auto found = oc_cloud_endpoint_find(&ce, uri1);
+  EXPECT_EQ(ce1, found);
+  found = oc_cloud_endpoint_find(&ce, uri2);
+  EXPECT_EQ(ce2, found);
+  found = oc_cloud_endpoint_find(&ce, uri3);
+  EXPECT_EQ(nullptr, found);
+
+  oc_cloud_endpoints_t ceEmpty{};
+  EXPECT_EQ(nullptr, oc_cloud_endpoint_find(&ceEmpty, uri1));
+}
+
+TEST_F(TestCloudEndpoint, EncodeEmpty)
+{
+  oc::RepPool pool{};
+
+  // if the list is empty, nothing should be encoded
+  oc_rep_begin_root_object();
+  oc_cloud_endpoints_encode(oc_rep_object(root), &getCloudEndpoints(),
+                            OC_STRING_VIEW("servers"), true);
+  oc_rep_end_root_object();
+  ASSERT_EQ(CborNoError, oc_rep_get_cbor_errno());
+  oc::oc_rep_unique_ptr rep = pool.ParsePayload();
+  ASSERT_EQ(nullptr, rep.get());
+}
+
+TEST_F(TestCloudEndpoint, EncodeSingle)
+{
+  oc_cloud_endpoints_t &ce{ getCloudEndpoints() };
+  auto uri1 = OC_STRING_VIEW("/uri/1");
+  oc_uuid_t id1;
+  oc_gen_uuid(&id1);
+  auto *ep1 = oc_cloud_endpoint_add(&ce, uri1, id1);
+  ASSERT_NE(nullptr, ep1);
+
+  oc::RepPool pool{};
+  oc_rep_begin_root_object();
+  oc_cloud_endpoints_encode(oc_rep_object(root), &getCloudEndpoints(),
+                            OC_STRING_VIEW("servers"),
+                            /*skipIfSingleAndSelected*/ false);
+  oc_rep_end_root_object();
+  oc::oc_rep_unique_ptr rep = pool.ParsePayload();
+  ASSERT_NE(nullptr, rep.get());
+  oc::RepPool::CheckJson(rep.get(), R"({"servers":[)" +
+                                      encodeCloudEndpointItem(uri1.data, id1) +
+                                      R"(]})");
+  rep.reset();
+  pool.Clear();
+
+  oc_rep_begin_root_object();
+  oc_cloud_endpoints_encode(oc_rep_object(root), &getCloudEndpoints(),
+                            OC_STRING_VIEW("servers"),
+                            /*skipIfSingleAndSelected*/ true);
+  oc_rep_end_root_object();
+  rep = pool.ParsePayload();
+  EXPECT_EQ(nullptr, rep.get());
+}
+
+TEST_F(TestCloudEndpoint, EncodeMultiple)
+{
+  oc_cloud_endpoints_t &ce{ getCloudEndpoints() };
+  auto uri1 = OC_STRING_VIEW("/uri/1");
+  oc_uuid_t id1;
+  oc_gen_uuid(&id1);
+  ASSERT_NE(nullptr, oc_cloud_endpoint_add(&ce, uri1, id1));
+  auto uri2 = OC_STRING_VIEW("/uri/2");
+  oc_uuid_t id2;
+  oc_gen_uuid(&id2);
+  ASSERT_NE(nullptr, oc_cloud_endpoint_add(&ce, uri2, id2));
+
+  oc::RepPool pool{};
+  oc_rep_begin_root_object();
+  oc_cloud_endpoints_encode(oc_rep_object(root), &getCloudEndpoints(),
+                            OC_STRING_VIEW("servers"),
+                            /*skipIfSingleAndSelected*/ false);
+  oc_rep_end_root_object();
+  oc::oc_rep_unique_ptr rep = pool.ParsePayload();
+  ASSERT_NE(nullptr, rep.get());
+  oc::RepPool::CheckJson(
+    rep.get(), R"({"servers":[)" + encodeCloudEndpointItem(uri1.data, id1) +
+                 "," + encodeCloudEndpointItem(uri2.data, id2) + R"(]})");
+  rep.reset();
+  pool.Clear();
+
+  oc_rep_begin_root_object();
+  oc_cloud_endpoints_encode(oc_rep_object(root), &getCloudEndpoints(),
+                            OC_STRING_VIEW("servers"),
+                            /*skipIfSingleAndSelected*/ true);
+  oc_rep_end_root_object();
+  rep = pool.ParsePayload();
+  ASSERT_NE(nullptr, rep.get());
+  oc::RepPool::CheckJson(
+    rep.get(), R"({"servers":[)" + encodeCloudEndpointItem(uri1.data, id1) +
+                 "," + encodeCloudEndpointItem(uri2.data, id2) + R"(]})");
+}

--- a/api/cloud/unittest/cloud_manager_test.cpp
+++ b/api/cloud/unittest/cloud_manager_test.cpp
@@ -17,6 +17,7 @@
  *
  ******************************************************************/
 
+#include "api/cloud/oc_cloud_context_internal.h"
 #include "api/cloud/oc_cloud_internal.h"
 #include "api/cloud/oc_cloud_manager_internal.h"
 #include "api/cloud/oc_cloud_store_internal.h"
@@ -44,16 +45,18 @@ public:
     ASSERT_TRUE(oc::TestDevice::StartServer());
 
     memset(&m_context, 0, sizeof(m_context));
-#define UID "501"
-    oc_new_string(&m_context.store.uid, UID, strlen(UID));
+    std::string uid = "501";
+    oc_new_string(&m_context.store.uid, uid.c_str(), uid.length());
     m_context.cloud_ep = oc_new_endpoint();
     memset(m_context.cloud_ep, 0, sizeof(oc_endpoint_t));
-#define ENDPOINT "coap://224.0.1.187:5683"
-    oc_new_string(&m_context.store.ci_server, ENDPOINT, strlen(ENDPOINT));
-#define TOKEN "access_token"
-    oc_new_string(&m_context.store.access_token, TOKEN, strlen(TOKEN));
-#define RTOKEN "refresh_token"
-    oc_new_string(&m_context.store.refresh_token, RTOKEN, strlen(RTOKEN));
+    std::string endpoint = "coap://224.0.1.187:5683";
+    oc_new_string(&m_context.store.ci_server, endpoint.c_str(),
+                  endpoint.length());
+    std::string token = "access_token";
+    oc_new_string(&m_context.store.access_token, token.c_str(), token.length());
+    std::string rtoken = "refresh_token";
+    oc_new_string(&m_context.store.refresh_token, rtoken.c_str(),
+                  rtoken.length());
   }
 
   void TearDown() override

--- a/api/cloud/unittest/cloud_rd_test.cpp
+++ b/api/cloud/unittest/cloud_rd_test.cpp
@@ -16,6 +16,7 @@
  *
  ******************************************************************/
 
+#include "api/cloud/oc_cloud_context_internal.h"
 #include "api/cloud/oc_cloud_internal.h"
 #include "api/oc_link_internal.h"
 #include "oc_api.h"

--- a/api/cloud/unittest/cloud_resource_test.cpp
+++ b/api/cloud/unittest/cloud_resource_test.cpp
@@ -55,7 +55,7 @@ struct CloudResourceData
   static std::vector<CloudEndpointData> decodeArray(const oc_rep_t *servers)
   {
     std::vector<CloudEndpointData> result{};
-    for (const oc_rep_t *server = servers; server != NULL;
+    for (const oc_rep_t *server = servers; server != nullptr;
          server = server->next) {
       const oc_rep_t *rep = oc_rep_get(server->value.object, OC_REP_STRING,
                                        "uri", OC_CHAR_ARRAY_LEN("uri"));
@@ -264,7 +264,7 @@ TEST_F(TestCloudResourceWithServer, GetRequest_NoCloudServers)
   EXPECT_EQ(0, crd.clec);
 
   // restore default store
-  oc_cloud_store_initialize(&ctx->store);
+  oc_cloud_store_initialize(&ctx->store, nullptr, nullptr);
 }
 
 template<typename Fn, oc_status_t CODE = OC_STATUS_BAD_REQUEST>

--- a/api/cloud/unittest/cloud_resource_test.cpp
+++ b/api/cloud/unittest/cloud_resource_test.cpp
@@ -16,33 +16,175 @@
  *
  ******************************************************************/
 
+#include "api/cloud/oc_cloud_resource_internal.h"
+#include "api/oc_rep_internal.h"
 #include "oc_core_res.h"
 #include "oc_ri.h"
+#include "port/oc_log_internal.h"
 #include "tests/gtest/Device.h"
+#include "tests/gtest/RepPool.h"
+#include "tests/gtest/Resource.h"
+#include "util/oc_macros_internal.h"
 
-#include <gtest/gtest.h>
 #include <cstddef>
+#include <gtest/gtest.h>
+#include <string>
+
+using namespace std::chrono_literals;
 
 static constexpr size_t kDeviceID{ 0 };
 
-class TestCloudResourceWithServer : public testing::Test {
-public:
-  static void SetUpTestCase() { ASSERT_TRUE(oc::TestDevice::StartServer()); }
+struct CloudResourceData
+{
+  std::string apn;
+  std::string cis;
+  std::string sid;
+  int clec;
+  std::string cps;
 
-  static void TearDownTestCase() { oc::TestDevice::StopServer(); }
-
-  void TearDown() override { oc::TestDevice::Reset(); }
+  static CloudResourceData decode(const oc_rep_t *rep)
+  {
+    CloudResourceData crd{};
+    for (; rep != nullptr; rep = rep->next) {
+      if (oc_rep_is_property_with_type(
+            rep, OC_REP_STRING, OCF_COAPCLOUDCONF_PROP_AUTHPROVIDER,
+            OC_CHAR_ARRAY_LEN(OCF_COAPCLOUDCONF_PROP_AUTHPROVIDER))) {
+        crd.apn = std::string(oc_string(rep->value.string));
+        continue;
+      }
+      if (oc_rep_is_property_with_type(
+            rep, OC_REP_STRING, OCF_COAPCLOUDCONF_PROP_CISERVER,
+            OC_CHAR_ARRAY_LEN(OCF_COAPCLOUDCONF_PROP_CISERVER))) {
+        crd.cis = std::string(oc_string(rep->value.string));
+        continue;
+      }
+      if (oc_rep_is_property_with_type(
+            rep, OC_REP_STRING, OCF_COAPCLOUDCONF_PROP_SERVERID,
+            OC_CHAR_ARRAY_LEN(OCF_COAPCLOUDCONF_PROP_SERVERID))) {
+        crd.sid = std::string(oc_string(rep->value.string));
+        continue;
+      }
+      if (oc_rep_is_property_with_type(
+            rep, OC_REP_INT, OCF_COAPCLOUDCONF_PROP_LASTERRORCODE,
+            OC_CHAR_ARRAY_LEN(OCF_COAPCLOUDCONF_PROP_LASTERRORCODE))) {
+        crd.clec = static_cast<decltype(crd.clec)>(rep->value.integer);
+        continue;
+      }
+      if (oc_rep_is_property_with_type(
+            rep, OC_REP_STRING, OCF_COAPCLOUDCONF_PROP_PROVISIONINGSTATUS,
+            OC_CHAR_ARRAY_LEN(OCF_COAPCLOUDCONF_PROP_PROVISIONINGSTATUS))) {
+        crd.cps = std::string(oc_string(rep->value.string));
+        continue;
+      }
+    }
+    return crd;
+  }
 };
 
-TEST_F(TestCloudResourceWithServer, GetResource)
+class TestCloudResource : public testing::Test {};
+
+TEST_F(TestCloudResource, CpsToString)
+{
+  EXPECT_STREQ(OC_CPS_UNINITIALIZED_STR,
+               oc_cps_to_string(OC_CPS_UNINITIALIZED).data);
+  EXPECT_STREQ(OC_CPS_READYTOREGISTER_STR,
+               oc_cps_to_string(OC_CPS_READYTOREGISTER).data);
+  EXPECT_STREQ(OC_CPS_REGISTERING_STR,
+               oc_cps_to_string(OC_CPS_REGISTERING).data);
+  EXPECT_STREQ(OC_CPS_REGISTERED_STR, oc_cps_to_string(OC_CPS_REGISTERED).data);
+  EXPECT_STREQ(OC_CPS_FAILED_STR, oc_cps_to_string(OC_CPS_FAILED).data);
+  EXPECT_STREQ(OC_CPS_DEREGISTERING_STR,
+               oc_cps_to_string(OC_CPS_DEREGISTERING).data);
+
+  EXPECT_EQ(nullptr, oc_cps_to_string(static_cast<oc_cps_t>(-1)).data);
+}
+
+class TestCloudResourceWithServer : public testing::Test {
+public:
+  static void SetUpTestCase()
+  {
+    ASSERT_TRUE(oc::TestDevice::StartServer());
+#ifdef OC_HAS_FEATURE_RESOURCE_ACCESS_IN_RFOTM
+    ASSERT_TRUE(oc::SetAccessInRFOTM(OCF_COAPCLOUDCONF, kDeviceID, false,
+                                     OC_PERM_RETRIEVE | OC_PERM_UPDATE));
+#endif /* OC_HAS_FEATURE_RESOURCE_ACCESS_IN_RFOTM */
+  }
+
+  static void TearDownTestCase()
+  {
+    oc::TestDevice::StopServer();
+  }
+
+  void SetUp() override
+  {
+    // TODO: rm
+    oc_log_set_level(OC_LOG_LEVEL_DEBUG);
+  }
+
+  void TearDown() override
+  {
+    // TODO: rm
+    oc_log_set_level(OC_LOG_LEVEL_INFO);
+  }
+};
+
+TEST_F(TestCloudResourceWithServer, GetResourceByIndex_F)
+{
+  EXPECT_EQ(nullptr, oc_core_get_resource_by_index(OCF_COAPCLOUDCONF, /*device*/
+                                                   SIZE_MAX));
+}
+
+TEST_F(TestCloudResourceWithServer, GetResourceByIndex)
 {
   EXPECT_NE(nullptr,
             oc_core_get_resource_by_index(OCF_COAPCLOUDCONF, kDeviceID));
 }
 
+TEST_F(TestCloudResourceWithServer, GetResourceByURI_F)
+{
+  EXPECT_EQ(nullptr,
+            oc_core_get_resource_by_uri_v1(
+              OCF_COAPCLOUDCONF_URI, OC_CHAR_ARRAY_LEN(OCF_COAPCLOUDCONF_URI),
+              /*device*/ SIZE_MAX));
+}
+
+TEST_F(TestCloudResourceWithServer, GetResourceByURI)
+{
+  oc_resource_t *res = oc_core_get_resource_by_uri_v1(
+    OCF_COAPCLOUDCONF_URI, OC_CHAR_ARRAY_LEN(OCF_COAPCLOUDCONF_URI), kDeviceID);
+  EXPECT_NE(nullptr, res);
+
+  EXPECT_STREQ(OCF_COAPCLOUDCONF_URI, oc_string(res->uri));
+}
+
+#if !defined(OC_SECURITY) || defined(OC_HAS_FEATURE_RESOURCE_ACCESS_IN_RFOTM)
+
 TEST_F(TestCloudResourceWithServer, GetRequest)
 {
-  // TODO
+  auto epOpt = oc::TestDevice::GetEndpoint(kDeviceID);
+  ASSERT_TRUE(epOpt.has_value());
+  auto ep = std::move(*epOpt);
+
+  auto get_handler = [](oc_client_response_t *data) {
+    EXPECT_EQ(OC_STATUS_OK, data->code);
+    oc::TestDevice::Terminate();
+    OC_DBG("GET payload: %s", oc::RepPool::GetJson(data->payload).data());
+    *static_cast<CloudResourceData *>(data->user_data) =
+      CloudResourceData::decode(data->payload);
+  };
+
+  auto timeout = 1s;
+  CloudResourceData crd{};
+  ASSERT_TRUE(oc_do_get_with_timeout(OCF_COAPCLOUDCONF_URI, &ep, nullptr,
+                                     timeout.count(), get_handler, LOW_QOS,
+                                     &crd));
+  oc::TestDevice::PoolEventsMsV1(timeout, true);
+
+  EXPECT_TRUE(crd.apn.empty());
+  EXPECT_STREQ(OCF_COAPCLOUDCONF_DEFAULT_CIS, crd.cis.c_str());
+  EXPECT_STREQ(OCF_COAPCLOUDCONF_DEFAULT_SID, crd.sid.c_str());
+  EXPECT_EQ(OC_CPS_UNINITIALIZED_STR, crd.cps);
+  EXPECT_EQ(0, crd.clec);
 }
 
 TEST_F(TestCloudResourceWithServer, PostRequest)
@@ -52,10 +194,29 @@ TEST_F(TestCloudResourceWithServer, PostRequest)
 
 TEST_F(TestCloudResourceWithServer, PutRequest_FailMethodNotSupported)
 {
-  // TODO
+  auto epOpt = oc::TestDevice::GetEndpoint(kDeviceID);
+  ASSERT_TRUE(epOpt.has_value());
+  auto ep = std::move(*epOpt);
+#if defined(OC_SECURITY) && !defined(OC_HAS_FEATURE_RESOURCE_ACCESS_IN_RFOTM)
+  oc_status_t code = OC_STATUS_UNAUTHORIZED;
+#else  /* !OC_SECURITY || OC_HAS_FEATURE_RESOURCE_ACCESS_IN_RFOTM */
+  oc_status_t code = OC_STATUS_METHOD_NOT_ALLOWED;
+#endif /* OC_SECURITY */
+  oc::testNotSupportedMethod(OC_PUT, &ep, OCF_COAPCLOUDCONF_URI, nullptr, code);
 }
 
 TEST_F(TestCloudResourceWithServer, DeleteRequest_FailMethodNotSupported)
 {
-  // TODO
+  auto epOpt = oc::TestDevice::GetEndpoint(kDeviceID);
+  ASSERT_TRUE(epOpt.has_value());
+  auto ep = std::move(*epOpt);
+#ifdef OC_SECURITY
+  oc_status_t code = OC_STATUS_UNAUTHORIZED;
+#else  /* !OC_SECURITY */
+  oc_status_t code = OC_STATUS_METHOD_NOT_ALLOWED;
+#endif /* OC_SECURITY */
+  oc::testNotSupportedMethod(OC_DELETE, &ep, OCF_COAPCLOUDCONF_URI, nullptr,
+                             code);
 }
+
+#endif /* !OC_SECURITY || OC_HAS_FEATURE_RESOURCE_ACCESS_IN_RFOTM */

--- a/api/cloud/unittest/cloud_store_test.cpp
+++ b/api/cloud/unittest/cloud_store_test.cpp
@@ -123,7 +123,7 @@ public:
   static void validateDefaults(const oc_cloud_store_t *store)
   {
     oc_cloud_store_t def{};
-    oc_cloud_store_initialize(&def);
+    oc_cloud_store_initialize(&def, nullptr, nullptr);
     compareStores(&def, store);
     freeStore(&def);
   }

--- a/api/cloud/unittest/cloud_store_test.cpp
+++ b/api/cloud/unittest/cloud_store_test.cpp
@@ -21,17 +21,27 @@
 #include "api/cloud/oc_cloud_internal.h"
 #include "api/cloud/oc_cloud_resource_internal.h"
 #include "api/cloud/oc_cloud_store_internal.h"
+#include "api/oc_event_callback_internal.h"
+#include "api/oc_storage_internal.h"
 #include "oc_api.h"
 #include "oc_config.h"
 #include "oc_collection.h"
+#include "oc_uuid.h"
+#include "port/oc_log_internal.h"
+#include "port/oc_random.h"
 #include "port/oc_storage.h"
 #include "port/oc_storage_internal.h"
 #include "tests/gtest/Device.h"
 #include "tests/gtest/RepPool.h"
 
+#include <array>
 #include <filesystem>
+#include <fstream>
+#include <functional>
 #include <gtest/gtest.h>
+#include <string>
 #include <string_view>
+#include <map>
 
 using namespace std::chrono_literals;
 
@@ -39,7 +49,9 @@ static constexpr std::string_view access_token = "access_token";
 static constexpr std::string_view auth_provider = "auth_provider";
 static constexpr std::string_view ci_server = "ci_server";
 static constexpr std::string_view refresh_token = "refresh_token";
-static constexpr std::string_view sid = "sid";
+static constexpr oc_uuid_t sid{ { 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD,
+                                  0xEF, 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB,
+                                  0xCD, 0xEF } };
 static constexpr std::string_view uid = "uid";
 static constexpr size_t kDevice = 1234;
 static constexpr int64_t kExpiresIn = 5678;
@@ -59,15 +71,49 @@ public:
 #endif /* OC_STORAGE */
   }
 
+  static void compareEndpoints(const oc_cloud_endpoints_t &eps1,
+                               const oc_cloud_endpoints_t &eps2)
+  {
+    std::map<std::string, oc_cloud_endpoint_t, std::less<>> e1{};
+    std::map<std::string, oc_cloud_endpoint_t, std::less<>> e2{};
+    oc_cloud_endpoint_t *eps = nullptr;
+    if (eps1.endpoints != nullptr) {
+      eps = static_cast<oc_cloud_endpoint_t *>(oc_list_head(eps1.endpoints));
+    }
+    while (eps != nullptr) {
+      e1[oc_string(eps->uri)] = *eps;
+      eps = eps->next;
+    }
+    eps = nullptr;
+    if (eps2.endpoints != nullptr) {
+      eps = static_cast<oc_cloud_endpoint_t *>(oc_list_head(eps2.endpoints));
+    }
+    while (eps != nullptr) {
+      e2[oc_string(eps->uri)] = *eps;
+      eps = eps->next;
+    }
+
+    EXPECT_EQ(e1.size(), e2.size());
+    if (e1.size() != e2.size()) {
+      return;
+    }
+
+    for (const auto &[key, value] : e1) {
+      auto it = e2.find(key);
+      EXPECT_NE(e2.end(), it);
+      EXPECT_STREQ(oc_string(value.uri), oc_string(it->second.uri));
+      EXPECT_TRUE(oc_uuid_is_equal(value.id, it->second.id));
+    }
+  }
+
   static void compareStores(const oc_cloud_store_t *s1,
                             const oc_cloud_store_t *s2)
   {
-    EXPECT_STREQ(oc_string(s1->ci_server), oc_string(s2->ci_server));
+    compareEndpoints(s1->ci_servers, s2->ci_servers);
     EXPECT_STREQ(oc_string(s1->auth_provider), oc_string(s2->auth_provider));
     EXPECT_STREQ(oc_string(s1->uid), oc_string(s2->uid));
     EXPECT_STREQ(oc_string(s1->access_token), oc_string(s2->access_token));
     EXPECT_STREQ(oc_string(s1->refresh_token), oc_string(s2->refresh_token));
-    EXPECT_STREQ(oc_string(s1->sid), oc_string(s2->sid));
     EXPECT_EQ(s1->expires_in, s2->expires_in);
     EXPECT_EQ(s1->device, s2->device);
     EXPECT_EQ(s1->cps, s2->cps);
@@ -77,7 +123,7 @@ public:
   static void validateDefaults(const oc_cloud_store_t *store)
   {
     oc_cloud_store_t def{};
-    cloud_store_initialize(&def);
+    oc_cloud_store_initialize(&def);
     compareStores(&def, store);
     freeStore(&def);
   }
@@ -86,7 +132,9 @@ public:
   {
     oc_cloud_store_t store;
     memset(&store, 0, sizeof(store));
-    oc_new_string(&store.ci_server, ci_server.data(), ci_server.length());
+    oc_cloud_endpoints_init(
+      &store.ci_servers, nullptr, nullptr,
+      oc_string_view(ci_server.data(), ci_server.length()), sid);
     oc_new_string(&store.auth_provider, auth_provider.data(),
                   auth_provider.length());
     oc_new_string(&store.uid, uid.data(), uid.length());
@@ -94,7 +142,6 @@ public:
                   access_token.length());
     oc_new_string(&store.refresh_token, refresh_token.data(),
                   refresh_token.length());
-    oc_new_string(&store.sid, sid.data(), sid.length());
     store.expires_in = kExpiresIn;
     store.device = kDevice;
     store.cps = kCps;
@@ -104,17 +151,17 @@ public:
 
   static void freeStore(oc_cloud_store_t *store)
   {
-    oc_free_string(&store->ci_server);
+    oc_cloud_endpoints_deinit(&store->ci_servers);
     oc_free_string(&store->auth_provider);
     oc_free_string(&store->uid);
     oc_free_string(&store->access_token);
     oc_free_string(&store->refresh_token);
-    oc_free_string(&store->sid);
   }
 
   static void SetUpTestCase()
   {
     clean();
+    oc_random_init();
 #ifdef OC_STORAGE
     ASSERT_EQ(0, oc_storage_config(kCloudStoragePath.data()));
 #endif /* OC_STORAGE */
@@ -125,14 +172,57 @@ public:
 #ifdef OC_STORAGE
     EXPECT_EQ(0, oc_storage_reset());
 #endif /* OC_STORAGE */
+    oc_random_destroy();
     clean();
   }
 
   void TearDown() override
   {
+    // selecting a cloud server schedules a storage dump, which we need to
+    // remove to avoid a leak
+    oc_event_callbacks_shutdown();
     clean();
   }
 };
+
+TEST_F(TestCloudStore, Decode_ServersArray)
+{
+  oc::RepPool pool{};
+  oc_rep_start_root_object();
+  std::string key{ "x.org.iotivity.servers" };
+  oc_rep_encode_text_string(oc_rep_object(root), key.c_str(), key.length());
+  oc_rep_begin_array(oc_rep_object(root), servers);
+  oc_rep_object_array_begin_item(servers);
+  // missing uri -> item skipped
+  oc_rep_set_text_string(servers, id, "00000000-0000-0000-0000-000000000000");
+  oc_rep_object_array_end_item(servers);
+  oc_rep_object_array_begin_item(servers);
+  // missing id -> item skipped
+  oc_rep_set_text_string(servers, uri, "coaps://plgd.dev");
+  oc_rep_object_array_end_item(servers);
+  oc_rep_object_array_begin_item(servers);
+  // invalid id -> item skipped
+  oc_rep_set_text_string(servers, uri, "coaps://plgd.dev");
+  oc_rep_set_text_string(servers, id, "invalid");
+  oc_rep_object_array_end_item(servers);
+  // valid
+  oc_rep_object_array_begin_item(servers);
+  oc_rep_set_text_string(servers, uri, "coaps://plgd.dev");
+  oc_rep_set_text_string(servers, id, "00000000-0000-0000-0000-000000000000");
+  oc_rep_object_array_end_item(servers);
+  // duplicate -> item skipped
+  oc_rep_object_array_begin_item(servers);
+  oc_rep_set_text_string(servers, uri, "coaps://plgd.dev");
+  oc_rep_set_text_string(servers, id, "00000000-0000-0000-0000-000000000000");
+  oc_rep_object_array_end_item(servers);
+  oc_rep_end_array(oc_rep_object(root), servers);
+  oc_rep_end_root_object();
+  ASSERT_EQ(CborNoError, oc_rep_get_cbor_errno());
+
+  oc_cloud_store_t store{};
+  EXPECT_TRUE(oc_cloud_store_decode(pool.ParsePayload().get(), &store));
+  freeStore(&store);
+}
 
 TEST_F(TestCloudStore, Decode_FailUnknownProperty)
 {
@@ -143,7 +233,7 @@ TEST_F(TestCloudStore, Decode_FailUnknownProperty)
   ASSERT_EQ(CborNoError, oc_rep_get_cbor_errno());
 
   oc_cloud_store_t store{};
-  EXPECT_FALSE(cloud_store_decode(pool.ParsePayload().get(), &store));
+  EXPECT_FALSE(oc_cloud_store_decode(pool.ParsePayload().get(), &store));
   freeStore(&store);
 }
 
@@ -156,7 +246,7 @@ TEST_F(TestCloudStore, Decode_FailUnknownIntProperty)
   ASSERT_EQ(CborNoError, oc_rep_get_cbor_errno());
 
   oc_cloud_store_t store{};
-  EXPECT_FALSE(cloud_store_decode(pool.ParsePayload().get(), &store));
+  EXPECT_FALSE(oc_cloud_store_decode(pool.ParsePayload().get(), &store));
   freeStore(&store);
 }
 
@@ -169,14 +259,48 @@ TEST_F(TestCloudStore, Decode_FailUnknownStringProperty)
   ASSERT_EQ(CborNoError, oc_rep_get_cbor_errno());
 
   oc_cloud_store_t store{};
-  EXPECT_FALSE(cloud_store_decode(pool.ParsePayload().get(), &store));
+  EXPECT_FALSE(oc_cloud_store_decode(pool.ParsePayload().get(), &store));
+  freeStore(&store);
+}
+
+TEST_F(TestCloudStore, Decode_FailUnknownObjectArrayProperty)
+{
+  oc::RepPool pool{};
+  oc_rep_start_root_object();
+  std::string key{ "key" };
+  oc_rep_encode_text_string(oc_rep_object(root), key.c_str(), key.length());
+  oc_rep_begin_array(oc_rep_object(root), plgd);
+  oc_rep_object_array_begin_item(plgd);
+  oc_rep_set_text_string(plgd, plgd, "dev");
+  oc_rep_object_array_end_item(plgd);
+  oc_rep_end_array(oc_rep_object(root), plgd);
+  oc_rep_end_root_object();
+  ASSERT_EQ(CborNoError, oc_rep_get_cbor_errno());
+
+  oc_cloud_store_t store{};
+  EXPECT_FALSE(oc_cloud_store_decode(pool.ParsePayload().get(), &store));
+  freeStore(&store);
+}
+
+TEST_F(TestCloudStore, Decode_FailInvalidSid)
+{
+  oc::RepPool pool{};
+  oc_rep_start_root_object();
+  oc_rep_set_text_string(root, ci_server, "coaps://plgd.dev");
+  oc_rep_set_text_string(root, sid, "non-UUID");
+  oc_rep_end_root_object();
+  ASSERT_EQ(CborNoError, oc_rep_get_cbor_errno());
+
+  oc_cloud_store_t store{};
+  // invalid sid resuls in a warning, not an error
+  EXPECT_TRUE(oc_cloud_store_decode(pool.ParsePayload().get(), &store));
   freeStore(&store);
 }
 
 TEST_F(TestCloudStore, LoadDefaults)
 {
   oc_cloud_store_t store{};
-  EXPECT_FALSE(cloud_store_load(&store));
+  EXPECT_FALSE(oc_cloud_store_load(&store));
 
   validateDefaults(&store);
   freeStore(&store);
@@ -185,14 +309,99 @@ TEST_F(TestCloudStore, LoadDefaults)
 TEST_F(TestCloudStore, DumpAndLoad)
 {
   oc_cloud_store_t store = makeStore();
-  ASSERT_LT(0, cloud_store_dump(&store));
+  ASSERT_LT(0, oc_cloud_store_dump(&store));
 
   oc_cloud_store_t store2{};
   store2.device = store.device;
-  ASSERT_TRUE(cloud_store_load(&store2));
+  ASSERT_TRUE(oc_cloud_store_load(&store2));
   compareStores(&store, &store2);
 
   freeStore(&store2);
+  freeStore(&store);
+}
+
+#ifdef OC_DYNAMIC_ALLOCATION
+
+TEST_F(TestCloudStore, DumpAndLoad_MultipleEndpoints)
+{
+  oc_cloud_store_t store = makeStore();
+  oc_uuid_t id{};
+  oc_gen_uuid(&id);
+  ASSERT_TRUE(
+    oc_cloud_endpoint_add(&store.ci_servers, OC_STRING_VIEW("/test/1"), id));
+  oc_gen_uuid(&id);
+  ASSERT_TRUE(
+    oc_cloud_endpoint_add(&store.ci_servers, OC_STRING_VIEW("/test/2"), id));
+  ASSERT_LT(0, oc_cloud_store_dump(&store));
+
+  oc_cloud_store_t store2{};
+  store2.device = store.device;
+  ASSERT_TRUE(oc_cloud_store_load(&store2));
+  compareStores(&store, &store2);
+
+  freeStore(&store2);
+  freeStore(&store);
+}
+
+#endif /* OC_DYNAMIC_ALLOCATION */
+
+static void
+writeCloudStoreData(const std::function<void()> &writePayload)
+{
+  std::array<char, OC_STORAGE_SVR_TAG_MAX> tag{};
+  ASSERT_LT(0, oc_storage_gen_svr_tag(OC_CLOUD_STORE_NAME, kDevice, &tag[0],
+                                      tag.size()));
+
+  std::ofstream storage(std::string(kCloudStoragePath) + "/" + tag.data());
+  ASSERT_TRUE(storage.good());
+
+  oc::RepPool pool{};
+  writePayload();
+  ASSERT_EQ(CborNoError, oc_rep_get_cbor_errno());
+  const uint8_t *payload = oc_rep_get_encoder_buf();
+  int payload_size = oc_rep_get_encoded_payload_size();
+  storage.write(reinterpret_cast<const char *>(payload), payload_size);
+
+#if OC_DBG_IS_ENABLED
+  auto rep = pool.ParsePayload();
+  OC_DBG("storage: %s", oc::RepPool::GetJson(rep.get(), true).data());
+#endif
+}
+
+TEST_F(TestCloudStore, SingleStoreData)
+{
+  writeCloudStoreData([]() {
+    oc_rep_begin_root_object();
+    oc_rep_set_int(root, cps, 1);
+    oc_rep_end_root_object();
+  });
+
+  oc_cloud_store_t store{};
+  store.device = kDevice;
+  ASSERT_TRUE(oc_cloud_store_load(&store));
+
+  freeStore(&store);
+}
+
+TEST_F(TestCloudStore, InvalidStoreData)
+{
+  std::array<char, OC_STORAGE_SVR_TAG_MAX> tag{};
+  ASSERT_LT(0, oc_storage_gen_svr_tag(OC_CLOUD_STORE_NAME, kDevice, &tag[0],
+                                      tag.size()));
+
+  std::ofstream storage(std::string(kCloudStoragePath) + "/" + tag.data());
+  ASSERT_TRUE(storage.good());
+
+  writeCloudStoreData([]() {
+    oc_rep_begin_root_object();
+    oc_rep_set_text_string(root, hello, "world");
+    oc_rep_end_root_object();
+  });
+
+  oc_cloud_store_t store{};
+  store.device = kDevice;
+  ASSERT_FALSE(oc_cloud_store_load(&store));
+
   freeStore(&store);
 }
 
@@ -215,57 +424,52 @@ public:
 #endif /* OC_STORAGE */
   }
 
-  void SetUp() override
-  {
-    m_store = TestCloudStore::makeStore();
-  }
-
   void TearDown() override
   {
-    TestCloudStore::freeStore(&m_store);
     TestCloudStore::clean();
     oc::TestDevice::Reset();
   }
-
-  oc_cloud_store_t m_store;
 };
 
 TEST_F(TestCloudStoreWithServer, DumpAsync)
 {
-  cloud_store_dump_async(&m_store);
+  oc_cloud_store_t store = TestCloudStore::makeStore();
+  oc_cloud_store_dump_async(&store);
   oc::TestDevice::PoolEventsMsV1(50ms);
 
-  oc_cloud_store_t store1;
-  memset(&store1, 0, sizeof(store1));
-  store1.device = m_store.device;
+  oc_cloud_store_t store1{};
+  store1.device = store.device;
 #ifdef OC_STORAGE
-  ASSERT_TRUE(cloud_store_load(&store1));
-  TestCloudStore::compareStores(&m_store, &store1);
+  ASSERT_TRUE(oc_cloud_store_load(&store1));
+  TestCloudStore::compareStores(&store, &store1);
 #else  /* !OC_STORAGE */
-  EXPECT_FALSE(cloud_store_load(&store1));
+  EXPECT_FALSE(oc_cloud_store_load(&store1));
   TestCloudStore::validateDefaults(&store1);
 #endif /* OC_STORAGE */
 
   TestCloudStore::freeStore(&store1);
+  TestCloudStore::freeStore(&store);
 }
 
 TEST_F(TestCloudStoreWithServer, Dump)
 {
+  oc_cloud_store_t store = TestCloudStore::makeStore();
 #ifdef OC_STORAGE
-  EXPECT_LE(0, cloud_store_dump(&m_store));
+  EXPECT_LE(0, oc_cloud_store_dump(&store));
 #else  /* !OC_STORAGE */
-  EXPECT_NE(0, cloud_store_dump(&m_store));
+  EXPECT_NE(0, oc_cloud_store_dump(&store));
 #endif /* OC_STORAGE */
   oc_cloud_store_t store1;
   memset(&store1, 0, sizeof(store1));
-  store1.device = m_store.device;
+  store1.device = store.device;
 #ifdef OC_STORAGE
-  ASSERT_TRUE(cloud_store_load(&store1));
-  TestCloudStore::compareStores(&m_store, &store1);
+  ASSERT_TRUE(oc_cloud_store_load(&store1));
+  TestCloudStore::compareStores(&store, &store1);
 #else  /* !OC_STORAGE */
-  EXPECT_FALSE(cloud_store_load(&store1));
+  EXPECT_FALSE(oc_cloud_store_load(&store1));
   TestCloudStore::validateDefaults(&store1);
 #endif /* OC_STORAGE */
 
   TestCloudStore::freeStore(&store1);
+  TestCloudStore::freeStore(&store);
 }

--- a/api/cloud/unittest/cloud_test.cpp
+++ b/api/cloud/unittest/cloud_test.cpp
@@ -744,6 +744,7 @@ TEST_F(TestCloud, EndpointAPI)
   // remove default
   oc_cloud_endpoints_clear(&ctx->store.ci_servers);
   // no enpoint selected -> both cis and sid should be nullptr
+  EXPECT_EQ(nullptr, oc_cloud_selected_server(ctx));
   EXPECT_EQ(nullptr, oc_cloud_get_cis(ctx));
   EXPECT_EQ(nullptr, oc_cloud_get_sid(ctx));
 
@@ -770,6 +771,7 @@ TEST_F(TestCloud, EndpointAPI)
 #endif /* OC_DYNAMIC_ALLOCATION */
 
   // first item added to empty list should be selected
+  EXPECT_EQ(ep1, oc_cloud_selected_server(ctx));
   EXPECT_STREQ(uri1.c_str(), oc_cloud_get_cis(ctx));
   EXPECT_TRUE(oc_uuid_is_equal(uid1, *oc_cloud_get_sid(ctx)));
 
@@ -777,6 +779,7 @@ TEST_F(TestCloud, EndpointAPI)
   ASSERT_TRUE(oc_cloud_remove_server(ctx, ep1));
 
   // next endpoint should be selected
+  EXPECT_EQ(ep2, oc_cloud_selected_server(ctx));
   EXPECT_STREQ(uri2.c_str(), oc_cloud_get_cis(ctx));
   EXPECT_TRUE(oc_uuid_is_equal(uid2, *oc_cloud_get_sid(ctx)));
 
@@ -817,9 +820,11 @@ TEST_F(TestCloud, EndpointAPI)
   ASSERT_NE(nullptr, toSelect);
   EXPECT_TRUE(oc_cloud_select_server(ctx, toSelect));
 #ifdef OC_DYNAMIC_ALLOCATION
+  EXPECT_EQ(ep3, oc_cloud_selected_server(ctx));
   EXPECT_STREQ(uri3.c_str(), oc_cloud_get_cis(ctx));
   EXPECT_TRUE(oc_uuid_is_equal(uid3, *oc_cloud_get_sid(ctx)));
 #else  /* !OC_DYNAMIC_ALLOCATION */
+  EXPECT_EQ(ep2, oc_cloud_selected_server(ctx));
   EXPECT_STREQ(uri2.c_str(), oc_cloud_get_cis(ctx));
   EXPECT_TRUE(oc_uuid_is_equal(uid2, *oc_cloud_get_sid(ctx)));
 #endif /* OC_DYNAMIC_ALLOCATION */

--- a/api/cloud/unittest/cloud_test.cpp
+++ b/api/cloud/unittest/cloud_test.cpp
@@ -16,19 +16,28 @@
  *
  ******************************************************************/
 
+#include "api/cloud/oc_cloud_apis_internal.h"
 #include "api/cloud/oc_cloud_context_internal.h"
+#include "api/cloud/oc_cloud_deregister_internal.h"
+#include "api/cloud/oc_cloud_endpoint_internal.h"
 #include "api/cloud/oc_cloud_internal.h"
+#include "api/cloud/oc_cloud_resource_internal.h"
+#include "messaging/coap/conf.h"
 #include "oc_api.h"
 #include "oc_cloud.h"
+#include "oc_uuid.h"
 #include "tests/gtest/Device.h"
 #include "util/oc_secure_string_internal.h"
 
 #include <gtest/gtest.h>
+#include <set>
 #include <string>
 
 #ifdef OC_SECURITY
 #include "security/oc_pstat_internal.h"
 #endif
+
+using namespace std::chrono_literals;
 
 static constexpr size_t kDeviceID{ 0 };
 
@@ -38,13 +47,31 @@ public:
 
   static void TearDownTestCase() { oc::TestDevice::StopServer(); }
 
-  void TearDown() override { oc::TestDevice::Reset(); }
+  void TearDown() override
+  {
+    oc::TestDevice::Reset();
+
+    auto *ctx = oc_cloud_get_context(kDeviceID);
+    oc_cloud_context_clear(ctx, false);
+  }
 };
 
 TEST_F(TestCloud, oc_cloud_get_context)
 {
   EXPECT_NE(nullptr, oc_cloud_get_context(kDeviceID));
   EXPECT_EQ(nullptr, oc_cloud_get_context(42));
+}
+
+TEST_F(TestCloud, set_published_resources_ttl)
+{
+  oc_cloud_context_t *ctx = oc_cloud_get_context(kDeviceID);
+  ASSERT_NE(nullptr, ctx);
+
+  uint32_t default_ttl = ctx->time_to_live;
+  oc_cloud_set_published_resources_ttl(ctx, 42);
+  EXPECT_EQ(42, ctx->time_to_live);
+
+  oc_cloud_set_published_resources_ttl(ctx, default_ttl);
 }
 
 TEST_F(TestCloud, cloud_status)
@@ -67,32 +94,27 @@ TEST_F(TestCloud, cloud_set_last_error)
   ASSERT_EQ(CLOUD_ERROR_RESPONSE, ctx->last_error);
 }
 
-TEST_F(TestCloud, cloud_update_by_resource)
+TEST_F(TestCloud, oc_cloud_update_by_resource)
 {
   oc_cloud_context_t *ctx = oc_cloud_get_context(kDeviceID);
   ASSERT_NE(nullptr, ctx);
   ctx->store.status = OC_CLOUD_FAILURE;
 
-  cloud_conf_update_t data;
-  std::string access_token = "access_token";
-  data.access_token = access_token.c_str();
-  data.access_token_len = access_token.length();
-  std::string auth_provider = "auth_provider";
-  data.auth_provider = auth_provider.c_str();
-  data.auth_provider_len = auth_provider.length();
-  std::string ci_server = "ci_server";
-  data.ci_server = ci_server.c_str();
-  data.ci_server_len = ci_server.length();
-  std::string sid = "sid";
-  data.sid = sid.c_str();
-  data.sid_len = sid.length();
+  oc_cloud_conf_update_t data;
+  auto access_token = OC_STRING_LOCAL("access_token");
+  data.access_token = &access_token;
+  auto auth_provider = OC_STRING_LOCAL("auth_provider");
+  data.auth_provider = &auth_provider;
+  auto ci_server = OC_STRING_LOCAL("ci_server");
+  data.ci_server = &ci_server;
+  auto sid = OC_STRING_LOCAL("12345678-1234-5678-1234-567812345678");
+  oc_str_to_uuid(oc_string(sid), &data.sid);
+  oc_cloud_update_by_resource(ctx, &data);
 
-  cloud_update_by_resource(ctx, &data);
-
-  EXPECT_STREQ(data.access_token, oc_cloud_get_at(ctx));
-  EXPECT_STREQ(data.auth_provider, oc_cloud_get_apn(ctx));
-  EXPECT_STREQ(data.ci_server, oc_cloud_get_cis(ctx));
-  EXPECT_STREQ(data.sid, oc_cloud_get_sid(ctx));
+  EXPECT_STREQ(oc_string(*data.access_token), oc_cloud_get_at(ctx));
+  EXPECT_STREQ(oc_string(*data.auth_provider), oc_cloud_get_apn(ctx));
+  EXPECT_STREQ(oc_string(*data.ci_server), oc_cloud_get_cis(ctx));
+  EXPECT_TRUE(oc_uuid_is_equal(data.sid, *oc_cloud_get_sid(ctx)));
   EXPECT_EQ(OC_CLOUD_INITIALIZED, ctx->store.status);
 }
 
@@ -104,7 +126,7 @@ TEST_F(TestCloud, oc_cloud_provision_conf_resource)
   EXPECT_EQ(-1, oc_cloud_provision_conf_resource(ctx, nullptr, nullptr, nullptr,
                                                  nullptr));
 
-  std::string invalid = std::string(OC_MAX_STRING_LENGTH, 'a');
+  std::string invalid(OC_MAX_STRING_LENGTH, 'a');
   const char *ci_server = "ci_server";
   EXPECT_EQ(-1, oc_cloud_provision_conf_resource(ctx, ci_server, nullptr,
                                                  nullptr, nullptr));
@@ -113,14 +135,13 @@ TEST_F(TestCloud, oc_cloud_provision_conf_resource)
   EXPECT_EQ(-1, oc_cloud_provision_conf_resource(ctx, ci_server, access_token,
                                                  nullptr, nullptr));
 
-  const char *sid = "sid";
+  const char *sid = "12345678-1234-5678-1234-567812345678";
+  oc_uuid_t sid_uuid;
+  oc_str_to_uuid(sid, &sid_uuid);
   EXPECT_EQ(0, oc_cloud_provision_conf_resource(ctx, ci_server, access_token,
                                                 sid, nullptr));
 
   const char *auth_provider = "auth_provider";
-  ASSERT_EQ(0, oc_cloud_provision_conf_resource(ctx, ci_server, access_token,
-                                                sid, auth_provider));
-
   EXPECT_EQ(-1, oc_cloud_provision_conf_resource(
                   ctx, invalid.c_str(), access_token, sid, auth_provider));
   EXPECT_EQ(-1, oc_cloud_provision_conf_resource(
@@ -131,17 +152,21 @@ TEST_F(TestCloud, oc_cloud_provision_conf_resource)
   EXPECT_EQ(-1, oc_cloud_provision_conf_resource(ctx, ci_server, access_token,
                                                  sid, invalid.c_str()));
 
-  EXPECT_STREQ(access_token, oc_string(ctx->store.access_token));
-  EXPECT_STREQ(auth_provider, oc_string(ctx->store.auth_provider));
-  EXPECT_STREQ(ci_server, oc_string(ctx->store.ci_server));
-  EXPECT_STREQ(sid, oc_string(ctx->store.sid));
+  ASSERT_EQ(0, oc_cloud_provision_conf_resource(ctx, ci_server, access_token,
+                                                sid, auth_provider));
+  EXPECT_STREQ(access_token, oc_cloud_get_at(ctx));
+  EXPECT_STREQ(auth_provider, oc_cloud_get_apn(ctx));
+  EXPECT_STREQ(ci_server, oc_cloud_get_cis(ctx));
+  EXPECT_TRUE(oc_uuid_is_equal(sid_uuid, *oc_cloud_get_sid(ctx)));
   EXPECT_EQ(OC_CLOUD_INITIALIZED, ctx->store.status);
-}
 
-TEST_F(TestCloud, oc_cloud_provision_conf_resource_v1)
-{
-  oc_cloud_context_t *ctx = oc_cloud_get_context(kDeviceID);
-  ASSERT_NE(nullptr, ctx);
+  ASSERT_EQ(0, oc_cloud_provision_conf_resource(ctx, "", "", "", ""));
+  EXPECT_EQ(nullptr, oc_cloud_get_at(ctx));
+  EXPECT_EQ(nullptr, oc_cloud_get_apn(ctx));
+  EXPECT_STREQ(OCF_COAPCLOUDCONF_DEFAULT_CIS, oc_cloud_get_cis(ctx));
+  EXPECT_TRUE(
+    oc_uuid_is_equal(OCF_COAPCLOUDCONF_DEFAULT_SID, *oc_cloud_get_sid(ctx)));
+  EXPECT_EQ(OC_CLOUD_INITIALIZED, ctx->store.status);
 }
 
 TEST_F(TestCloud, oc_cloud_action_to_str)
@@ -157,110 +182,655 @@ TEST_F(TestCloud, oc_cloud_action_to_str)
   EXPECT_EQ(OC_CLOUD_ACTION_UNKNOWN_STR, v);
 }
 
-TEST_F(TestCloud, cloud_register)
+static void
+setRFNOP(void)
 {
 #ifdef OC_SECURITY
   oc_sec_pstat_t *pstat = oc_sec_get_pstat(kDeviceID);
   ASSERT_NE(nullptr, pstat);
   pstat->s = OC_DOS_RFNOP;
-#endif
-
-  oc_cloud_context_t *ctx = oc_cloud_get_context(kDeviceID);
-  ASSERT_NE(nullptr, ctx);
-  const char *access_token = "access_token";
-  const char *auth_provider = "auth_provider";
-  const char *ci_server = "coap://224.0.1.187:5683";
-  const char *sid = "sid";
-  ASSERT_EQ(0, oc_cloud_provision_conf_resource(ctx, ci_server, access_token,
-                                                sid, auth_provider));
-  bool cbk_called = false;
-  auto cbk = [](oc_cloud_context_t *, oc_cloud_status_t status,
-                void *user_data) {
-    auto called = static_cast<bool *>(user_data);
-    EXPECT_EQ(OC_CLOUD_FAILURE, (status & OC_CLOUD_FAILURE));
-    *called = true;
-  };
-
-  int ret = cloud_register(ctx, cbk, &cbk_called, 1);
-  EXPECT_EQ(0, ret);
-
-  oc::TestDevice::PoolEvents(2);
-  EXPECT_TRUE(cbk_called);
+#endif /* OC_SECURITY */
 }
 
-TEST_F(TestCloud, cloud_login)
+static void
+provisionCloud(oc_cloud_context_t *ctx, const std::string &uid = {})
 {
-#ifdef OC_SECURITY
-  oc_sec_pstat_t *pstat = oc_sec_get_pstat(kDeviceID);
-  ASSERT_NE(nullptr, pstat);
-  pstat->s = OC_DOS_RFNOP;
-#endif
-
-  oc_cloud_context_t *ctx = oc_cloud_get_context(kDeviceID);
-  ASSERT_NE(nullptr, ctx);
   const char *access_token = "access_token";
   const char *auth_provider = "auth_provider";
   const char *ci_server = "coap://224.0.1.187:5683";
-  const char *sid = "sid";
+  const char *sid = "12345678-1234-5678-1234-567812345678";
   ASSERT_EQ(0, oc_cloud_provision_conf_resource(ctx, ci_server, access_token,
                                                 sid, auth_provider));
+  if (!uid.empty()) {
+    oc_set_string(&ctx->store.uid, uid.c_str(), uid.length());
+  }
+}
+
+TEST_F(TestCloud, oc_cloud_register_already_registered)
+{
+  oc_cloud_context_t *ctx = oc_cloud_get_context(kDeviceID);
+  ASSERT_NE(nullptr, ctx);
+  // if the cloud is already registered, then the callback is called immediately
   ctx->store.status = OC_CLOUD_REGISTERED;
-  oc_free_string(&ctx->store.uid);
-  oc_new_string(&ctx->store.uid, "uid", 3);
 
   bool cbk_called = false;
   auto cbk = [](oc_cloud_context_t *, oc_cloud_status_t status,
                 void *user_data) {
-    auto called = static_cast<bool *>(user_data);
-    EXPECT_EQ(OC_CLOUD_FAILURE, (status & OC_CLOUD_FAILURE));
-    *called = true;
+    *static_cast<bool *>(user_data) = true;
+    EXPECT_EQ(OC_CLOUD_REGISTERED, status);
   };
 
-  int ret = cloud_login(ctx, cbk, &cbk_called, 1);
-  EXPECT_EQ(0, ret);
-
-  oc::TestDevice::PoolEvents(2);
+  ASSERT_EQ(0, oc_cloud_register(ctx, cbk, &cbk_called));
   EXPECT_TRUE(cbk_called);
 }
 
-TEST_F(TestCloud, cloud_refresh_token)
+TEST_F(TestCloud, oc_cloud_register_fail_invalid_input)
 {
-#ifdef OC_SECURITY
-  oc_sec_pstat_t *pstat = oc_sec_get_pstat(kDeviceID);
-  ASSERT_NE(nullptr, pstat);
-  pstat->s = OC_DOS_RFNOP;
-#endif
+  EXPECT_EQ(-1, oc_cloud_register(nullptr, nullptr, nullptr));
 
   oc_cloud_context_t *ctx = oc_cloud_get_context(kDeviceID);
   ASSERT_NE(nullptr, ctx);
-  const char *access_token = "access_token";
-  const char *auth_provider = "auth_provider";
-  const char *ci_server = "coap://224.0.1.187:5683";
-  const char *sid = "sid";
-  ASSERT_EQ(0, oc_cloud_provision_conf_resource(ctx, ci_server, access_token,
-                                                sid, auth_provider));
+  ASSERT_EQ(-1, oc_cloud_register(ctx, nullptr, nullptr));
+}
+
+TEST_F(TestCloud, oc_cloud_register_fail_invalid_status)
+{
+  oc_cloud_context_t *ctx = oc_cloud_get_context(kDeviceID);
+  ASSERT_NE(nullptr, ctx);
+  // all other states than OC_CLOUD_INITIALIZED or OC_CLOUD_REGISTERED are
+  // invalid
+  ctx->store.status = OC_CLOUD_DEREGISTERED;
+  bool cbk_called = false;
+  auto cbk = [](oc_cloud_context_t *, oc_cloud_status_t, void *user_data) {
+    *static_cast<bool *>(user_data) = true;
+  };
+  ASSERT_EQ(-1, oc_cloud_register(ctx, cbk, &cbk_called));
+  EXPECT_FALSE(cbk_called);
+}
+
+TEST_F(TestCloud, oc_cloud_register_fail_invalid_server)
+{
+  oc_cloud_context_t *ctx = oc_cloud_get_context(kDeviceID);
+  ASSERT_NE(nullptr, ctx);
+  bool cbk_called = false;
+  auto cbk = [](oc_cloud_context_t *, oc_cloud_status_t, void *user_data) {
+    *static_cast<bool *>(user_data) = true;
+  };
+  oc_cloud_endpoints_clear(&ctx->store.ci_servers);
+
+  ASSERT_EQ(-1, oc_cloud_register(ctx, cbk, &cbk_called));
+  EXPECT_FALSE(cbk_called);
+}
+
+TEST_F(TestCloud, oc_cloud_do_register)
+{
+  setRFNOP();
+
+  oc_cloud_context_t *ctx = oc_cloud_get_context(kDeviceID);
+  ASSERT_NE(nullptr, ctx);
+  provisionCloud(ctx);
+  bool cbk_called = false;
+  auto cbk = [](oc_cloud_context_t *, oc_cloud_status_t status,
+                void *user_data) {
+    *static_cast<bool *>(user_data) = true;
+    EXPECT_EQ(OC_CLOUD_FAILURE, (status & OC_CLOUD_FAILURE));
+  };
+
+  auto timeout = 1s;
+  ASSERT_EQ(0, oc_cloud_do_register(ctx, cbk, &cbk_called, timeout.count()));
+
+  oc::TestDevice::PoolEventsMsV1(timeout, true);
+  EXPECT_TRUE(cbk_called);
+}
+
+TEST_F(TestCloud, oc_cloud_login_already_logged_in)
+{
+  oc_cloud_context_t *ctx = oc_cloud_get_context(kDeviceID);
+  ASSERT_NE(nullptr, ctx);
+  // if the cloud is already logged in, then the callback is called immediately
+  ctx->store.status = OC_CLOUD_REGISTERED | OC_CLOUD_LOGGED_IN;
+
+  bool cbk_called = false;
+  auto cbk = [](oc_cloud_context_t *, oc_cloud_status_t status,
+                void *user_data) {
+    *static_cast<bool *>(user_data) = true;
+    EXPECT_EQ(OC_CLOUD_REGISTERED | OC_CLOUD_LOGGED_IN, status);
+  };
+
+  ASSERT_EQ(0, oc_cloud_login(ctx, cbk, &cbk_called));
+  EXPECT_TRUE(cbk_called);
+}
+
+TEST_F(TestCloud, oc_cloud_login_fail_invalid_input)
+{
+  EXPECT_EQ(-1, oc_cloud_login(nullptr, nullptr, nullptr));
+
+  oc_cloud_context_t *ctx = oc_cloud_get_context(kDeviceID);
+  ASSERT_NE(nullptr, ctx);
+  ASSERT_EQ(-1, oc_cloud_login(ctx, nullptr, nullptr));
+}
+
+TEST_F(TestCloud, oc_cloud_login_fail_invalid_status)
+{
+  oc_cloud_context_t *ctx = oc_cloud_get_context(kDeviceID);
+  ASSERT_NE(nullptr, ctx);
+  // must contain the OC_CLOUD_REGISTERED flag to be valid
+  ctx->store.status = OC_CLOUD_INITIALIZED;
+  bool cbk_called = false;
+  auto cbk = [](oc_cloud_context_t *, oc_cloud_status_t, void *user_data) {
+    *static_cast<bool *>(user_data) = true;
+  };
+  ASSERT_EQ(-1, oc_cloud_login(ctx, cbk, &cbk_called));
+  EXPECT_FALSE(cbk_called);
+}
+
+TEST_F(TestCloud, oc_cloud_login_fail_invalid_server)
+{
+  oc_cloud_context_t *ctx = oc_cloud_get_context(kDeviceID);
+  ASSERT_NE(nullptr, ctx);
+  bool cbk_called = false;
+  auto cbk = [](oc_cloud_context_t *, oc_cloud_status_t, void *user_data) {
+    *static_cast<bool *>(user_data) = true;
+  };
+  ctx->store.status = OC_CLOUD_REGISTERED;
+  oc_cloud_endpoints_clear(&ctx->store.ci_servers);
+
+  ASSERT_EQ(-1, oc_cloud_login(ctx, cbk, &cbk_called));
+  EXPECT_FALSE(cbk_called);
+}
+
+TEST_F(TestCloud, oc_cloud_do_login)
+{
+  setRFNOP();
+
+  oc_cloud_context_t *ctx = oc_cloud_get_context(kDeviceID);
+  ASSERT_NE(nullptr, ctx);
+  provisionCloud(ctx, "uid");
   ctx->store.status = OC_CLOUD_REGISTERED;
 
-  oc_free_string(&ctx->store.uid);
-  std::string uid = "501";
-  oc_new_string(&ctx->store.uid, uid.c_str(), uid.length());
+  bool cbk_called = false;
+  auto cbk = [](oc_cloud_context_t *, oc_cloud_status_t status,
+                void *user_data) {
+    *static_cast<bool *>(user_data) = true;
+    EXPECT_EQ(OC_CLOUD_FAILURE, (status & OC_CLOUD_FAILURE));
+  };
 
-  oc_free_string(&ctx->store.refresh_token);
+  auto timeout = 1s;
+  ASSERT_EQ(0, oc_cloud_do_login(ctx, cbk, &cbk_called, timeout.count()));
+
+  oc::TestDevice::PoolEventsMsV1(timeout, true);
+  EXPECT_TRUE(cbk_called);
+}
+
+TEST_F(TestCloud, oc_cloud_refresh_token_fail_invalid_input)
+{
+  EXPECT_EQ(-1, oc_cloud_refresh_token(nullptr, nullptr, nullptr));
+
+  oc_cloud_context_t *ctx = oc_cloud_get_context(kDeviceID);
+  ASSERT_NE(nullptr, ctx);
+  ASSERT_EQ(-1, oc_cloud_refresh_token(ctx, nullptr, nullptr));
+}
+
+TEST_F(TestCloud, oc_cloud_refresh_token_fail_invalid_status)
+{
+  oc_cloud_context_t *ctx = oc_cloud_get_context(kDeviceID);
+  ASSERT_NE(nullptr, ctx);
+  // must contain the OC_CLOUD_REGISTERED flag to be valid
+  ctx->store.status = OC_CLOUD_INITIALIZED;
+  bool cbk_called = false;
+  auto cbk = [](oc_cloud_context_t *, oc_cloud_status_t, void *user_data) {
+    *static_cast<bool *>(user_data) = true;
+  };
+  ASSERT_EQ(-1, oc_cloud_refresh_token(ctx, cbk, &cbk_called));
+  EXPECT_FALSE(cbk_called);
+}
+
+TEST_F(TestCloud, oc_cloud_refresh_token_fail_invalid_server)
+{
+  oc_cloud_context_t *ctx = oc_cloud_get_context(kDeviceID);
+  ASSERT_NE(nullptr, ctx);
+  bool cbk_called = false;
+  auto cbk = [](oc_cloud_context_t *, oc_cloud_status_t, void *user_data) {
+    *static_cast<bool *>(user_data) = true;
+  };
+  ctx->store.status = OC_CLOUD_REGISTERED;
+  oc_cloud_endpoints_clear(&ctx->store.ci_servers);
+
+  ASSERT_EQ(-1, oc_cloud_refresh_token(ctx, cbk, &cbk_called));
+  EXPECT_FALSE(cbk_called);
+}
+
+TEST_F(TestCloud, oc_cloud_do_refresh_token)
+{
+  setRFNOP();
+
+  oc_cloud_context_t *ctx = oc_cloud_get_context(kDeviceID);
+  ASSERT_NE(nullptr, ctx);
+  provisionCloud(ctx, "501");
   std::string refresh_token = "refresh_token";
-  oc_new_string(&ctx->store.refresh_token, refresh_token.c_str(),
+  oc_set_string(&ctx->store.refresh_token, refresh_token.c_str(),
                 refresh_token.length());
+  ctx->store.status = OC_CLOUD_REGISTERED;
 
   bool cbk_called = false;
   auto cbk = [](oc_cloud_context_t *, oc_cloud_status_t status,
                 void *user_data) {
-    auto called = static_cast<bool *>(user_data);
+    *static_cast<bool *>(user_data) = true;
     EXPECT_EQ(OC_CLOUD_FAILURE, (status & OC_CLOUD_FAILURE));
-    *called = true;
   };
 
-  int ret = cloud_refresh_token(ctx, cbk, &cbk_called, 1);
-  EXPECT_EQ(0, ret);
+  auto timeout = 1s;
+  ASSERT_EQ(0,
+            oc_cloud_do_refresh_token(ctx, cbk, &cbk_called, timeout.count()));
 
-  oc::TestDevice::PoolEvents(2);
+  oc::TestDevice::PoolEventsMsV1(timeout, true);
   EXPECT_TRUE(cbk_called);
+}
+
+TEST_F(TestCloud, oc_cloud_logout_fail_invalid_input)
+{
+  EXPECT_EQ(-1, oc_cloud_logout(nullptr, nullptr, nullptr));
+
+  oc_cloud_context_t *ctx = oc_cloud_get_context(kDeviceID);
+  ASSERT_NE(nullptr, ctx);
+  ASSERT_EQ(-1, oc_cloud_logout(ctx, nullptr, nullptr));
+}
+
+TEST_F(TestCloud, oc_cloud_logout_fail_invalid_status)
+{
+  oc_cloud_context_t *ctx = oc_cloud_get_context(kDeviceID);
+  ASSERT_NE(nullptr, ctx);
+  // must contain the OC_CLOUD_LOGGED_IN flag to be valid
+  ctx->store.status = OC_CLOUD_INITIALIZED;
+  bool cbk_called = false;
+  auto cbk = [](oc_cloud_context_t *, oc_cloud_status_t, void *user_data) {
+    *static_cast<bool *>(user_data) = true;
+  };
+  ASSERT_EQ(-1, oc_cloud_logout(ctx, cbk, &cbk_called));
+  EXPECT_FALSE(cbk_called);
+}
+
+TEST_F(TestCloud, oc_cloud_logout_fail_invalid_server)
+{
+  oc_cloud_context_t *ctx = oc_cloud_get_context(kDeviceID);
+  ASSERT_NE(nullptr, ctx);
+  bool cbk_called = false;
+  auto cbk = [](oc_cloud_context_t *, oc_cloud_status_t, void *user_data) {
+    *static_cast<bool *>(user_data) = true;
+  };
+  ctx->store.status = OC_CLOUD_REGISTERED | OC_CLOUD_LOGGED_IN;
+  oc_cloud_endpoints_clear(&ctx->store.ci_servers);
+
+  ASSERT_EQ(-1, oc_cloud_logout(ctx, cbk, &cbk_called));
+  EXPECT_FALSE(cbk_called);
+}
+
+TEST_F(TestCloud, oc_cloud_do_logout)
+{
+  setRFNOP();
+
+  oc_cloud_context_t *ctx = oc_cloud_get_context(kDeviceID);
+  ASSERT_NE(nullptr, ctx);
+  provisionCloud(ctx, "501");
+  ctx->store.status = OC_CLOUD_REGISTERED | OC_CLOUD_LOGGED_IN;
+
+  bool cbk_called = false;
+  auto cbk = [](oc_cloud_context_t *, oc_cloud_status_t status,
+                void *user_data) {
+    *static_cast<bool *>(user_data) = true;
+    EXPECT_EQ(OC_CLOUD_FAILURE, (status & OC_CLOUD_FAILURE));
+  };
+
+  auto timeout = 1s;
+  ASSERT_EQ(0, oc_cloud_do_logout(ctx, cbk, &cbk_called, timeout.count()));
+
+  oc::TestDevice::PoolEventsMsV1(timeout, true);
+  EXPECT_TRUE(cbk_called);
+}
+
+TEST_F(TestCloud, oc_cloud_deregister_fail_invalid_input)
+{
+  EXPECT_EQ(-1, oc_cloud_deregister(nullptr, nullptr, nullptr));
+
+  oc_cloud_context_t *ctx = oc_cloud_get_context(kDeviceID);
+  ASSERT_NE(nullptr, ctx);
+  ASSERT_EQ(-1, oc_cloud_deregister(ctx, nullptr, nullptr));
+}
+
+TEST_F(TestCloud, oc_cloud_deregister_fail_invalid_status)
+{
+  oc_cloud_context_t *ctx = oc_cloud_get_context(kDeviceID);
+  ASSERT_NE(nullptr, ctx);
+  // must contain the OC_CLOUD_REGISTERED flag to be valid
+  ctx->store.status = OC_CLOUD_INITIALIZED;
+  bool cbk_called = false;
+  auto cbk = [](oc_cloud_context_t *, oc_cloud_status_t, void *user_data) {
+    *static_cast<bool *>(user_data) = true;
+  };
+  ASSERT_EQ(-1, oc_cloud_deregister(ctx, cbk, &cbk_called));
+  EXPECT_FALSE(cbk_called);
+}
+
+TEST_F(TestCloud, oc_cloud_deregister_fail_already_deregistering)
+{
+  oc_cloud_context_t *ctx = oc_cloud_get_context(kDeviceID);
+  ASSERT_NE(nullptr, ctx);
+  // if the cloud is already logged in, then the callback is called immediately
+  ctx->store.status = OC_CLOUD_REGISTERED;
+  ctx->store.cps = OC_CPS_DEREGISTERING;
+
+  bool cbk_called = false;
+  auto cbk = [](oc_cloud_context_t *, oc_cloud_status_t, void *user_data) {
+    *static_cast<bool *>(user_data) = true;
+  };
+
+  ASSERT_EQ(CLOUD_DEREGISTER_ERROR_ALREADY_DEREGISTERING,
+            oc_cloud_deregister(ctx, cbk, &cbk_called));
+  EXPECT_FALSE(cbk_called);
+}
+
+TEST_F(TestCloud, oc_cloud_deregister_fail_invalid_server)
+{
+  oc_cloud_context_t *ctx = oc_cloud_get_context(kDeviceID);
+  ASSERT_NE(nullptr, ctx);
+  provisionCloud(ctx, "501");
+  bool cbk_called = false;
+  auto cbk = [](oc_cloud_context_t *, oc_cloud_status_t, void *user_data) {
+    *static_cast<bool *>(user_data) = true;
+  };
+  ctx->store.status = OC_CLOUD_REGISTERED;
+  oc_cloud_endpoints_clear(&ctx->store.ci_servers);
+
+  ASSERT_EQ(-1, oc_cloud_deregister(ctx, cbk, &cbk_called));
+  EXPECT_FALSE(cbk_called);
+}
+
+TEST_F(TestCloud, oc_cloud_do_deregister_with_short_access_token)
+{
+  setRFNOP();
+
+  oc_cloud_context_t *ctx = oc_cloud_get_context(kDeviceID);
+  ASSERT_NE(nullptr, ctx);
+  provisionCloud(ctx, "501");
+  ctx->store.status = OC_CLOUD_REGISTERED;
+
+  bool cbk_called = false;
+  auto cbk = [](oc_cloud_context_t *, oc_cloud_status_t status,
+                void *user_data) {
+    *static_cast<bool *>(user_data) = true;
+    EXPECT_EQ(OC_CLOUD_FAILURE, (status & OC_CLOUD_FAILURE));
+  };
+
+  auto timeout = 1s;
+  ASSERT_EQ(0, oc_cloud_do_deregister(ctx, /*sync*/ true, timeout.count(), cbk,
+                                      &cbk_called));
+
+  oc::TestDevice::PoolEventsMsV1(timeout, true);
+  EXPECT_TRUE(cbk_called);
+}
+
+#ifdef OC_DYNAMIC_ALLOCATION
+
+TEST_F(TestCloud, oc_cloud_deregister_fail_not_logged_in_long_access_token)
+{
+  oc_cloud_context_t *ctx = oc_cloud_get_context(kDeviceID);
+  ASSERT_NE(nullptr, ctx);
+  provisionCloud(ctx, "501");
+  std::string longAccessToken(COAP_MAX_HEADER_SIZE, 'a');
+  oc_set_string(&ctx->store.access_token, longAccessToken.c_str(),
+                longAccessToken.length());
+  ASSERT_FALSE(oc_cloud_check_accesstoken_for_deregister(ctx));
+  ctx->store.status = OC_CLOUD_REGISTERED;
+
+  bool cbk_called = false;
+  auto cbk = [](oc_cloud_context_t *, oc_cloud_status_t, void *user_data) {
+    *static_cast<bool *>(user_data) = true;
+  };
+  ASSERT_EQ(-1, oc_cloud_deregister(ctx, cbk, &cbk_called));
+  EXPECT_FALSE(cbk_called);
+}
+
+TEST_F(TestCloud, oc_cloud_do_deregister_logged_in)
+{
+  setRFNOP();
+
+  oc_cloud_context_t *ctx = oc_cloud_get_context(kDeviceID);
+  ASSERT_NE(nullptr, ctx);
+  provisionCloud(ctx, "501");
+  std::string longAccessToken(COAP_MAX_HEADER_SIZE, 'a');
+  oc_set_string(&ctx->store.access_token, longAccessToken.c_str(),
+                longAccessToken.length());
+  ASSERT_FALSE(oc_cloud_check_accesstoken_for_deregister(ctx));
+  ctx->store.status = OC_CLOUD_REGISTERED | OC_CLOUD_LOGGED_IN;
+
+  bool cbk_called = false;
+  auto cbk = [](oc_cloud_context_t *, oc_cloud_status_t status,
+                void *user_data) {
+    *static_cast<bool *>(user_data) = true;
+    EXPECT_EQ(OC_CLOUD_FAILURE, (status & OC_CLOUD_FAILURE));
+  };
+
+  auto timeout = 1s;
+  ASSERT_EQ(0, oc_cloud_do_deregister(ctx, /*sync*/ true, timeout.count(), cbk,
+                                      &cbk_called));
+  oc::TestDevice::PoolEventsMsV1(timeout, true);
+  EXPECT_TRUE(cbk_called);
+}
+
+TEST_F(TestCloud, oc_cloud_do_deregister_with_refresh_token)
+{
+  setRFNOP();
+
+  oc_cloud_context_t *ctx = oc_cloud_get_context(kDeviceID);
+  ASSERT_NE(nullptr, ctx);
+  provisionCloud(ctx, "501");
+  std::string longAccessToken(COAP_MAX_HEADER_SIZE, 'a');
+  oc_set_string(&ctx->store.access_token, longAccessToken.c_str(),
+                longAccessToken.length());
+  std::string refresh_token = "refresh_token";
+  oc_set_string(&ctx->store.refresh_token, refresh_token.c_str(),
+                refresh_token.length());
+  ASSERT_FALSE(oc_cloud_check_accesstoken_for_deregister(ctx));
+  ctx->store.status = OC_CLOUD_REGISTERED;
+
+  bool cbk_called = false;
+  auto cbk = [](oc_cloud_context_t *, oc_cloud_status_t, void *user_data) {
+    *static_cast<bool *>(user_data) = true;
+  };
+
+  auto timeout = 1s;
+  ASSERT_EQ(0, oc_cloud_do_deregister(ctx, /*sync*/ false, timeout.count(), cbk,
+                                      &cbk_called));
+  oc::TestDevice::PoolEventsMsV1(timeout, true);
+  EXPECT_FALSE(cbk_called);
+}
+
+TEST_F(TestCloud, oc_cloud_deregister_with_refresh_token_fail_invalid_server)
+{
+  oc_cloud_context_t *ctx = oc_cloud_get_context(kDeviceID);
+  ASSERT_NE(nullptr, ctx);
+  provisionCloud(ctx, "501");
+  std::string longAccessToken(COAP_MAX_HEADER_SIZE, 'a');
+  oc_set_string(&ctx->store.access_token, longAccessToken.c_str(),
+                longAccessToken.length());
+  std::string refresh_token = "refresh_token";
+  oc_set_string(&ctx->store.refresh_token, refresh_token.c_str(),
+                refresh_token.length());
+  ASSERT_FALSE(oc_cloud_check_accesstoken_for_deregister(ctx));
+  ctx->store.status = OC_CLOUD_REGISTERED;
+  oc_cloud_endpoints_clear(&ctx->store.ci_servers);
+
+  bool cbk_called = false;
+  auto cbk = [](oc_cloud_context_t *, oc_cloud_status_t, void *user_data) {
+    *static_cast<bool *>(user_data) = true;
+  };
+
+  ASSERT_EQ(-1, oc_cloud_do_deregister(ctx, /*sync*/ false, /*timeout*/ 0, cbk,
+                                       &cbk_called));
+  EXPECT_FALSE(cbk_called);
+}
+
+TEST_F(TestCloud, oc_cloud_do_deregister_with_login)
+{
+  setRFNOP();
+
+  oc_cloud_context_t *ctx = oc_cloud_get_context(kDeviceID);
+  ASSERT_NE(nullptr, ctx);
+  provisionCloud(ctx, "501");
+  std::string longAccessToken(COAP_MAX_HEADER_SIZE, 'a');
+  oc_set_string(&ctx->store.access_token, longAccessToken.c_str(),
+                longAccessToken.length());
+  ASSERT_FALSE(oc_cloud_check_accesstoken_for_deregister(ctx));
+  ctx->store.status = OC_CLOUD_REGISTERED;
+
+  bool cbk_called = false;
+  auto cbk = [](oc_cloud_context_t *, oc_cloud_status_t, void *user_data) {
+    *static_cast<bool *>(user_data) = true;
+  };
+
+  auto timeout = 1s;
+  ASSERT_EQ(0, oc_cloud_do_deregister(ctx, /*sync*/ false, timeout.count(), cbk,
+                                      &cbk_called));
+  oc::TestDevice::PoolEventsMsV1(timeout, true);
+  EXPECT_FALSE(cbk_called);
+}
+
+TEST_F(TestCloud, oc_cloud_deregister_with_login_fail_invalid_server)
+{
+  oc_cloud_context_t *ctx = oc_cloud_get_context(kDeviceID);
+  ASSERT_NE(nullptr, ctx);
+  provisionCloud(ctx, "501");
+  std::string longAccessToken(COAP_MAX_HEADER_SIZE, 'a');
+  oc_set_string(&ctx->store.access_token, longAccessToken.c_str(),
+                longAccessToken.length());
+  ASSERT_FALSE(oc_cloud_check_accesstoken_for_deregister(ctx));
+  ctx->store.status = OC_CLOUD_REGISTERED;
+  oc_cloud_endpoints_clear(&ctx->store.ci_servers);
+
+  bool cbk_called = false;
+  auto cbk = [](oc_cloud_context_t *, oc_cloud_status_t, void *user_data) {
+    *static_cast<bool *>(user_data) = true;
+  };
+
+  ASSERT_EQ(-1, oc_cloud_do_deregister(ctx, /*sync*/ false, /*timeout*/ 0, cbk,
+                                       &cbk_called));
+  EXPECT_FALSE(cbk_called);
+
+  ctx->store.cps = OC_CPS_UNINITIALIZED;
+  std::string refresh_token = "refresh_token";
+  oc_set_string(&ctx->store.refresh_token, refresh_token.c_str(),
+                refresh_token.length());
+  ctx->store.expires_in = -1;
+  // permanent access token should force login attempt even if refresh token is
+  // set
+  ASSERT_TRUE(cloud_context_has_permanent_access_token(ctx));
+  ASSERT_EQ(-1, oc_cloud_do_deregister(ctx, /*sync*/ false, /*timeout*/ 0, cbk,
+                                       &cbk_called));
+  EXPECT_FALSE(cbk_called);
+}
+
+#endif /* OC_DYNAMIC_ALLOCATION */
+
+// TODO: async deregister steps with mocked cloud
+
+TEST_F(TestCloud, EndpointAPI)
+{
+  oc_cloud_context_t *ctx = cloud_context_init(/*device*/ 0);
+  ASSERT_NE(nullptr, ctx);
+  // after initialization, the default endpoint should be selected
+  EXPECT_STREQ(OCF_COAPCLOUDCONF_DEFAULT_CIS, oc_cloud_get_cis(ctx));
+  EXPECT_TRUE(
+    oc_uuid_is_equal(OCF_COAPCLOUDCONF_DEFAULT_SID, *oc_cloud_get_sid(ctx)));
+  // remove default
+  oc_cloud_endpoints_clear(&ctx->store.ci_servers);
+  // no enpoint selected -> both cis and sid should be nullptr
+  EXPECT_EQ(nullptr, oc_cloud_get_cis(ctx));
+  EXPECT_EQ(nullptr, oc_cloud_get_sid(ctx));
+
+  // add
+  std::string uri1 = "/uri/1";
+  oc_uuid_t uid1;
+  oc_gen_uuid(&uid1);
+  oc_cloud_endpoint_t *ep1 =
+    oc_cloud_add_server(ctx, uri1.c_str(), uri1.length(), uid1);
+  ASSERT_NE(nullptr, ep1);
+  std::string uri2 = "/uri/2";
+  oc_uuid_t uid2;
+  oc_gen_uuid(&uid2);
+  oc_cloud_endpoint_t *ep2 =
+    oc_cloud_add_server(ctx, uri2.c_str(), uri2.length(), uid2);
+  ASSERT_NE(nullptr, ep2);
+#ifdef OC_DYNAMIC_ALLOCATION
+  std::string uri3 = "/uri/3";
+  oc_uuid_t uid3;
+  oc_gen_uuid(&uid3);
+  oc_cloud_endpoint_t *ep3 =
+    oc_cloud_add_server(ctx, uri3.c_str(), uri3.length(), uid3);
+  ASSERT_NE(nullptr, ep3);
+#endif /* OC_DYNAMIC_ALLOCATION */
+
+  // first item added to empty list should be selected
+  EXPECT_STREQ(uri1.c_str(), oc_cloud_get_cis(ctx));
+  EXPECT_TRUE(oc_uuid_is_equal(uid1, *oc_cloud_get_sid(ctx)));
+
+  // remove the first item
+  ASSERT_TRUE(oc_cloud_remove_server(ctx, ep1));
+
+  // next endpoint should be selected
+  EXPECT_STREQ(uri2.c_str(), oc_cloud_get_cis(ctx));
+  EXPECT_TRUE(oc_uuid_is_equal(uid2, *oc_cloud_get_sid(ctx)));
+
+  std::set<std::string, std::less<>> uris{};
+  // iterate
+  oc_cloud_iterate_servers(
+    ctx,
+    [](oc_cloud_endpoint_t *endpoint, void *data) {
+      auto uri = oc_cloud_endpoint_uri(endpoint);
+      static_cast<std::set<std::string> *>(data)->insert(
+        std::string(oc_string(*uri), oc_string_len(*uri)));
+      return true;
+    },
+    &uris);
+
+#ifdef OC_DYNAMIC_ALLOCATION
+  ASSERT_EQ(2, uris.size());
+  EXPECT_NE(uris.end(), uris.find(uri3));
+#else  /* !OC_DYNAMIC_ALLOCATION */
+  ASSERT_EQ(1, uris.size());
+#endif /* OC_DYNAMIC_ALLOCATION */
+  EXPECT_NE(uris.end(), uris.find(uri2));
+  EXPECT_EQ(uris.end(), uris.find(uri1));
+
+  oc_cloud_endpoint_t *toSelect = nullptr;
+  // iterate to get the last endpoint
+  oc_cloud_iterate_servers(
+    ctx,
+    [](oc_cloud_endpoint_t *endpoint, void *data) {
+      *static_cast<oc_cloud_endpoint_t **>(data) = endpoint;
+      return true;
+    },
+    &toSelect);
+
+  oc_cloud_endpoint_t notInList{};
+  EXPECT_FALSE(oc_cloud_select_server(ctx, &notInList));
+
+  ASSERT_NE(nullptr, toSelect);
+  EXPECT_TRUE(oc_cloud_select_server(ctx, toSelect));
+#ifdef OC_DYNAMIC_ALLOCATION
+  EXPECT_STREQ(uri3.c_str(), oc_cloud_get_cis(ctx));
+  EXPECT_TRUE(oc_uuid_is_equal(uid3, *oc_cloud_get_sid(ctx)));
+#else  /* !OC_DYNAMIC_ALLOCATION */
+  EXPECT_STREQ(uri2.c_str(), oc_cloud_get_cis(ctx));
+  EXPECT_TRUE(oc_uuid_is_equal(uid2, *oc_cloud_get_sid(ctx)));
+#endif /* OC_DYNAMIC_ALLOCATION */
+
+  oc_uuid_t uid;
+  oc_gen_uuid(&uid);
+  oc_cloud_endpoint_set_id(toSelect, uid);
+  EXPECT_TRUE(oc_uuid_is_equal(uid, oc_cloud_endpoint_id(toSelect)));
+  EXPECT_TRUE(oc_uuid_is_equal(uid, *oc_cloud_get_sid(ctx)));
+
+  EXPECT_TRUE(oc_cloud_remove_server(ctx, toSelect));
+
+  cloud_context_deinit(ctx);
 }

--- a/api/cloud/unittest/rd_client_test.cpp
+++ b/api/cloud/unittest/rd_client_test.cpp
@@ -401,6 +401,8 @@ TEST_F(TestRDClient, DeleteIterateLinks_FailToSendSingle)
   oc_delete_link(link_p);
 }
 
+#ifdef OC_DYNAMIC_ALLOCATION
+
 TEST_F(TestRDClient, DeleteIterateLinks_PartialBuffer)
 {
   // query: di=${deviceUUID}&ins=${instanceID}
@@ -461,3 +463,5 @@ TEST_F(TestRDClient, DeleteIterateLinks_PartialBuffer)
     link = next;
   }
 }
+
+#endif // OC_DYNAMIC_ALLOCATION

--- a/api/oc_etag.c
+++ b/api/oc_etag.c
@@ -285,9 +285,9 @@ typedef struct etag_encode_data_t
 } etag_encode_data_t;
 
 static int
-etag_store_encode(size_t device, void *data)
+etag_store_encode(size_t device, const void *data)
 {
-  etag_encode_data_t *encode_data = (etag_encode_data_t *)data;
+  const etag_encode_data_t *encode_data = (const etag_encode_data_t *)data;
   oc_rep_start_root_object();
   oc_resources_iterate(device, encode_data->platform_only,
                        !encode_data->platform_only, !encode_data->platform_only,

--- a/api/oc_helpers.c
+++ b/api/oc_helpers.c
@@ -31,7 +31,7 @@
 
 static bool g_mmem_initialized = false;
 
-static void
+static size_t
 oc_malloc(
 #ifdef OC_MEMORY_TRACE
   const char *func,
@@ -48,6 +48,7 @@ oc_malloc(
 #endif
     block, num_items, pool_type);
   oc_assert(alloc_ret > 0);
+  return alloc_ret;
 }
 
 static void
@@ -77,11 +78,14 @@ _oc_new_string(
 #endif
   oc_string_t *ocstring, const char *str, size_t str_len)
 {
-  oc_malloc(
+  size_t size = oc_malloc(
 #ifdef OC_MEMORY_TRACE
     func,
 #endif
     ocstring, str_len + 1, BYTE_POOL);
+  if (size == 0) {
+    return;
+  }
   memcpy(oc_string(*ocstring), (const uint8_t *)str, str_len);
   memcpy(oc_string(*ocstring) + str_len, (const uint8_t *)"", 1);
 }
@@ -200,6 +204,9 @@ oc_copy_string(oc_string_t *dst, const oc_string_t *src)
 void
 oc_concat_strings(oc_string_t *concat, const char *str1, const char *str2)
 {
+  assert(concat != NULL);
+  assert(str1 != NULL);
+  assert(str2 != NULL);
   size_t len1 = strlen(str1);
   size_t len2 = strlen(str2);
   oc_alloc_string(concat, len1 + len2 + 1);

--- a/api/oc_helpers_internal.h
+++ b/api/oc_helpers_internal.h
@@ -50,6 +50,21 @@ typedef struct oc_string_view_t
 
 #ifdef __cplusplus
 
+#ifdef OC_DYNAMIC_ALLOCATION
+#define OC_STRING_LOCAL(str)                                                   \
+  oc_string_t                                                                  \
+  {                                                                            \
+    OC_CHAR_ARRAY_LEN(str), (void *)(str),                                     \
+  }
+
+#else /* !OC_DYNAMIC_ALLOCATION */
+#define OC_STRING_LOCAL(str)                                                   \
+  oc_string_t                                                                  \
+  {                                                                            \
+    nullptr, OC_CHAR_ARRAY_LEN(str), (void *)(str),                            \
+  }
+#endif /* OC_DYNAMIC_ALLOCATION */
+
 #define OC_STRING_VIEW(str)                                                    \
   oc_string_view_t                                                             \
   {                                                                            \
@@ -64,6 +79,12 @@ typedef struct oc_string_view_t
   }
 
 #else /* !__cplusplus */
+
+#define OC_STRING_LOCAL(str)                                                   \
+  (oc_string_t)                                                                \
+  {                                                                            \
+    .size = OC_CHAR_ARRAY_LEN(str), .data = (void *)(str),                     \
+  }
 
 #define OC_STRING_VIEW(str)                                                    \
   (oc_string_view_t)                                                           \

--- a/api/oc_helpers_internal.h
+++ b/api/oc_helpers_internal.h
@@ -54,14 +54,14 @@ typedef struct oc_string_view_t
 #define OC_STRING_LOCAL(str)                                                   \
   oc_string_t                                                                  \
   {                                                                            \
-    OC_CHAR_ARRAY_LEN(str), (void *)(str),                                     \
+    OC_CHAR_ARRAY_LEN(str) + 1, (void *)(str),                                 \
   }
 
 #else /* !OC_DYNAMIC_ALLOCATION */
 #define OC_STRING_LOCAL(str)                                                   \
   oc_string_t                                                                  \
   {                                                                            \
-    nullptr, OC_CHAR_ARRAY_LEN(str), (void *)(str),                            \
+    nullptr, OC_CHAR_ARRAY_LEN(str) + 1, (void *)(str),                        \
   }
 #endif /* OC_DYNAMIC_ALLOCATION */
 
@@ -83,7 +83,7 @@ typedef struct oc_string_view_t
 #define OC_STRING_LOCAL(str)                                                   \
   (oc_string_t)                                                                \
   {                                                                            \
-    .size = OC_CHAR_ARRAY_LEN(str), .data = (void *)(str),                     \
+    .size = OC_CHAR_ARRAY_LEN(str) + 1, .data = (void *)(str),                 \
   }
 
 #define OC_STRING_VIEW(str)                                                    \
@@ -116,6 +116,13 @@ oc_string_view_t oc_string_view2(const oc_string_t *str);
  * @return false strings are not equal
  */
 bool oc_string_view_is_equal(oc_string_view_t str1, oc_string_view_t str2);
+
+/** Check if pointer is NULL or an empty oc_string_t */
+static inline bool
+oc_string_is_null_or_empty(const oc_string_t *ocstring)
+{
+  return ocstring == NULL || oc_string_is_empty(ocstring);
+}
 
 /**
  * @brief Compare two oc_strings.

--- a/api/oc_rep_internal.h
+++ b/api/oc_rep_internal.h
@@ -67,6 +67,10 @@ typedef struct
   oc_rep_t *rep;
 } oc_rep_parse_result_t;
 
+/** @brief Get the value of a property by name. */
+const oc_rep_t *oc_rep_get(const oc_rep_t *rep, oc_rep_value_type_t type,
+                           const char *key, size_t key_len) OC_NONNULL(3);
+
 /**
  * @brief Decode the payload into a oc_rep_t object using the global decoder.
  *

--- a/api/oc_storage.c
+++ b/api/oc_storage.c
@@ -183,7 +183,7 @@ storage_print_data(const uint8_t *buf, size_t size)
 
 long
 oc_storage_data_save(const char *name, size_t device,
-                     oc_encode_to_storage_fn_t encode, void *encode_data)
+                     oc_encode_to_storage_fn_t encode, const void *encode_data)
 {
   assert(encode != NULL);
 

--- a/api/oc_storage_internal.h
+++ b/api/oc_storage_internal.h
@@ -108,7 +108,7 @@ long oc_storage_data_load(const char *name, size_t device,
  *
  * @return 0 on success
  */
-typedef int (*oc_encode_to_storage_fn_t)(size_t device, void *data);
+typedef int (*oc_encode_to_storage_fn_t)(size_t device, const void *data);
 
 /**
  * @brief Save data of resource to storage.
@@ -117,12 +117,13 @@ typedef int (*oc_encode_to_storage_fn_t)(size_t device, void *data);
  * @param device device index
  * @param encode callback function invoked before saving the global encoder to
  * storage (cannot be NULL)
+ * @param encode_data custom user data provided to \p encode
  * @return >= 0 number of written bytes
  * @return -1 on error
  */
 long oc_storage_data_save(const char *name, size_t device,
-                          oc_encode_to_storage_fn_t encode, void *encode_data)
-  OC_NONNULL(1, 3);
+                          oc_encode_to_storage_fn_t encode,
+                          const void *encode_data) OC_NONNULL(1, 3);
 
 /** @brief Truncate store with given name. */
 bool oc_storage_data_clear(const char *name, size_t device) OC_NONNULL();

--- a/api/oc_swupdate.c
+++ b/api/oc_swupdate.c
@@ -956,7 +956,7 @@ oc_swupdate_load(size_t device)
 }
 
 static int
-swupdate_store_encode(size_t device, void *data)
+swupdate_store_encode(size_t device, const void *data)
 {
   (void)data;
   return oc_swupdate_encode_for_device(device,

--- a/api/plgd/plgd_time.c
+++ b/api/plgd/plgd_time.c
@@ -475,10 +475,10 @@ plgd_time_decode(const oc_rep_t *rep, plgd_time_t *pt)
 }
 
 static int
-store_encode_plgd_time(size_t device, void *data)
+store_encode_plgd_time(size_t device, const void *data)
 {
   (void)device;
-  const plgd_time_t *pt = (plgd_time_t *)data;
+  const plgd_time_t *pt = (const plgd_time_t *)data;
   return plgd_time_encode(*pt, OC_IF_RW, PLGD_TIME_ENCODE_FLAG_TO_STORAGE);
 }
 

--- a/api/unittest/coreresourcetest.cpp
+++ b/api/unittest/coreresourcetest.cpp
@@ -467,10 +467,12 @@ TEST_F(TestCoreResourceWithDevice, GetDeviceIndex_P)
 {
   EXPECT_TRUE(
     oc_core_get_device_index(oc_core_get_device_info(kDevice1ID)->di, nullptr));
+#if defined(OC_SERVER) && defined(OC_DYNAMIC_ALLOCATION)
   size_t index{};
   EXPECT_TRUE(
     oc_core_get_device_index(oc_core_get_device_info(kDevice2ID)->di, &index));
   EXPECT_EQ(kDevice2ID, index);
+#endif /* OC_SERVER && OC_DYNAMIC_ALLOCATION */
 }
 
 TEST_F(TestCoreResourceWithDevice, GetDeviceIndex_F)

--- a/api/unittest/coreresourcetest.cpp
+++ b/api/unittest/coreresourcetest.cpp
@@ -47,9 +47,11 @@ static const std::string kOCFSpecVersion{ "ocf.1.0.0" };
 static const std::string kOCFDataModelVersion{ "ocf.res.1.0.0" };
 
 static constexpr size_t kDevice1ID{ 0 };
-static constexpr size_t kDevice2ID{ 1 };
 static constexpr std::string_view kDevice1Name{ "Test Device 1" };
+#if defined(OC_SERVER) && defined(OC_DYNAMIC_ALLOCATION)
+static constexpr size_t kDevice2ID{ 1 };
 static constexpr std::string_view kDevice2Name{ "Test Device 2" };
+#endif /* OC_SERVER && OC_DYNAMIC_ALLOCATION */
 
 class TestCoreResource : public testing::Test {
 public:
@@ -240,13 +242,15 @@ public:
         /*data_model_version=*/"ocf.res.1.0.0",
         /*uri=*/"/oic/d",
       },
-      {
-        /*rt=*/OCF_D_RT,
-        /*name=*/std::string(kDevice2Name),
-        /*spec_version=*/"ocf.1.0.0",
-        /*data_model_version=*/"ocf.res.1.0.0",
-        /*uri=*/"/oic/d",
-      },
+#if defined(OC_SERVER) && defined(OC_DYNAMIC_ALLOCATION)
+        {
+          /*rt=*/OCF_D_RT,
+          /*name=*/std::string(kDevice2Name),
+          /*spec_version=*/"ocf.1.0.0",
+          /*data_model_version=*/"ocf.res.1.0.0",
+          /*uri=*/"/oic/d",
+        },
+#endif /* OC_SERVER && OC_DYNAMIC_ALLOCATION */
     });
     EXPECT_TRUE(oc::TestDevice::StartServer());
 
@@ -352,12 +356,14 @@ TEST_F(TestCoreResourceWithDevice, CoreGetResourceByURI_P)
     check_uri(uri, kDevice1ID);
   }
 
+#if defined(OC_SERVER) && defined(OC_DYNAMIC_ALLOCATION)
   // add leading '/' and recheck
   std::transform(uris.cbegin(), uris.cend(), uris.begin(),
                  [](const std::string &str) { return "/" + str; });
   for (const auto &uri : uris) {
-    check_uri(uri, /*device*/ 1);
+    check_uri(uri, kDevice2ID);
   }
+#endif /* OC_SERVER && OC_DYNAMIC_ALLOCATION */
 }
 
 TEST_F(TestCoreResourceWithDevice, CoreGetResourceIsDCR_P)

--- a/api/unittest/etagtest.cpp
+++ b/api/unittest/etagtest.cpp
@@ -822,7 +822,7 @@ TEST_F(TestETagWithServer, IgnoreInvalidStorageData)
   // set all etags to 1337
   setAllETags(kETag);
 
-  auto empty_storage = [](size_t, void *) {
+  auto empty_storage = [](size_t, const void *) {
     oc_rep_start_root_object();
     oc_rep_end_root_object();
     return 0;
@@ -844,7 +844,7 @@ TEST_F(TestETagWithServer, IgnoreInvalidStorageData)
   //   ...
   // }
 
-  auto store_encode_single_string = [](size_t, void *) {
+  auto store_encode_single_string = [](size_t, const void *) {
     oc_rep_start_root_object();
     oc_rep_set_text_string(root, uri, "/oic/d");
     oc_rep_end_root_object();
@@ -858,7 +858,7 @@ TEST_F(TestETagWithServer, IgnoreInvalidStorageData)
     EXPECT_EQ(kETag, oc_resource_get_etag(resource));
   });
 
-  auto store_encode_invalid_type = [](size_t, void *) {
+  auto store_encode_invalid_type = [](size_t, const void *) {
     oc_rep_start_root_object();
     std::string uri = "/oic/d";
     int err =
@@ -883,7 +883,7 @@ TEST_F(TestETagWithServer, IgnoreInvalidStorageData)
     EXPECT_EQ(kETag, oc_resource_get_etag(resource));
   });
 
-  auto store_encode_invalid_value = [](size_t, void *) {
+  auto store_encode_invalid_value = [](size_t, const void *) {
     oc_rep_start_root_object();
     int err = encodeResourceETag(oc_rep_object(root), "/oic/p", 0);
     err |= encodeResourceETag(oc_rep_object(root), "/oic/d", -1);

--- a/api/unittest/maintest.cpp
+++ b/api/unittest/maintest.cpp
@@ -201,3 +201,10 @@ TEST_F(TestMain, NeedsPoll)
     // no-op
   }
 }
+
+TEST(TestMainInit, Init_Fail)
+{
+  oc_handler_t handler{};
+  handler.init = []() { return -1; };
+  EXPECT_EQ(-1, oc_main_init(&handler));
+}

--- a/api/unittest/storagetest.cpp
+++ b/api/unittest/storagetest.cpp
@@ -47,7 +47,7 @@ public:
   {
     ASSERT_EQ(0, oc_storage_config(testStorage.c_str()));
 
-    auto encode = [](size_t, void *) {
+    auto encode = [](size_t, const void *) {
       oc_rep_start_root_object();
       oc_rep_set_boolean(root, ok, true);
       oc_rep_end_root_object();
@@ -137,10 +137,10 @@ TEST_F(TestCommonStorage, LoadResourceFail)
 
 TEST_F(TestCommonStorage, SaveResourceFail)
 {
-  auto encodeFail = [](size_t, void *) { return -1; };
+  auto encodeFail = [](size_t, const void *) { return -1; };
   EXPECT_EQ(-1, oc_storage_data_save("fail", 0, encodeFail, nullptr));
 
-  auto encodeTooLarge = [](size_t, void *) {
+  auto encodeTooLarge = [](size_t, const void *) {
     std::string str(OC_MAX_APP_DATA_SIZE, 'a');
     oc_rep_start_root_object();
     oc_rep_set_text_string(root, too_long, str.c_str());
@@ -163,8 +163,8 @@ TEST_F(TestCommonStorage, SaveAndLoad)
   td.str = "Hello world";
   td.num = 42;
 
-  auto encode = [](size_t, void *data) {
-    const auto *d = static_cast<TestData *>(data);
+  auto encode = [](size_t, const void *data) {
+    const auto *d = static_cast<const TestData *>(data);
     oc_rep_start_root_object();
     oc_rep_set_text_string(root, str, d->str.c_str());
     oc_rep_set_int(root, num, d->num);

--- a/api/unittest/uuidtest.cpp
+++ b/api/unittest/uuidtest.cpp
@@ -40,6 +40,38 @@ TEST(UUID, UUIDIsNill)
   EXPECT_FALSE(oc_uuid_is_empty(uuid2));
 }
 
+TEST(UUID, StrToUUIDTestV1_P)
+{
+  oc_uuid_t uuid{};
+  oc_uuid_t uuidTemp = uuid;
+  ASSERT_EQ(OC_UUID_ID_SIZE, oc_str_to_uuid_v1(UUID, sizeof(UUID), &uuid));
+  EXPECT_NE(0, memcmp(uuid.id, uuidTemp.id, OC_UUID_ID_SIZE));
+
+  oc_uuid_t uuid2{};
+  oc_uuid_t uuid2Temp = uuid2;
+  ASSERT_EQ(OC_UUID_ID_SIZE, oc_str_to_uuid_v1(UUID2, sizeof(UUID2), &uuid2));
+  EXPECT_NE(0, memcmp(uuid2.id, uuid2Temp.id, OC_UUID_ID_SIZE));
+
+  // no output buffer
+  EXPECT_EQ(OC_UUID_ID_SIZE, oc_str_to_uuid_v1(UUID, sizeof(UUID), nullptr));
+  EXPECT_EQ(OC_UUID_ID_SIZE, oc_str_to_uuid_v1(UUID2, sizeof(UUID2), nullptr));
+
+  // wildcard string ("*")
+  ASSERT_EQ(1, oc_str_to_uuid_v1("*", 1, &uuid));
+  EXPECT_EQ('*', uuid.id[0]);
+  EXPECT_EQ(1, oc_str_to_uuid_v1("*", 1, nullptr));
+}
+
+TEST(UUID, StrToUUIDTestV1_F)
+{
+  /* only wildcard string "*" should work as a single char string */
+  EXPECT_EQ(-1, oc_str_to_uuid_v1("a", 1, nullptr));
+
+  std::string truncated_uuid = std::string(UUID).substr(1);
+  EXPECT_EQ(-1, oc_str_to_uuid_v1(truncated_uuid.c_str(), truncated_uuid.size(),
+                                  nullptr));
+}
+
 TEST(UUID, StrToUUIDTest_P)
 {
   oc_uuid_t uuid{};

--- a/apps/cloud_certification_tests.c
+++ b/apps/cloud_certification_tests.c
@@ -330,6 +330,20 @@ cloud_register_cb(oc_cloud_context_t *ctx, oc_cloud_status_t status, void *data)
 }
 
 static void
+cloud_provision_conf_resource(oc_cloud_context_t *ctx)
+{
+  if (cis == NULL || auth_code == NULL || sid == NULL) {
+    return;
+  }
+  size_t cis_len = strlen(cis);
+  size_t auth_code_len = strlen(auth_code);
+  size_t sid_len = strlen(sid);
+  size_t apn_len = apn ? strlen(apn) : 0;
+  oc_cloud_provision_conf_resource_v1(
+    ctx, cis, cis_len, auth_code, auth_code_len, sid, sid_len, apn, apn_len);
+}
+
+static void
 cloud_register(void)
 {
   pthread_mutex_lock(&app_sync_lock);
@@ -338,7 +352,7 @@ cloud_register(void)
     pthread_mutex_unlock(&app_sync_lock);
     return;
   }
-  oc_cloud_provision_conf_resource(ctx, cis, auth_code, sid, apn);
+  cloud_provision_conf_resource(ctx);
   int ret = oc_cloud_register(ctx, cloud_register_cb, NULL);
   pthread_mutex_unlock(&app_sync_lock);
   if (ret < 0) {

--- a/apps/cloud_certification_tests.c
+++ b/apps/cloud_certification_tests.c
@@ -335,12 +335,7 @@ cloud_provision_conf_resource(oc_cloud_context_t *ctx)
   if (cis == NULL || auth_code == NULL || sid == NULL) {
     return;
   }
-  size_t cis_len = strlen(cis);
-  size_t auth_code_len = strlen(auth_code);
-  size_t sid_len = strlen(sid);
-  size_t apn_len = apn ? strlen(apn) : 0;
-  oc_cloud_provision_conf_resource_v1(
-    ctx, cis, cis_len, auth_code, auth_code_len, sid, sid_len, apn, apn_len);
+  oc_cloud_provision_conf_resource(ctx, cis, auth_code, sid, apn);
 }
 
 static void

--- a/apps/cloud_client.c
+++ b/apps/cloud_client.c
@@ -360,6 +360,20 @@ factory_presets_cb(size_t device, void *data)
 #endif /* OC_SECURITY && OC_PKI */
 }
 
+static void
+cloud_provision_conf_resource(oc_cloud_context_t *ctx)
+{
+  if (cis == NULL || auth_code == NULL || sid == NULL) {
+    return;
+  }
+  size_t cis_len = strlen(cis);
+  size_t auth_code_len = strlen(auth_code);
+  size_t sid_len = strlen(sid);
+  size_t apn_len = apn ? strlen(apn) : 0;
+  oc_cloud_provision_conf_resource_v1(
+    ctx, cis, cis_len, auth_code, auth_code_len, sid, sid_len, apn, apn_len);
+}
+
 #if defined(_WIN32)
 static DWORD WINAPI
 ocf_event_thread(LPVOID lpParam)
@@ -383,9 +397,7 @@ ocf_event_thread(LPVOID lpParam)
   oc_cloud_context_t *ctx = oc_cloud_get_context(0);
   if (ctx) {
     oc_cloud_manager_start(ctx, cloud_status_handler, NULL);
-    if (cis) {
-      oc_cloud_provision_conf_resource(ctx, cis, auth_code, sid, apn);
-    }
+    cloud_provision_conf_resource(ctx);
   }
   oc_clock_time_t next_event_mt;
   while (OC_ATOMIC_LOAD8(quit) != 1) {
@@ -430,9 +442,7 @@ ocf_event_thread(void *data)
   oc_cloud_context_t *ctx = oc_cloud_get_context(0);
   if (ctx) {
     oc_cloud_manager_start(ctx, cloud_status_handler, NULL);
-    if (cis) {
-      oc_cloud_provision_conf_resource(ctx, cis, auth_code, sid, apn);
-    }
+    cloud_provision_conf_resource(ctx);
   }
   oc_clock_time_t next_event_mt;
   while (OC_ATOMIC_LOAD8(quit) != 1) {

--- a/apps/cloud_client.c
+++ b/apps/cloud_client.c
@@ -366,12 +366,7 @@ cloud_provision_conf_resource(oc_cloud_context_t *ctx)
   if (cis == NULL || auth_code == NULL || sid == NULL) {
     return;
   }
-  size_t cis_len = strlen(cis);
-  size_t auth_code_len = strlen(auth_code);
-  size_t sid_len = strlen(sid);
-  size_t apn_len = apn ? strlen(apn) : 0;
-  oc_cloud_provision_conf_resource_v1(
-    ctx, cis, cis_len, auth_code, auth_code_len, sid, sid_len, apn, apn_len);
+  oc_cloud_provision_conf_resource(ctx, cis, auth_code, sid, apn);
 }
 
 #if defined(_WIN32)

--- a/apps/cloud_proxy.c
+++ b/apps/cloud_proxy.c
@@ -1921,12 +1921,7 @@ cloud_provision_conf_resource(oc_cloud_context_t *ctx)
     return;
   }
 
-  size_t cis_len = strlen(cis);
-  size_t auth_code_len = strlen(auth_code);
-  size_t sid_len = strlen(sid);
-  size_t apn_len = apn ? strlen(apn) : 0;
-  oc_cloud_provision_conf_resource_v1(
-    ctx, cis, cis_len, auth_code, auth_code_len, sid, sid_len, apn, apn_len);
+  oc_cloud_provision_conf_resource(ctx, cis, auth_code, sid, apn);
   OC_PRINTF("   config status  %d\n", 0);
 
   OC_PRINTF("Conf Cloud Manager\n");

--- a/apps/cloud_server.c
+++ b/apps/cloud_server.c
@@ -1541,12 +1541,7 @@ cloud_provision_conf_resource(oc_cloud_context_t *ctx)
   if (cis == NULL || auth_code == NULL || sid == NULL) {
     return;
   }
-  size_t cis_len = strlen(cis);
-  size_t auth_code_len = strlen(auth_code);
-  size_t sid_len = strlen(sid);
-  size_t apn_len = apn ? strlen(apn) : 0;
-  oc_cloud_provision_conf_resource_v1(
-    ctx, cis, cis_len, auth_code, auth_code_len, sid, sid_len, apn, apn_len);
+  oc_cloud_provision_conf_resource(ctx, cis, auth_code, sid, apn);
 }
 
 static void

--- a/apps/cloud_server.c
+++ b/apps/cloud_server.c
@@ -1536,6 +1536,20 @@ cloud_server_log(oc_log_level_t log_level, oc_log_component_t component,
 }
 
 static void
+cloud_provision_conf_resource(oc_cloud_context_t *ctx)
+{
+  if (cis == NULL || auth_code == NULL || sid == NULL) {
+    return;
+  }
+  size_t cis_len = strlen(cis);
+  size_t auth_code_len = strlen(auth_code);
+  size_t sid_len = strlen(sid);
+  size_t apn_len = apn ? strlen(apn) : 0;
+  oc_cloud_provision_conf_resource_v1(
+    ctx, cis, cis_len, auth_code, auth_code_len, sid, sid_len, apn, apn_len);
+}
+
+static void
 cloud_server_send_response_cb(oc_request_t *request, oc_status_t response_code)
 {
   const char *uri = "???";
@@ -1698,9 +1712,7 @@ main(int argc, char *argv[])
     oc_cloud_context_t *ctx = oc_cloud_get_context(i);
     if (ctx) {
       oc_cloud_manager_start(ctx, cloud_status_handler, NULL);
-      if (cis) {
-        oc_cloud_provision_conf_resource(ctx, cis, auth_code, sid, apn);
-      }
+      cloud_provision_conf_resource(ctx);
     }
     display_device_uuid(i);
   }

--- a/include/oc_cloud.h
+++ b/include/oc_cloud.h
@@ -495,14 +495,20 @@ oc_cloud_endpoint_t *oc_cloud_add_server(oc_cloud_context_t *ctx,
  * @param ctx cloud context (cannot be NULL)
  * @param ce cloud endpoint to remove
  *
+ * @return true if the endpoint address was removed from the list of cloud
+ * servers
+ * @return false on failure
+ *
  * @note The servers are stored in a list. If the selected server is removed,
  * then next server in the list will be selected. If the selected server is the
  * last item in the list, then the first server in the list will be selected (if
  * it exists).
  *
- * @return true if the endpoint address was removed from the list of cloud
- * servers
- * @return false on failure
+ * @note The server is cached by the cloud, so if you remove the selected server
+ * during cloud provisioning then it might be necessary to restart the cloud
+ * manager for the change to take effect.
+ *
+ * @see oc_cloud_manager_restart
  */
 OC_API
 bool oc_cloud_remove_server(oc_cloud_context_t *ctx,
@@ -563,13 +569,29 @@ void oc_cloud_iterate_servers(const oc_cloud_context_t *ctx,
  * @note The address of the selected server will be returned as the cis value
  * and the identity of the selected server will be returned as the sid value.
  *
+ * @note The server is cached by the cloud, so if you the selected server during
+ * cloud provisioning then it might be necessary to restart the cloud manager
+ * for the change to take effect.
+ *
  * @see oc_cloud_remove_server
  * @see oc_cloud_get_cis
  * @see oc_cloud_get_sid
+ * @see oc_cloud_manager_restart
  */
 OC_API
 bool oc_cloud_select_server(oc_cloud_context_t *ctx,
                             const oc_cloud_endpoint_t *server) OC_NONNULL();
+
+/**
+ * @brief Get the selected cloud server.
+ *
+ * @param ctx cloud context (cannot be NULL)
+ * @return oc_cloud_endpoint_t* pointer to the selected cloud server
+ * @return NULL if no cloud server is selected
+ */
+OC_API
+const oc_cloud_endpoint_t *oc_cloud_selected_server(
+  const oc_cloud_context_t *ctx) OC_NONNULL();
 
 /** @} */ // end of cloud_servers
 

--- a/include/oc_helpers.h
+++ b/include/oc_helpers.h
@@ -166,7 +166,8 @@ typedef struct oc_mmem oc_handle_t, oc_string_t, oc_array_t, oc_string_array_t,
  * @param str1 first string (cannot be NULL)
  * @param str2 second string (cannot be NULL)
  */
-void oc_concat_strings(oc_string_t *concat, const char *str1, const char *str2);
+void oc_concat_strings(oc_string_t *concat, const char *str1, const char *str2)
+  OC_NONNULL();
 #define oc_string_len(ocstring) ((ocstring).size != 0 ? (ocstring).size - 1 : 0)
 
 #define oc_int_array_size(ocintarray) ((ocintarray).size)

--- a/include/oc_uuid.h
+++ b/include/oc_uuid.h
@@ -68,11 +68,27 @@ typedef struct
  * oc_uuid_t uuid;
  * oc_str_to_uuid("1628fbcc-13ce-4e37-b883-1fd8d2ad945d", &uuid);
  * ```
- * @param[in] str the UUID string
+ * @param str the UUID string
  * @param[out] uuid the oc_uuid_t to hold the UUID bits (cannot be NULL).
  */
 OC_API
 void oc_str_to_uuid(const char *str, oc_uuid_t *uuid) OC_NONNULL(2);
+
+/**
+ * Convert a UUID string representation to a 128-bit oc_uuid_t
+ *
+ * @param str the UUID string (cannot be NULL)
+ * @param str_len the length of the UUID string
+ * @param[out] uuid the oc_uuid_t to hold the UUID bits.
+ * @return -1 if the string is not a valid UUID
+ * @return 1 if the string is the special case ("*") UUID value
+ * @return OC_UUID_ID_SIZE (size of the uuid) if the string is a valid UUID
+ *
+ * @see oc_str_to_uuid
+ */
+OC_API
+int oc_str_to_uuid_v1(const char *str, size_t str_len, oc_uuid_t *uuid)
+  OC_NONNULL(1);
 
 /**
  * Convert the 128 bit oc_uuid_t to a string representation.

--- a/port/esp32/main/CMakeLists.txt
+++ b/port/esp32/main/CMakeLists.txt
@@ -131,6 +131,7 @@ if (CONFIG_CLOUD)
 		${CMAKE_CURRENT_SOURCE_DIR}/../../../api/cloud/oc_cloud_apis.c
 		${CMAKE_CURRENT_SOURCE_DIR}/../../../api/cloud/oc_cloud_context.c
 		${CMAKE_CURRENT_SOURCE_DIR}/../../../api/cloud/oc_cloud_deregister.c
+		${CMAKE_CURRENT_SOURCE_DIR}/../../../api/cloud/oc_cloud_endpoint.c
 		${CMAKE_CURRENT_SOURCE_DIR}/../../../api/cloud/oc_cloud_manager.c
 		${CMAKE_CURRENT_SOURCE_DIR}/../../../api/cloud/oc_cloud_rd.c
 		${CMAKE_CURRENT_SOURCE_DIR}/../../../api/cloud/oc_cloud_resource.c

--- a/security/oc_store.c
+++ b/security/oc_store.c
@@ -62,7 +62,7 @@ oc_sec_load_doxm(size_t device)
 }
 
 static int
-store_encode_doxm(size_t device, void *data)
+store_encode_doxm(size_t device, const void *data)
 {
   (void)data;
   return oc_sec_encode_doxm(device, /*iface_mask*/ 0, true);
@@ -100,7 +100,7 @@ oc_sec_load_pstat(size_t device)
 }
 
 static int
-store_encode_pstat(size_t device, void *data)
+store_encode_pstat(size_t device, const void *data)
 {
   (void)data;
   oc_sec_encode_pstat(device, /*iface_mask*/ 0, /*to_storage*/ true);
@@ -140,7 +140,7 @@ oc_sec_load_sp(size_t device)
 }
 
 static int
-store_encode_sp(size_t device, void *data)
+store_encode_sp(size_t device, const void *data)
 {
   (void)data;
   return oc_sec_sp_encode_for_device(device, /*flags*/ 0) ? 0 : -1;
@@ -504,7 +504,7 @@ oc_sec_load_sdi(size_t device)
 }
 
 static int
-store_encode_sdi(size_t device, void *data)
+store_encode_sdi(size_t device, const void *data)
 {
   (void)data;
   return oc_sec_sdi_encode(device, /*iface_mask*/ 0);

--- a/security/unittest/csrtest.cpp
+++ b/security/unittest/csrtest.cpp
@@ -284,7 +284,8 @@ TEST_F(TestCSRWithDevice, RegenerateDeviceKeypair)
   ASSERT_LT(0, oc_sec_ecdsa_count_keypairs());
 }
 
-#ifdef OC_HAS_FEATURE_RESOURCE_ACCESS_IN_RFOTM
+#if defined(OC_HAS_FEATURE_RESOURCE_ACCESS_IN_RFOTM) &&                        \
+  defined(OC_DYNAMIC_ALLOCATION)
 
 TEST_F(TestCSRWithDevice, GetResourceBaseline)
 {
@@ -315,7 +316,7 @@ TEST_F(TestCSRWithDevice, GetResourceBaseline)
   EXPECT_TRUE(invoked);
 }
 
-#endif /* OC_HAS_FEATURE_RESOURCE_ACCESS_IN_RFOTM */
+#endif /* OC_HAS_FEATURE_RESOURCE_ACCESS_IN_RFOTM && OC_DYNAMIC_ALLOCATION */
 
 class TestCSRWithDeviceTPM : public TestCSRWithDevice {
 public:

--- a/security/unittest/csrtest.cpp
+++ b/security/unittest/csrtest.cpp
@@ -50,14 +50,14 @@ public:
         g_ocf_ecs.push_back(ec);
       }
     }
+    EXPECT_TRUE(oc::TestDevice::StartServer());
   }
 
-  void SetUp() override { EXPECT_TRUE(oc::TestDevice::StartServer()); }
+  static void TearDownTestCase() { oc::TestDevice::StopServer(); }
 
   void TearDown() override
   {
     oc::TestDevice::Reset();
-    oc::TestDevice::StopServer();
     oc_sec_certs_default();
   }
 

--- a/security/unittest/dtlstest.cpp
+++ b/security/unittest/dtlstest.cpp
@@ -99,7 +99,7 @@ dtls_thread_win32(void *data)
 TEST_F(TestDTLSWithServer, DTLSInactivityMonitor)
 {
   oc_clock_time_t timeout_default = oc_dtls_inactivity_timeout();
-  oc_dtls_set_inactivity_timeout(2 * OC_CLOCK_SECOND);
+  oc_dtls_set_inactivity_timeout(OC_CLOCK_SECOND);
 
   // DTLS endpoint
   auto epOpt = oc::TestDevice::GetEndpoint(kDeviceID, SECURED, TCP);
@@ -139,7 +139,7 @@ TEST_F(TestDTLSWithServer, DTLSInactivityMonitor)
 #endif /* MINGW_WINTHREAD */
 
   while (dtls_status.load() == DTLS_STATUS::DTLS_INIT) {
-    oc::TestDevice::PoolEventsMs(200);
+    oc::TestDevice::PoolEventsMs(50);
   }
 
   ASSERT_EQ(1, oc_tls_num_peers(kDeviceID));

--- a/security/unittest/obt_certstest.cpp
+++ b/security/unittest/obt_certstest.cpp
@@ -581,10 +581,14 @@ public:
     // allow all ocf-supported MDs and ECs
     oc_sec_certs_md_set_algorithms_allowed(OCF_CERTS_SUPPORTED_MDS);
     oc_sec_certs_ecp_set_group_ids_allowed(OCF_CERTS_SUPPORTED_ELLIPTIC_CURVES);
+
+    EXPECT_TRUE(oc::TestDevice::StartServer());
   }
 
   static void TearDownTestCase()
   {
+    oc::TestDevice::StopServer();
+
     // restore defaults
     oc_sec_certs_md_set_algorithms_allowed(
       MBEDTLS_X509_ID_FLAG(MBEDTLS_MD_SHA256));
@@ -594,8 +598,6 @@ public:
 
   void SetUp() override
   {
-    EXPECT_TRUE(oc::TestDevice::StartServer());
-
     oc_uuid_t uuid{};
     oc_gen_uuid(&uuid);
     std::array<char, 50> buf;
@@ -606,11 +608,7 @@ public:
     roles_.Add("user", "");
   }
 
-  void TearDown() override
-  {
-    oc::TestDevice::Reset();
-    oc::TestDevice::StopServer();
-  }
+  void TearDown() override { oc::TestDevice::Reset(); }
 
   std::string uuid_{};
   oc::Roles roles_{};

--- a/swig/swig_interfaces/oc_cloud.i
+++ b/swig/swig_interfaces/oc_cloud.i
@@ -221,7 +221,7 @@ const char *jni_cloud_get_cis(const oc_cloud_context_t *ctx)
 %ignore oc_cloud_get_sid;
 %rename (getId) jni_cloud_get_sid;
 %inline %{
-const char *jni_cloud_get_sid(const oc_cloud_context_t *ctx)
+const oc_uuid_t *jni_cloud_get_sid(const oc_cloud_context_t *ctx)
 {
 #ifdef OC_CLOUD
   return oc_cloud_get_sid(ctx);
@@ -543,38 +543,6 @@ int jni_cloud_provision_conf_resource(oc_cloud_context_t *ctx,
   (void)accessToken;
   (void)serverId;
   (void)authProvider;
-  return -1;
-#endif /* !OC_CLOUD */
-}
-%}
-
-%ignore oc_cloud_provision_conf_resource_v1;
-%rename(provisionConfResourceV1) jni_cloud_provision_conf_resource_v1;
-%inline %{
-int jni_cloud_provision_conf_resource_v1(oc_cloud_context_t *ctx,
-                                         const char *server,
-                                         size_t server_len,
-                                         const char *accessToken,
-                                         size_t accessToken_len,
-                                         const char *serverId,
-                                         size_t serverId_len,
-                                         const char *authProvider,
-                                         size_t authProvider_len)
-{
-#ifdef OC_CLOUD
-  return oc_cloud_provision_conf_resource_v1(ctx, server, server_len, accessToken, accessToken_len,
-    serverId, serverId_len, authProvider, authProvider_len);
-#else /* OC_CLOUD*/
-  OC_DBG("JNI: %s - Must build with OC_CLOUD defined to use this function.\n", __func__);
-  (void)ctx;
-  (void)server;
-  (void)server_len;
-  (void)accessToken;
-  (void)accessToken_len;
-  (void)serverId;
-  (void)serverId_len;
-  (void)authProvider;
-  (void)authProvider_len;
   return -1;
 #endif /* !OC_CLOUD */
 }

--- a/swig/swig_interfaces/oc_cloud.i
+++ b/swig/swig_interfaces/oc_cloud.i
@@ -24,6 +24,8 @@
 
 %{
 #include "oc_iotivity_lite_jni.h"
+#include "api/cloud/oc_cloud_context_internal.h"
+#include "api/cloud/oc_cloud_store_internal.h"
 #include "oc_cloud.h"
 #include "port/oc_log_internal.h"
 
@@ -99,6 +101,17 @@ static void jni_cloud_cb(oc_cloud_context_t *ctx, oc_cloud_status_t status, void
 %ignore oc_cloud_keepalive_t;
 %ignore oc_cloud_set_keepalive;
 
+// TODO: implement
+%ignore cloud_context_iterator_cb_t;
+%ignore cloud_context_iterate;
+
+// TODO: implement
+%ignore oc_cloud_set_schedule_action;
+%ignore oc_cloud_schedule_action_cb_t;
+%ignore oc_cloud_schedule_action_t;
+%ignore oc_cloud_action_to_str;
+%ignore oc_cloud_action_t;
+
 // oc_cloud_status is a bitmask exposed through OCCloudStatusMask.java as ints
 %ignore oc_cloud_status_t;
 %rename (OCCloudPrivisoningStatus) oc_cps_t;
@@ -108,24 +121,27 @@ static void jni_cloud_cb(oc_cloud_context_t *ctx, oc_cloud_status_t status, void
 %rename (REGISTERED) OC_CPS_REGISTERED;
 %rename (FAILED) OC_CPS_FAILED;
 
-%rename (OCCloudStore) oc_cloud_store_t;
 %rename (OCCloudError) oc_cloud_error_t;
+%ignore oc_cloud_on_status_change_cb_t;
+
 %rename (OCCloudContext) oc_cloud_context_t;
-%ignore oc_cloud_context_t::callback;
-%ignore oc_cloud_context_t::user_data;
+%ignore oc_cloud_context_t::next;
+%ignore oc_cloud_context_t::device;
+%ignore oc_cloud_context_t::on_status_change;
+%ignore oc_cloud_context_t::store;
 %ignore oc_cloud_context_t::keepalive;
-%rename (cloudEndpointState) oc_cloud_context_t::cloud_ep_state;
-%rename (cloudEndpoint) oc_cloud_context_t::cloud_ep;
-%rename (retryCount) oc_cloud_context_t::retry_count;
-%rename (retryRefreshTokenCount) oc_cloud_context_t::retry_refresh_token_count;
-%rename (lastError) oc_cloud_context_t::last_error;
-%rename (expiresIn) oc_cloud_context_t::expires_in;
-%rename (rdPublishResources) oc_cloud_context_t::rd_publish_resources;
-%rename (rdPublishedResources) oc_cloud_context_t::rd_published_resources;
-%rename (rdDeleteResources) oc_cloud_context_t::rd_delete_resources;
-%ignore oc_cloud_context_t::cps;
-%rename (cloudConf) oc_cloud_context_t::cloud_conf;
-%rename (cloudManager) oc_cloud_context_t::cloud_manager;
+%ignore oc_cloud_context_t::schedule_action;
+%ignore oc_cloud_context_t::cloud_ep_state;
+%ignore oc_cloud_context_t::cloud_ep;
+%ignore oc_cloud_context_t::rd_publish_resources;
+%ignore oc_cloud_context_t::rd_published_resources;
+%ignore oc_cloud_context_t::rd_delete_resources;
+%ignore oc_cloud_context_t::selected_identity_cred_id;
+%ignore oc_cloud_context_t::last_error;
+%ignore oc_cloud_context_t::time_to_live;
+%ignore oc_cloud_context_t::retry_count;
+%ignore oc_cloud_context_t::cloud_manager;
+%ignore oc_cloud_context_t::retry_refresh_token_count;
 
 %ignore oc_cloud_get_context;
 %rename (getContext) jni_cloud_get_context;
@@ -137,6 +153,96 @@ oc_cloud_context_t *jni_cloud_get_context(size_t device)
 #else /* OC_CLOUD*/
   OC_DBG("JNI: %s - Must build with OC_CLOUD defined to use this function.\n", __func__);
   (void)device;
+  return NULL;
+#endif /* !OC_CLOUD */
+}
+%}
+
+%ignore oc_cloud_get_device;
+%rename (getDevice) jni_cloud_get_device;
+%inline %{
+size_t jni_cloud_get_device(const oc_cloud_context_t *ctx)
+{
+#ifdef OC_CLOUD
+  return oc_cloud_get_device(ctx);
+#else /* OC_CLOUD*/
+  OC_DBG("JNI: %s - Must build with OC_CLOUD defined to use this function.\n", __func__);
+  (void)ctx;
+  return 0;
+#endif /* !OC_CLOUD */
+}
+%}
+
+%ignore oc_cloud_get_apn;
+%rename (getAuthorizationProviderName) jni_cloud_get_apn;
+%inline %{
+const char *jni_cloud_get_apn(const oc_cloud_context_t *ctx)
+{
+#ifdef OC_CLOUD
+  return oc_cloud_get_apn(ctx);
+#else /* OC_CLOUD*/
+  OC_DBG("JNI: %s - Must build with OC_CLOUD defined to use this function.\n", __func__);
+  (void)ctx;
+  return NULL;
+#endif /* !OC_CLOUD */
+}
+%}
+
+%ignore oc_cloud_get_at;
+%rename (getAccessToken) jni_cloud_get_at;
+%inline %{
+const char *jni_cloud_get_at(const oc_cloud_context_t *ctx)
+{
+#ifdef OC_CLOUD
+  return oc_cloud_get_at(ctx);
+#else /* OC_CLOUD*/
+  OC_DBG("JNI: %s - Must build with OC_CLOUD defined to use this function.\n", __func__);
+  (void)ctx;
+  return NULL;
+#endif /* !OC_CLOUD */
+}
+%}
+
+%ignore oc_cloud_get_cis;
+%rename (getAddress) jni_cloud_get_cis;
+%inline %{
+const char *jni_cloud_get_cis(const oc_cloud_context_t *ctx)
+{
+#ifdef OC_CLOUD
+  return oc_cloud_get_cis(ctx);
+#else /* OC_CLOUD*/
+  OC_DBG("JNI: %s - Must build with OC_CLOUD defined to use this function.\n", __func__);
+  (void)ctx;
+  return NULL;
+#endif /* !OC_CLOUD */
+}
+%}
+
+%ignore oc_cloud_get_sid;
+%rename (getId) jni_cloud_get_sid;
+%inline %{
+const char *jni_cloud_get_sid(const oc_cloud_context_t *ctx)
+{
+#ifdef OC_CLOUD
+  return oc_cloud_get_sid(ctx);
+#else /* OC_CLOUD*/
+  OC_DBG("JNI: %s - Must build with OC_CLOUD defined to use this function.\n", __func__);
+  (void)ctx;
+  return NULL;
+#endif /* !OC_CLOUD */
+}
+%}
+
+%ignore oc_cloud_get_uid;
+%rename (getUserId) jni_cloud_get_uid;
+%inline %{
+const char *jni_cloud_get_uid(const oc_cloud_context_t *ctx)
+{
+#ifdef OC_CLOUD
+  return oc_cloud_get_uid(ctx);
+#else /* OC_CLOUD*/
+  OC_DBG("JNI: %s - Must build with OC_CLOUD defined to use this function.\n", __func__);
+  (void)ctx;
   return NULL;
 #endif /* !OC_CLOUD */
 }
@@ -442,6 +548,38 @@ int jni_cloud_provision_conf_resource(oc_cloud_context_t *ctx,
 }
 %}
 
+%ignore oc_cloud_provision_conf_resource_v1;
+%rename(provisionConfResourceV1) jni_cloud_provision_conf_resource_v1;
+%inline %{
+int jni_cloud_provision_conf_resource_v1(oc_cloud_context_t *ctx,
+                                         const char *server,
+                                         size_t server_len,
+                                         const char *accessToken,
+                                         size_t accessToken_len,
+                                         const char *serverId,
+                                         size_t serverId_len,
+                                         const char *authProvider,
+                                         size_t authProvider_len)
+{
+#ifdef OC_CLOUD
+  return oc_cloud_provision_conf_resource_v1(ctx, server, server_len, accessToken, accessToken_len,
+    serverId, serverId_len, authProvider, authProvider_len);
+#else /* OC_CLOUD*/
+  OC_DBG("JNI: %s - Must build with OC_CLOUD defined to use this function.\n", __func__);
+  (void)ctx;
+  (void)server;
+  (void)server_len;
+  (void)accessToken;
+  (void)accessToken_len;
+  (void)serverId;
+  (void)serverId_len;
+  (void)authProvider;
+  (void)authProvider_len;
+  return -1;
+#endif /* !OC_CLOUD */
+}
+%}
+
 %ignore oc_cloud_set_identity_cert_chain;
 %rename(setIdentityCertChain) jni_cloud_set_identity_cert_chain;
 %inline %{
@@ -461,7 +599,7 @@ void jni_cloud_set_identity_cert_chain(oc_cloud_context_t *ctx,
 %ignore oc_cloud_get_identity_cert_chain;
 %rename(getIdentityCertChain) jni_cloud_get_identity_cert_chain;
 %inline %{
-int jni_cloud_get_identity_cert_chain(oc_cloud_context_t *ctx)
+int jni_cloud_get_identity_cert_chain(const oc_cloud_context_t *ctx)
 {
 #ifdef OC_CLOUD
   return oc_cloud_get_identity_cert_chain(ctx);
@@ -472,4 +610,36 @@ int jni_cloud_get_identity_cert_chain(oc_cloud_context_t *ctx)
 #endif /* !OC_CLOUD */
 }
 %}
+
+%ignore oc_cloud_context_clear;
+%rename(clearContext) jni_cloud_context_clear;
+%inline %{
+void jni_cloud_context_clear(oc_cloud_context_t *ctx, bool dump_async)
+{
+#ifdef OC_CLOUD
+  oc_cloud_context_clear(ctx, dump_async);
+#else /* OC_CLOUD*/
+  OC_DBG("JNI: %s - Must build with OC_CLOUD defined to use this function.\n", __func__);
+  (void)ctx;
+  (void)dump_async;
+#endif /* !OC_CLOUD */
+}
+%}
+
+#define OC_NONNULL(...)
+
+// get oc_cloud_context_t definition, but ignore all other definitions
+%ignore cloud_context_init;
+%ignore cloud_context_deinit;
+%ignore cloud_context_size;
+%ignore cloud_context_iterator_cb_t;
+%ignore cloud_context_has_access_token;
+%ignore cloud_context_iterate;
+%ignore cloud_context_clear;
+%ignore cloud_context_has_permanent_access_token;
+%ignore cloud_context_clear_access_token;
+%ignore cloud_context_has_refresh_token;
+%include "api/cloud/oc_cloud_context_internal.h"
+
+#define OC_API
 %include "oc_cloud.h"

--- a/swig/swig_interfaces/oc_ri.i
+++ b/swig/swig_interfaces/oc_ri.i
@@ -146,6 +146,8 @@ struct oc_response_s
 // get/set properties callbacks are not expected to be read or writen directly to by Java code.
 %ignore oc_resource_s::get_properties;
 %ignore oc_resource_s::set_properties;
+%ignore oc_ri_on_delete_resource_add_callback;
+%ignore oc_ri_on_delete_resource_remove_callback;
 
 %rename(OCEventCallbackResult) oc_event_callback_retval_t;
 %ignore oc_event_callback_s;


### PR DESCRIPTION
Remove oc_cloud_store_t and oc_cloud_context_t definitions from oc_cloud.h header.