### PR TITLE
cloud: add oc_cloud_manager_stop_v1 function

### DIFF
--- a/api/cloud/oc_cloud_context.c
+++ b/api/cloud/oc_cloud_context.c
@@ -300,6 +300,24 @@ oc_cloud_get_identity_cert_chain(const oc_cloud_context_t *ctx)
   return ctx->selected_identity_cred_id;
 }
 
+bool
+oc_cloud_registration_context_is_initialized(
+  const oc_cloud_registration_context_t *regctx)
+{
+  return oc_string(regctx->initial_server) != NULL;
+}
+
+void
+oc_cloud_registration_context_init_if_not_set(
+  oc_cloud_registration_context_t *regctx,
+  const oc_endpoint_addresses_t *servers)
+{
+  if (oc_cloud_registration_context_is_initialized(regctx)) {
+    return;
+  }
+  oc_cloud_registration_context_init(regctx, servers);
+}
+
 void
 oc_cloud_registration_context_init(oc_cloud_registration_context_t *regctx,
                                    const oc_endpoint_addresses_t *servers)
@@ -322,6 +340,12 @@ oc_cloud_registration_context_deinit(oc_cloud_registration_context_t *regctx)
 {
   oc_free_string(&regctx->initial_server);
   regctx->remaining_server_changes = 0;
+  regctx->server_changed = false;
+}
+
+void
+oc_cloud_registration_context_reset(oc_cloud_registration_context_t *regctx)
+{
   regctx->server_changed = false;
 }
 

--- a/api/cloud/oc_cloud_context_internal.h
+++ b/api/cloud/oc_cloud_context_internal.h
@@ -184,6 +184,20 @@ void oc_cloud_registration_context_init(oc_cloud_registration_context_t *regctx,
 void oc_cloud_registration_context_deinit(
   oc_cloud_registration_context_t *regctx) OC_NONNULL();
 
+/** @brief Check if the registration context is initialized */
+bool oc_cloud_registration_context_is_initialized(
+  const oc_cloud_registration_context_t *regctx) OC_NONNULL();
+
+/** @brief Initialize the registration context if it hasn't been previously
+ * initialized */
+void oc_cloud_registration_context_init_if_not_set(
+  oc_cloud_registration_context_t *regctx,
+  const oc_endpoint_addresses_t *servers) OC_NONNULL();
+
+/** @brief Reset temporary data */
+void oc_cloud_registration_context_reset(
+  oc_cloud_registration_context_t *regctx) OC_NONNULL();
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/oc_cloud.h
+++ b/include/oc_cloud.h
@@ -305,7 +305,7 @@ oc_cps_t oc_cloud_get_provisioning_status(const oc_cloud_context_t *ctx)
 /**
  * @brief Start cloud registration process.
  *
- * @param ctx cloud context (cannot be NULL)
+ * @param ctx cloud context
  * @param cb callback function invoked on status change
  * @param data user data provided to the status change function
  * @return int 0 on success
@@ -319,12 +319,27 @@ int oc_cloud_manager_start(oc_cloud_context_t *ctx, oc_cloud_cb_t cb,
  * @brief Stop cloud registration process, remove related pending delayed
  * callbacks and clean-up data.
  *
- * @param ctx cloud context (cannot be NULL)
+ * @param ctx cloud context
  * @return int 0 on success
  * @return int -1 on error
  */
 OC_API
 int oc_cloud_manager_stop(oc_cloud_context_t *ctx);
+
+/**
+ * @brief Stop cloud registration process, remove related pending delayed
+ * callbacks and clean-up data.
+ *
+ * @param ctx cloud context (cannot be NULL)
+ * @param resetConfiguration if true, reset cloud configuration to default
+ * (cloud must be reconfigured by oc_cloud_provision_conf_resource or by
+ * updating the cloud resource); if false the previous cloud configuration is
+ * kept, but the cloud is reset to OC_CPS_REGISTERED state if it was registered
+ * or to OC_CPS_READYTOREGISTER otherwise
+ */
+OC_API
+void oc_cloud_manager_stop_v1(oc_cloud_context_t *ctx, bool resetConfiguration)
+  OC_NONNULL();
 
 /**
  * @brief Restart cloud registration process with the current configuration.

--- a/swig/swig_interfaces/oc_cloud.i
+++ b/swig/swig_interfaces/oc_cloud.i
@@ -377,6 +377,23 @@ int jni_cloud_manager_stop(oc_cloud_context_t *ctx)
 }
 %}
 
+%ignore oc_cloud_manager_stop_v1;
+%rename (managerStopV1) jni_cloud_manager_stop_v1;
+%inline %{
+void jni_cloud_manager_stop_v1(oc_cloud_context_t *ctx, bool resetConfiguration)
+{
+#ifdef OC_CLOUD
+  oc_cloud_manager_stop_v1(ctx, resetConfiguration);
+  jni_callback_data *item = jni_list_get_item_by_callback_valid(OC_CALLBACK_VALID_TILL_CLOUD_MANAGER_STOP);
+  jni_list_remove(item);
+#else /* OC_CLOUD*/
+  OC_DBG("JNI: %s - Must build with OC_CLOUD defined to use this function.\n", __func__);
+  (void)ctx;
+  (void)resetConfiguration;
+#endif /* !OC_CLOUD */
+}
+%}
+
 %ignore oc_cloud_manager_restart;
 %rename (managerRestart) jni_cloud_manager_restart;
 %inline %{
@@ -712,10 +729,14 @@ void jni_cloud_context_clear(oc_cloud_context_t *ctx, bool dump_async)
 %ignore cloud_context_has_permanent_access_token;
 %ignore cloud_context_clear_access_token;
 %ignore cloud_context_has_refresh_token;
+%ignore cloud_context_on_server_change;
 
 %ignore oc_cloud_registration_context_t;
 %ignore oc_cloud_registration_context_init;
 %ignore oc_cloud_registration_context_deinit;
+%ignore oc_cloud_registration_context_is_initialized;
+%ignore oc_cloud_registration_context_init_if_not_set;
+%ignore oc_cloud_registration_context_reset;
 %ignore oc_cloud_context_t::registration_ctx;
 %include "api/cloud/oc_cloud_context_internal.h"
 


### PR DESCRIPTION
The function enables the caller to stop the cloud manager, but without clearing the cloud configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a function to check if cloud configuration exists.
	- Introduced functions to check and initialize the cloud registration context.
	- Implemented a function to stop cloud registration with an option to reset the configuration.
	- Added a test case to verify cloud configuration provisioning with a started cloud context.

- **Bug Fixes**
	- Enhanced cloud context handling during the stop process for improved stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->