### PR TITLE
discovery: allow to ignore resource in batch notification

### DIFF
--- a/api/oc_discovery_internal.h
+++ b/api/oc_discovery_internal.h
@@ -98,6 +98,9 @@ bool oc_filter_out_ep_for_resource(const oc_endpoint_t *ep,
 
 #ifdef OC_RES_BATCH_SUPPORT
 
+/** Batch responses are currently only supported with a secure endpoint */
+bool oc_discovery_batch_response_is_supported(const oc_endpoint_t *ep);
+
 /**
  * @brief Check if resource should be included in the batch response.
  *

--- a/api/oc_server_api.c
+++ b/api/oc_server_api.c
@@ -139,6 +139,7 @@ oc_send_response_internal(oc_request_t *request, oc_status_t response_code,
 {
   int status_code = oc_status_code(response_code);
   if (status_code < 0) {
+    OC_ERR("could not send response: invalid response code");
     request->response->response_buffer->code = CLEAR_TRANSACTION;
     return false;
   }
@@ -190,7 +191,7 @@ oc_send_response_with_callback(oc_request_t *request, oc_status_t response_code,
   bool canTruncate = request->method != OC_GET || response_code != OC_STATUS_OK;
   if (!oc_send_response_internal(request, response_code, content_format,
                                  response_length(canTruncate), trigger_cb)) {
-    OC_ERR("could not send response: invalid response code");
+    return;
   }
 }
 

--- a/api/unittest/discovery/discovery.h
+++ b/api/unittest/discovery/discovery.h
@@ -110,12 +110,12 @@ public:
   void SetUp() override;
   void TearDown() override;
 
-  static void onGetDynamicResource(oc_request_t *request,
-                                   oc_interface_mask_t interface,
+  static void onGetDynamicResource(oc_request_t *request, oc_interface_mask_t,
                                    void *user_data);
   static void onGetEmptyDynamicResource(oc_request_t *request,
-                                        oc_interface_mask_t interface,
-                                        void *user_data);
+                                        oc_interface_mask_t, void *);
+  static void onGetIgnoredDynamicResource(oc_request_t *request,
+                                          oc_interface_mask_t, void *);
 
   static void addDynamicResources();
 #ifdef OC_COLLECTIONS
@@ -154,6 +154,7 @@ constexpr size_t kDeviceID{ 0 };
 constexpr std::string_view kDynamicURI1 = "/dyn/discoverable";
 constexpr std::string_view kDynamicURI2 = "/dyn/undiscoverable";
 constexpr std::string_view kDynamicURI3 = "/dyn/empty";
+constexpr std::string_view kDynamicURIIgnored = "/dyn/ignored";
 
 #ifdef OC_COLLECTIONS
 


### PR DESCRIPTION
Use OC_IGNORE response code to ignore resource in batch notification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced notification handling in the discovery process for more nuanced decision-making.
  - Added support for batch responses in secure endpoints.
  - Improved handling of ETags for resource discovery to skip processing under specific conditions.
  - Introduced dynamic resource management in tests, including handling for ignored resources.

- **Bug Fixes**
  - Added error logging and response failure handling in server API functions to improve reliability and error tracking.

- **Tests**
  - Expanded unit tests to cover new functionalities such as batch discovery and dynamic resource handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->