### PR TITLE
ports: Enhance TCP Client Disconnect Notifications in TLS Handling

### DIFF
--- a/api/cloud/oc_cloud.c
+++ b/api/cloud/oc_cloud.c
@@ -132,19 +132,7 @@ void
 oc_cloud_close_endpoint(const oc_endpoint_t *ep)
 {
   OC_CLOUD_DBG("oc_cloud_close_endpoint");
-#ifdef OC_SECURITY
-  const oc_tls_peer_t *peer = oc_tls_get_peer(ep);
-  if (peer != NULL) {
-    OC_CLOUD_DBG("oc_cloud_close_endpoint: oc_tls_close_connection");
-    oc_tls_close_connection(ep);
-  } else
-#endif /* OC_SECURITY */
-  {
-#ifdef OC_TCP
-    OC_CLOUD_DBG("oc_cloud_close_endpoint: oc_connectivity_end_session");
-    oc_connectivity_end_session(ep);
-#endif /* OC_TCP */
-  }
+  oc_close_session(ep);
 }
 
 void

--- a/api/oc_client_api.c
+++ b/api/oc_client_api.c
@@ -961,16 +961,23 @@ oc_do_ip_discovery_at_endpoint(const char *rt, oc_discovery_handler_t handler,
 void
 oc_close_session(const oc_endpoint_t *endpoint)
 {
-  if (endpoint->flags & SECURED) {
 #ifdef OC_SECURITY
+  if ((endpoint->flags & SECURED) != 0) {
     oc_tls_close_connection(endpoint);
+    return;
+  }
 #endif /* OC_SECURITY */
-  } else if (endpoint->flags & TCP) {
 #ifdef OC_TCP
+  if ((endpoint->flags & TCP) != 0) {
     oc_endpoint_t session_endpoint;
     while (oc_connectivity_end_session_v1(endpoint, false, &session_endpoint)) {
       oc_handle_session(&session_endpoint, OC_SESSION_DISCONNECTED);
     }
-#endif /* OC_TCP */
+    return;
   }
+#endif /* OC_TCP */
+
+#if !defined(OC_TCP) && !defined(OC_SECURITY)
+  (void)endpoint;
+#endif /* !OC_TCP && !OC_SECURITY */
 }

--- a/api/oc_client_api.c
+++ b/api/oc_client_api.c
@@ -18,6 +18,18 @@
 
 #include "oc_config.h"
 
+#include "oc_api.h"
+#include "oc_endpoint.h"
+
+#ifdef OC_TCP
+#include "api/oc_session_events_internal.h"
+#include "port/oc_connectivity_internal.h"
+#endif /* OC_TCP */
+
+#ifdef OC_SECURITY
+#include "security/oc_tls_internal.h"
+#endif /* OC_SECURITY */
+
 #ifdef OC_CLIENT
 
 #include "api/client/oc_client_cb_internal.h"
@@ -37,10 +49,6 @@
 #ifdef OC_TCP
 #include "messaging/coap/signal_internal.h"
 #endif /* OC_TCP */
-
-#ifdef OC_SECURITY
-#include "security/oc_tls_internal.h"
-#endif /* OC_SECURITY */
 
 #include <assert.h>
 
@@ -948,6 +956,8 @@ oc_do_ip_discovery_at_endpoint(const char *rt, oc_discovery_handler_t handler,
   return status;
 }
 
+#endif /* OC_CLIENT */
+
 void
 oc_close_session(const oc_endpoint_t *endpoint)
 {
@@ -957,9 +967,9 @@ oc_close_session(const oc_endpoint_t *endpoint)
 #endif /* OC_SECURITY */
   } else if (endpoint->flags & TCP) {
 #ifdef OC_TCP
-    oc_connectivity_end_session(endpoint);
+    if (oc_connectivity_end_session_v1(endpoint, false)) {
+      oc_handle_session(endpoint, OC_SESSION_DISCONNECTED);
+    }
 #endif /* OC_TCP */
   }
 }
-
-#endif /* OC_CLIENT */

--- a/api/oc_client_api.c
+++ b/api/oc_client_api.c
@@ -967,8 +967,9 @@ oc_close_session(const oc_endpoint_t *endpoint)
 #endif /* OC_SECURITY */
   } else if (endpoint->flags & TCP) {
 #ifdef OC_TCP
-    if (oc_connectivity_end_session_v1(endpoint, false)) {
-      oc_handle_session(endpoint, OC_SESSION_DISCONNECTED);
+    oc_endpoint_t session_endpoint;
+    while (oc_connectivity_end_session_v1(endpoint, false, &session_endpoint)) {
+      oc_handle_session(&session_endpoint, OC_SESSION_DISCONNECTED);
     }
 #endif /* OC_TCP */
   }

--- a/api/oc_endpoint.c
+++ b/api/oc_endpoint.c
@@ -685,7 +685,7 @@ oc_endpoint_compare_session_ids(const oc_endpoint_t *ep1,
   }
   return ep1->session_id == ep2->session_id ? 0 : -1;
 }
-#endif
+#endif /* OC_TCP */
 
 int
 oc_endpoint_compare(const oc_endpoint_t *ep1, const oc_endpoint_t *ep2)
@@ -711,7 +711,7 @@ oc_endpoint_compare(const oc_endpoint_t *ep1, const oc_endpoint_t *ep2)
     return -1;
   }
 #ifdef OC_IPV4
-  else if (ep1->flags & IPV4) {
+  if (ep1->flags & IPV4) {
     if (memcmp(ep1->addr.ipv4.address, ep2->addr.ipv4.address, 4) == 0 &&
         ep1->addr.ipv4.port == ep2->addr.ipv4.port) {
 #ifdef OC_TCP
@@ -724,15 +724,6 @@ oc_endpoint_compare(const oc_endpoint_t *ep1, const oc_endpoint_t *ep2)
   }
 #endif /* OC_IPV4 */
 
-#ifdef OC_TCP
-  else if (ep1->flags & TCP) {
-    if (memcmp(ep1->addr.ipv6.address, ep2->addr.ipv6.address, 16) == 0 &&
-        ep1->addr.ipv6.port == ep2->addr.ipv6.port) {
-      return 0;
-    }
-    return -1;
-  }
-#endif
   // TODO: Add support for other endpoint types
   return -1;
 }

--- a/api/oc_endpoint.c
+++ b/api/oc_endpoint.c
@@ -675,6 +675,18 @@ oc_endpoint_compare_address(const oc_endpoint_t *ep1, const oc_endpoint_t *ep2)
   return -1;
 }
 
+#ifdef OC_TCP
+static int
+oc_endpoint_compare_session_ids(const oc_endpoint_t *ep1,
+                                const oc_endpoint_t *ep2)
+{
+  if (ep1->session_id == 0 || ep2->session_id == 0) {
+    return 0; // session_id == 0 means any
+  }
+  return ep1->session_id == ep2->session_id ? 0 : -1;
+}
+#endif
+
 int
 oc_endpoint_compare(const oc_endpoint_t *ep1, const oc_endpoint_t *ep2)
 {
@@ -690,7 +702,11 @@ oc_endpoint_compare(const oc_endpoint_t *ep1, const oc_endpoint_t *ep2)
   if (ep1->flags & IPV6) {
     if (memcmp(ep1->addr.ipv6.address, ep2->addr.ipv6.address, 16) == 0 &&
         ep1->addr.ipv6.port == ep2->addr.ipv6.port) {
+#ifdef OC_TCP
+      return oc_endpoint_compare_session_ids(ep1, ep2);
+#else  /* OC_TCP */
       return 0;
+#endif /* !OC_TCP */
     }
     return -1;
   }
@@ -698,11 +714,25 @@ oc_endpoint_compare(const oc_endpoint_t *ep1, const oc_endpoint_t *ep2)
   else if (ep1->flags & IPV4) {
     if (memcmp(ep1->addr.ipv4.address, ep2->addr.ipv4.address, 4) == 0 &&
         ep1->addr.ipv4.port == ep2->addr.ipv4.port) {
+#ifdef OC_TCP
+      return oc_endpoint_compare_session_ids(ep1, ep2);
+#else  /* OC_TCP */
       return 0;
+#endif /* !OC_TCP */
     }
     return -1;
   }
 #endif /* OC_IPV4 */
+
+#ifdef OC_TCP
+  else if (ep1->flags & TCP) {
+    if (memcmp(ep1->addr.ipv6.address, ep2->addr.ipv6.address, 16) == 0 &&
+        ep1->addr.ipv6.port == ep2->addr.ipv6.port) {
+      return 0;
+    }
+    return -1;
+  }
+#endif
   // TODO: Add support for other endpoint types
   return -1;
 }

--- a/api/oc_session_events.c
+++ b/api/oc_session_events.c
@@ -133,6 +133,9 @@ oc_session_start_event(const oc_endpoint_t *endpoint)
     return;
   }
 
+  // only a specific session should be connected
+  assert(endpoint->session_id != 0);
+
   oc_endpoint_t *ep = oc_new_endpoint();
   memcpy(ep, endpoint, sizeof(oc_endpoint_t));
   ep->next = NULL;
@@ -151,6 +154,9 @@ oc_session_end_event(const oc_endpoint_t *endpoint)
   if (!oc_process_is_running(&oc_session_events)) {
     return;
   }
+
+  // only a specific session should be disconnected
+  assert(endpoint->session_id != 0);
 
   oc_endpoint_t *ep = oc_new_endpoint();
   memcpy(ep, endpoint, sizeof(oc_endpoint_t));

--- a/api/oc_session_events.c
+++ b/api/oc_session_events.c
@@ -332,7 +332,7 @@ handle_session_disconnected(const oc_endpoint_t *endpoint)
   (void)endpoint;
 #ifdef OC_SECURITY
   if ((endpoint->flags & SECURED) != 0 && (endpoint->flags & TCP) != 0) {
-    oc_tls_remove_peer(endpoint);
+    oc_tls_remove_peer(endpoint, false);
   }
 #endif /* OC_SECURITY */
 #ifdef OC_SERVER

--- a/api/oc_session_events_internal.h
+++ b/api/oc_session_events_internal.h
@@ -22,10 +22,21 @@
 #include "oc_endpoint.h"
 #include "oc_session_events.h"
 #include "util/oc_process.h"
+#include "util/oc_features.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @brief Invoke all session handlers associated with given endpoint
+ *
+ * @param endpoint endpoint of the session event (cannot be NULLL)
+ * @param state new session state
+ */
+void oc_handle_session(const oc_endpoint_t *endpoint, oc_session_state_t state);
+
+#ifdef OC_SESSION_EVENTS
 
 #define OC_SESSION_EVENT_API_V0 (0)
 #define OC_SESSION_EVENT_API_V1 (1)
@@ -61,40 +72,6 @@ typedef struct oc_session_event_cb
   void *user_data;
 } oc_session_event_cb_t;
 
-OC_PROCESS_NAME(oc_session_events);
-
-/**
- * @brief session start event
- *
- * @param endpoint start event on endpoint
- */
-void oc_session_start_event(const oc_endpoint_t *endpoint);
-
-/**
- * @brief session end event
- *
- * @param endpoint stop event on endpoint
- */
-void oc_session_end_event(const oc_endpoint_t *endpoint);
-
-/**
- * @brief Invoke all session handlers associated with given endpoint
- *
- * @param endpoint endpoint of the session event (cannot be NULLL)
- * @param state new session state
- */
-void oc_handle_session(const oc_endpoint_t *endpoint, oc_session_state_t state);
-
-/**
- * @brief Check if session events are currently in the process of being
- * disconnected.
- *
- * @return true all sessions are currently being iterated, disconnected and
- * deallocated
- * @return false otherwise
- */
-bool oc_session_events_disconnect_is_ongoing(void);
-
 /**
  * @brief Find first session event callback matching the input parameters.
  *
@@ -114,6 +91,38 @@ oc_session_event_cb_t *oc_session_event_callback_find(
  * callbacks.
  */
 void oc_session_events_remove_all_callbacks(void);
+
+#endif /* OC_SESSION_EVENTS */
+
+#ifdef OC_TCP
+
+OC_PROCESS_NAME(oc_session_events);
+
+/**
+ * @brief session start event
+ *
+ * @param endpoint start event on endpoint
+ */
+void oc_session_start_event(const oc_endpoint_t *endpoint);
+
+/**
+ * @brief session end event
+ *
+ * @param endpoint stop event on endpoint
+ */
+void oc_session_end_event(const oc_endpoint_t *endpoint);
+
+/**
+ * @brief Check if session events are currently in the process of being
+ * disconnected.
+ *
+ * @return true all sessions are currently being iterated, disconnected and
+ * deallocated
+ * @return false otherwise
+ */
+bool oc_session_events_disconnect_is_ongoing(void);
+
+#endif /* OC_TCP */
 
 #ifdef __cplusplus
 }

--- a/api/oc_tcp.c
+++ b/api/oc_tcp.c
@@ -32,15 +32,6 @@
 #endif /* OC_OSCORE */
 #endif /* OC_SECURITY */
 
-static OC_ATOMIC_UINT32_T g_tcp_session_id = 0;
-
-uint32_t
-oc_tcp_get_new_session_id(void)
-{
-  uint32_t v = OC_ATOMIC_INCREMENT32(g_tcp_session_id);
-  return (v == 0) ? OC_ATOMIC_INCREMENT32(g_tcp_session_id) : v;
-}
-
 #ifdef OC_HAS_FEATURE_TCP_ASYNC_CONNECT
 
 #include "port/oc_allocator_internal.h"
@@ -95,6 +86,15 @@ oc_tcp_on_connect_event_free(oc_tcp_on_connect_event_t *event)
 }
 
 #endif /* OC_HAS_FEATURE_TCP_ASYNC_CONNECT */
+
+static OC_ATOMIC_UINT32_T g_tcp_session_id = 0;
+
+uint32_t
+oc_tcp_get_new_session_id(void)
+{
+  uint32_t v = OC_ATOMIC_INCREMENT32(g_tcp_session_id);
+  return (v == 0) ? OC_ATOMIC_INCREMENT32(g_tcp_session_id) : v;
+}
 
 bool
 oc_tcp_is_valid_header(const uint8_t *data, size_t data_size, bool is_tls)

--- a/api/oc_tcp.c
+++ b/api/oc_tcp.c
@@ -24,12 +24,22 @@
 #include "oc_endpoint.h"
 #include "port/oc_connectivity.h"
 #include "oc_tcp_internal.h"
+#include "util/oc_atomic.h"
 #ifdef OC_SECURITY
 #include <mbedtls/ssl.h>
 #ifdef OC_OSCORE
 #include "messaging/coap/oscore_internal.h"
 #endif /* OC_OSCORE */
 #endif /* OC_SECURITY */
+
+static OC_ATOMIC_UINT32_T g_tcp_session_id = 0;
+
+uint32_t
+oc_tcp_get_new_session_id(void)
+{
+  uint32_t v = OC_ATOMIC_INCREMENT32(g_tcp_session_id);
+  return (v == 0) ? OC_ATOMIC_INCREMENT32(g_tcp_session_id) : v;
+}
 
 #ifdef OC_HAS_FEATURE_TCP_ASYNC_CONNECT
 

--- a/api/oc_tcp_internal.h
+++ b/api/oc_tcp_internal.h
@@ -23,10 +23,10 @@
 
 #ifdef OC_TCP
 
-#include <stdint.h>
 #include "messaging/coap/constants.h"
 #include "port/oc_connectivity.h"
 #include "oc_endpoint.h"
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/api/oc_tcp_internal.h
+++ b/api/oc_tcp_internal.h
@@ -23,6 +23,7 @@
 
 #ifdef OC_TCP
 
+#include <stdint.h>
 #include "messaging/coap/constants.h"
 #include "port/oc_connectivity.h"
 #include "oc_endpoint.h"
@@ -33,6 +34,9 @@ extern "C" {
 
 #define OC_TCP_DEFAULT_RECEIVE_SIZE                                            \
   (COAP_TCP_DEFAULT_HEADER_LEN + COAP_TCP_MAX_EXTENDED_LENGTH_LEN)
+
+/** @brief Get new tcp session ID */
+uint32_t oc_tcp_get_new_session_id(void);
 
 #ifdef OC_HAS_FEATURE_TCP_ASYNC_CONNECT
 

--- a/api/plgd/plgd_time.c
+++ b/api/plgd/plgd_time.c
@@ -922,7 +922,7 @@ plgd_time_fetch(plgd_time_fetch_config_t fetch, unsigned *flags)
     OC_ERR("failed to send fetch plgd-time request to endpoint");
 #if defined(OC_SECURITY) && defined(OC_PKI)
     if (add_insecure_peer) {
-      oc_tls_remove_peer(fetch.endpoint);
+      oc_tls_remove_peer(fetch.endpoint, true);
     }
 #endif /* OC_SECURITY && OC_PKI */
     oc_memb_free(&g_fetch_params_s, fetch_params);

--- a/apps/client_multithread_linux.c
+++ b/apps/client_multithread_linux.c
@@ -107,7 +107,7 @@ pong_received_handler(oc_client_response_t *data)
     ping_count++;
     if (ping_count > PING_RETRY_COUNT) {
       OC_PRINTF("retry over. close connection.\n");
-      oc_connectivity_end_session(data->endpoint);
+      oc_close_session(data->endpoint);
     } else {
       ping_timeout <<= 1;
       OC_PRINTF("PING send again.[retry: %zd, time: %u]\n", ping_count,

--- a/include/oc_endpoint.h
+++ b/include/oc_endpoint.h
@@ -98,7 +98,7 @@ typedef struct oc_endpoint_t
     oc_ipv4_addr_t ipv4; ///< ipv4 address
     oc_le_addr_t bt;     ///< blue tooth address
   } addr, addr_local;
-  unsigned interface_index; ///< interface index (valid intefaces are >0, 0
+  unsigned interface_index; ///< interface index (valid interfaces are >0, 0
                             ///< means no index or error)
   uint8_t priority;         ///< priority
   ocf_version_t version;    ///< ocf version
@@ -106,6 +106,10 @@ typedef struct oc_endpoint_t
   uint8_t piv[OSCORE_PIV_LEN];
   uint8_t piv_len;
 #endif /* OC_OSCORE */
+#ifdef OC_TCP
+  uint32_t session_id; ///< session id for pairing tls peer with tcp session - 0
+                       ///< means any
+#endif
 } oc_endpoint_t;
 
 #define oc_make_ipv4_endpoint(__name__, __flags__, __port__, ...)              \

--- a/messaging/coap/engine.c
+++ b/messaging/coap/engine.c
@@ -1100,7 +1100,7 @@ coap_process_invalid_inbound_message(const coap_packet_t *packet,
 #endif /* OC_SECURITY */
 #ifdef OC_TCP
   if ((msg->endpoint.flags & TCP) != 0) {
-    oc_connectivity_end_session(&msg->endpoint);
+    oc_close_session(&msg->endpoint);
     return;
   }
 #endif /* OC_TCP */

--- a/messaging/coap/signal.c
+++ b/messaging/coap/signal.c
@@ -21,6 +21,7 @@
 #include "log_internal.h"
 #include "signal_internal.h"
 #include "coap_internal.h"
+#include "oc_api.h"
 #include "transactions_internal.h"
 #include <string.h>
 
@@ -223,7 +224,7 @@ coap_signal_handle_message(const coap_packet_t *packet,
   if (packet->code == RELEASE_7_04) {
     // alternative address
     // hold off
-    oc_connectivity_end_session(endpoint);
+    oc_close_session(endpoint);
     return COAP_SIGNAL_DONE;
   }
 

--- a/port/android/ipadapter.c
+++ b/port/android/ipadapter.c
@@ -1630,12 +1630,20 @@ oc_connectivity_shutdown(size_t device)
 void
 oc_connectivity_end_session(const oc_endpoint_t *endpoint)
 {
+  oc_connectivity_end_session_v1(endpoint, true);
+}
+
+bool
+oc_connectivity_end_session_v1(const oc_endpoint_t *endpoint,
+                               bool notify_session_end)
+{
   if (endpoint->flags & TCP) {
     ip_context_t *dev = get_ip_context_for_device(endpoint->device);
     if (dev) {
-      oc_tcp_end_session(dev, endpoint);
+      return oc_tcp_end_session(dev, endpoint, notify_session_end);
     }
   }
+  return false;
 }
 #endif /* OC_TCP */
 

--- a/port/android/ipadapter.c
+++ b/port/android/ipadapter.c
@@ -1630,17 +1630,21 @@ oc_connectivity_shutdown(size_t device)
 void
 oc_connectivity_end_session(const oc_endpoint_t *endpoint)
 {
-  oc_connectivity_end_session_v1(endpoint, true);
+  while (oc_connectivity_end_session_v1(endpoint, true, NULL)) {
+    // no-op
+  }
 }
 
 bool
 oc_connectivity_end_session_v1(const oc_endpoint_t *endpoint,
-                               bool notify_session_end)
+                               bool notify_session_end,
+                               oc_endpoint_t *session_endpoint)
 {
   if (endpoint->flags & TCP) {
     ip_context_t *dev = get_ip_context_for_device(endpoint->device);
     if (dev) {
-      return oc_tcp_end_session(dev, endpoint, notify_session_end);
+      return oc_tcp_end_session(dev, endpoint, notify_session_end,
+                                session_endpoint);
     }
   }
   return false;

--- a/port/android/tcpadapter.c
+++ b/port/android/tcpadapter.c
@@ -189,11 +189,11 @@ oc_tcp_add_socks_to_fd_set(ip_context_t *dev)
 }
 
 static void
-free_tcp_session(tcp_session_t *session)
+free_tcp_session(tcp_session_t *session, bool notify_session_end)
 {
   oc_list_remove(session_list, session);
 
-  if (!oc_session_events_disconnect_is_ongoing()) {
+  if (!oc_session_events_disconnect_is_ongoing() && notify_session_end) {
     oc_session_end_event(&session->endpoint);
   }
 
@@ -401,13 +401,13 @@ oc_tcp_receive_message(ip_context_t *dev, fd_set *fds, oc_message_t *message)
     if (count < 0) {
       OC_ERR("recv error! %d", errno);
 
-      free_tcp_session(session);
+      free_tcp_session(session, true);
 
       ret_with_code(ADAPTER_STATUS_ERROR);
     } else if (count == 0) {
       OC_DBG("peer closed TCP session\n");
 
-      free_tcp_session(session);
+      free_tcp_session(session, true);
 
       ret_with_code(ADAPTER_STATUS_NONE);
     }
@@ -428,7 +428,7 @@ oc_tcp_receive_message(ip_context_t *dev, fd_set *fds, oc_message_t *message)
         oc_tcp_get_total_length_from_message_header(message);
       if (length_from_header < 0) {
         OC_ERR("invalid message size in header");
-        free_tcp_session(session);
+        free_tcp_session(session, true);
         ret_with_code(ADAPTER_STATUS_ERROR);
       }
 
@@ -438,7 +438,7 @@ oc_tcp_receive_message(ip_context_t *dev, fd_set *fds, oc_message_t *message)
         OC_ERR(
           "total receive length(%zu) is bigger than message buffer size(%zu)",
           total_length, oc_message_buffer_size(message));
-        free_tcp_session(session);
+        free_tcp_session(session, true);
         ret_with_code(ADAPTER_STATUS_ERROR);
       }
       OC_DBG("tcp packet total length : %zu bytes.", total_length);
@@ -448,7 +448,7 @@ oc_tcp_receive_message(ip_context_t *dev, fd_set *fds, oc_message_t *message)
   } while (total_length > message->length);
 
   if (!oc_tcp_is_valid_message(message)) {
-    free_tcp_session(session);
+    free_tcp_session(session, true);
     return ADAPTER_STATUS_ERROR;
   }
 
@@ -461,15 +461,17 @@ oc_tcp_receive_message_done:
   return ret;
 }
 
-void
-oc_tcp_end_session(ip_context_t *dev, const oc_endpoint_t *endpoint)
+bool
+oc_tcp_end_session(ip_context_t *dev, const oc_endpoint_t *endpoint,
+                   bool notify_session_end)
 {
   pthread_mutex_lock(&dev->tcp.mutex);
   tcp_session_t *session = find_session_by_endpoint(endpoint);
   if (session) {
-    free_tcp_session(session);
+    free_tcp_session(session, notify_session_end);
   }
   pthread_mutex_unlock(&dev->tcp.mutex);
+  return session != NULL;
 }
 
 static int
@@ -764,7 +766,7 @@ oc_tcp_connectivity_shutdown(ip_context_t *dev)
   while (session != NULL) {
     next = session->next;
     if (session->endpoint.device == dev->device) {
-      free_tcp_session(session);
+      free_tcp_session(session, true);
     }
     session = next;
   }

--- a/port/android/tcpadapter.c
+++ b/port/android/tcpadapter.c
@@ -235,6 +235,9 @@ add_new_session(int sock, ip_context_t *dev, oc_endpoint_t *endpoint,
   session->endpoint.next = NULL;
   session->sock = sock;
   session->csm_state = state;
+  if (session->endpoint.session_id == 0) {
+    session->endpoint.session_id = oc_tcp_get_new_session_id();
+  }
 
   oc_list_add(session_list, session);
 
@@ -463,11 +466,14 @@ oc_tcp_receive_message_done:
 
 bool
 oc_tcp_end_session(ip_context_t *dev, const oc_endpoint_t *endpoint,
-                   bool notify_session_end)
+                   bool notify_session_end, oc_endpoint_t *session_endpoint)
 {
   pthread_mutex_lock(&dev->tcp.mutex);
   tcp_session_t *session = find_session_by_endpoint(endpoint);
   if (session) {
+    if (session_endpoint) {
+      memcpy(session_endpoint, &session->endpoint, sizeof(oc_endpoint_t));
+    }
     free_tcp_session(session, notify_session_end);
   }
   pthread_mutex_unlock(&dev->tcp.mutex);

--- a/port/android/tcpadapter.h
+++ b/port/android/tcpadapter.h
@@ -39,7 +39,8 @@ void oc_tcp_add_socks_to_fd_set(ip_context_t *dev);
 adapter_receive_state_t oc_tcp_receive_message(ip_context_t *dev, fd_set *fds,
                                                oc_message_t *message);
 
-void oc_tcp_end_session(ip_context_t *dev, const oc_endpoint_t *endpoint);
+bool oc_tcp_end_session(ip_context_t *dev, const oc_endpoint_t *endpoint,
+                        bool notify_session_end);
 
 #ifdef __cplusplus
 }

--- a/port/android/tcpadapter.h
+++ b/port/android/tcpadapter.h
@@ -40,7 +40,8 @@ adapter_receive_state_t oc_tcp_receive_message(ip_context_t *dev, fd_set *fds,
                                                oc_message_t *message);
 
 bool oc_tcp_end_session(ip_context_t *dev, const oc_endpoint_t *endpoint,
-                        bool notify_session_end);
+                        bool notify_session_end,
+                        oc_endpoint_t *session_endpoint);
 
 #ifdef __cplusplus
 }

--- a/port/esp32/adapter/src/ipadapter.c
+++ b/port/esp32/adapter/src/ipadapter.c
@@ -1618,17 +1618,21 @@ oc_connectivity_shutdown(size_t device)
 void
 oc_connectivity_end_session(const oc_endpoint_t *endpoint)
 {
-  oc_connectivity_end_session_v1(endpoint, true);
+  while (oc_connectivity_end_session_v1(endpoint, true, NULL)) {
+    // no-op
+  }
 }
 
 bool
 oc_connectivity_end_session_v1(const oc_endpoint_t *endpoint,
-                               bool notify_session_end)
+                               bool notify_session_end,
+                               oc_endpoint_t *session_endpoint)
 {
   if (endpoint->flags & TCP) {
     ip_context_t *dev = get_ip_context_for_device(endpoint->device);
     if (dev) {
-      return oc_tcp_end_session(dev, endpoint, notify_session_end);
+      return oc_tcp_end_session(dev, endpoint, notify_session_end,
+                                session_endpoint);
     }
   }
   return false;

--- a/port/esp32/adapter/src/ipadapter.c
+++ b/port/esp32/adapter/src/ipadapter.c
@@ -1618,12 +1618,20 @@ oc_connectivity_shutdown(size_t device)
 void
 oc_connectivity_end_session(const oc_endpoint_t *endpoint)
 {
+  oc_connectivity_end_session_v1(endpoint, true);
+}
+
+bool
+oc_connectivity_end_session_v1(const oc_endpoint_t *endpoint,
+                               bool notify_session_end)
+{
   if (endpoint->flags & TCP) {
     ip_context_t *dev = get_ip_context_for_device(endpoint->device);
     if (dev) {
-      oc_tcp_end_session(dev, endpoint);
+      return oc_tcp_end_session(dev, endpoint, notify_session_end);
     }
   }
+  return false;
 }
 #endif /* OC_TCP */
 

--- a/port/esp32/adapter/src/tcpadapter.c
+++ b/port/esp32/adapter/src/tcpadapter.c
@@ -205,6 +205,9 @@ add_new_session(int sock, ip_context_t *dev, oc_endpoint_t *endpoint,
   session->endpoint.next = NULL;
   session->sock = sock;
   session->csm_state = state;
+  if (session->endpoint.session_id == 0) {
+    session->endpoint.session_id = oc_tcp_get_new_session_id();
+  }
 
   oc_list_add(session_list, session);
 
@@ -436,11 +439,14 @@ oc_tcp_receive_message_done:
 
 bool
 oc_tcp_end_session(ip_context_t *dev, const oc_endpoint_t *endpoint,
-                   bool notify_session_end)
+                   bool notify_session_end, oc_endpoint_t *session_endpoint)
 {
   pthread_mutex_lock(&dev->tcp.mutex);
   tcp_session_t *session = find_session_by_endpoint(endpoint);
   if (session) {
+    if (session_endpoint) {
+      memcpy(session_endpoint, &session->endpoint, sizeof(oc_endpoint_t));
+    }
     free_tcp_session(session, notify_session_end);
   }
   pthread_mutex_unlock(&dev->tcp.mutex);

--- a/port/esp32/adapter/src/tcpadapter.c
+++ b/port/esp32/adapter/src/tcpadapter.c
@@ -28,6 +28,7 @@
 #include "oc_endpoint.h"
 #include "oc_session_events.h"
 #include "port/oc_assert.h"
+#include "port/oc_connectivity_internal.h"
 #include "port/oc_log_internal.h"
 #include "port/oc_tcp_socket_internal.h"
 #include "tcpadapter.h"
@@ -198,18 +199,16 @@ add_new_session(int sock, ip_context_t *dev, oc_endpoint_t *endpoint,
     return -1;
   }
 
-  endpoint->interface_index = (unsigned)if_index;
-
   session->dev = dev;
+  endpoint->interface_index = (unsigned)if_index;
+  if (session_id == 0) {
+    session_id = oc_tcp_get_new_session_id();
+  }
+  endpoint->session_id = session_id;
   memcpy(&session->endpoint, endpoint, sizeof(oc_endpoint_t));
   session->endpoint.next = NULL;
   session->sock = sock;
   session->csm_state = state;
-  if (session_id == 0) {
-    session->endpoint.session_id = oc_tcp_get_new_session_id();
-  } else {
-    session->endpoint.session_id = session_id;
-  }
 
   oc_list_add(session_list, session);
 
@@ -283,6 +282,22 @@ find_session_by_endpoint(const oc_endpoint_t *endpoint)
   OC_DBG("found TCP session for");
   OC_LOGipaddr(*endpoint);
   OC_DBG("%s", "");
+  return session;
+}
+
+static tcp_session_t *
+find_session_by_id(uint32_t session_id)
+{
+  tcp_session_t *session = oc_list_head(session_list);
+  while (session != NULL && session->endpoint.session_id != session_id) {
+    session = session->next;
+  }
+
+  if (!session) {
+    OC_DBG("could not find ongoing TCP session for session id %d", session_id);
+    return NULL;
+  }
+  OC_DBG("found TCP session for session id %d", session_id);
   return session;
 }
 
@@ -751,6 +766,15 @@ int
 oc_tcp_connection_state(const oc_endpoint_t *endpoint)
 {
   if (find_session_by_endpoint(endpoint) != NULL) {
+    return OC_TCP_SOCKET_STATE_CONNECTED;
+  }
+  return -1;
+}
+
+int
+oc_tcp_session_state(uint32_t session_id)
+{
+  if (find_session_by_id(session_id) != NULL) {
     return OC_TCP_SOCKET_STATE_CONNECTED;
   }
   return -1;

--- a/port/esp32/adapter/src/tcpadapter.c
+++ b/port/esp32/adapter/src/tcpadapter.c
@@ -32,16 +32,16 @@
 #include "port/oc_tcp_socket_internal.h"
 #include "tcpadapter.h"
 #include "util/oc_memb.h"
+#include "vfs_pipe.h"
 
 #include <arpa/inet.h>
 #include <assert.h>
 #include <errno.h>
+#include <esp_netif.h>
 #include <fcntl.h>
-// #include <ifaddrs.h>
-#include "esp_netif.h"
-#include "vfs_pipe.h"
 #include <net/if.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
@@ -184,7 +184,7 @@ free_tcp_session(tcp_session_t *session, bool notify_session_end)
 
 static int
 add_new_session(int sock, ip_context_t *dev, oc_endpoint_t *endpoint,
-                tcp_csm_state_t state)
+                uint32_t session_id, tcp_csm_state_t state)
 {
   int if_index = get_interface_index(sock);
   if (if_index < 0) {
@@ -205,14 +205,16 @@ add_new_session(int sock, ip_context_t *dev, oc_endpoint_t *endpoint,
   session->endpoint.next = NULL;
   session->sock = sock;
   session->csm_state = state;
-  if (session->endpoint.session_id == 0) {
+  if (session_id == 0) {
     session->endpoint.session_id = oc_tcp_get_new_session_id();
+  } else {
+    session->endpoint.session_id = session_id;
   }
 
   oc_list_add(session_list, session);
 
-  if (!(endpoint->flags & SECURED)) {
-    oc_session_start_event(endpoint);
+  if ((session->endpoint.flags & SECURED) == 0) {
+    oc_session_start_event(&session->endpoint);
   }
 
   OC_DBG("recorded new TCP session");
@@ -251,7 +253,8 @@ accept_new_session(ip_context_t *dev, int fd, fd_set *setfds,
 
   FD_CLR(fd, setfds);
 
-  if (add_new_session(new_socket, dev, endpoint, CSM_NONE) < 0) {
+  if (add_new_session(new_socket, dev, endpoint, /*session_id*/ 0, CSM_NONE) <
+      0) {
     OC_ERR("could not record new TCP session");
     close(new_socket);
     return -1;
@@ -468,6 +471,7 @@ get_session_socket(const oc_endpoint_t *endpoint)
 
 static int
 initiate_new_session(ip_context_t *dev, oc_endpoint_t *endpoint,
+                     uint32_t session_id,
                      const struct sockaddr_storage *receiver)
 {
   int sock = -1;
@@ -490,7 +494,7 @@ initiate_new_session(ip_context_t *dev, oc_endpoint_t *endpoint,
 
   OC_DBG("successfully initiated TCP connection");
 
-  if (add_new_session(sock, dev, endpoint, CSM_SENT) < 0) {
+  if (add_new_session(sock, dev, endpoint, session_id, CSM_SENT) < 0) {
     OC_ERR("could not record new TCP session");
     close(sock);
     return -1;
@@ -522,8 +526,9 @@ oc_tcp_send_buffer(ip_context_t *dev, oc_message_t *message,
       OC_ERR("connection was closed");
       goto oc_tcp_send_buffer_done;
     }
-    if ((send_sock = initiate_new_session(dev, &message->endpoint, receiver)) <
-        0) {
+    if ((send_sock =
+           initiate_new_session(dev, &message->endpoint,
+                                message->endpoint.session_id, receiver)) < 0) {
       OC_ERR("could not initiate new TCP session");
       goto oc_tcp_send_buffer_done;
     }

--- a/port/esp32/adapter/src/tcpadapter.h
+++ b/port/esp32/adapter/src/tcpadapter.h
@@ -39,7 +39,8 @@ void oc_tcp_add_socks_to_fd_set(ip_context_t *dev);
 adapter_receive_state_t oc_tcp_receive_message(ip_context_t *dev, fd_set *fds,
                                                oc_message_t *message);
 
-void oc_tcp_end_session(ip_context_t *dev, const oc_endpoint_t *endpoint);
+bool oc_tcp_end_session(ip_context_t *dev, const oc_endpoint_t *endpoint,
+                        bool notify_session_end);
 
 #ifdef __cplusplus
 }

--- a/port/esp32/adapter/src/tcpadapter.h
+++ b/port/esp32/adapter/src/tcpadapter.h
@@ -40,7 +40,8 @@ adapter_receive_state_t oc_tcp_receive_message(ip_context_t *dev, fd_set *fds,
                                                oc_message_t *message);
 
 bool oc_tcp_end_session(ip_context_t *dev, const oc_endpoint_t *endpoint,
-                        bool notify_session_end);
+                        bool notify_session_end,
+                        oc_endpoint_t *session_endpoint);
 
 #ifdef __cplusplus
 }

--- a/port/linux/ipadapter.c
+++ b/port/linux/ipadapter.c
@@ -1579,11 +1579,12 @@ oc_connectivity_shutdown(size_t device)
 #ifdef OC_TCP
 bool
 oc_connectivity_end_session_v1(const oc_endpoint_t *endpoint,
-                               bool notify_session_end)
+                               bool notify_session_end,
+                               oc_endpoint_t *session_endpoint)
 {
   if ((endpoint->flags & TCP) != 0 &&
       oc_get_ip_context_for_device(endpoint->device) != NULL) {
-    return tcp_end_session(endpoint, notify_session_end);
+    return tcp_end_session(endpoint, notify_session_end, session_endpoint);
   }
   return false;
 }
@@ -1591,6 +1592,8 @@ oc_connectivity_end_session_v1(const oc_endpoint_t *endpoint,
 void
 oc_connectivity_end_session(const oc_endpoint_t *endpoint)
 {
-  oc_connectivity_end_session_v1(endpoint, true);
+  while (oc_connectivity_end_session_v1(endpoint, true, NULL)) {
+    // no-op
+  }
 }
 #endif /* OC_TCP */

--- a/port/linux/ipadapter.c
+++ b/port/linux/ipadapter.c
@@ -1577,12 +1577,20 @@ oc_connectivity_shutdown(size_t device)
 }
 
 #ifdef OC_TCP
-void
-oc_connectivity_end_session(const oc_endpoint_t *endpoint)
+bool
+oc_connectivity_end_session_v1(const oc_endpoint_t *endpoint,
+                               bool notify_session_end)
 {
   if ((endpoint->flags & TCP) != 0 &&
       oc_get_ip_context_for_device(endpoint->device) != NULL) {
-    tcp_end_session(endpoint);
+    return tcp_end_session(endpoint, notify_session_end);
   }
+  return false;
+}
+
+void
+oc_connectivity_end_session(const oc_endpoint_t *endpoint)
+{
+  oc_connectivity_end_session_v1(endpoint, true);
 }
 #endif /* OC_TCP */

--- a/port/linux/tcpsession.h
+++ b/port/linux/tcpsession.h
@@ -105,7 +105,7 @@ adapter_receive_state_t tcp_receive_message(ip_context_t *dev, fd_set *fds,
  * @brief Schedule the session associated with the endpoint to be stopped and
  * deallocated (if it exists).
  */
-void tcp_end_session(const oc_endpoint_t *endpoint);
+bool tcp_end_session(const oc_endpoint_t *endpoint, bool notify_session_end);
 
 /**
  * @brief Handle data received on the signal pipe.

--- a/port/linux/tcpsession.h
+++ b/port/linux/tcpsession.h
@@ -17,19 +17,21 @@
  *
  ****************************************************************************/
 
-#ifndef TCP_SESION_H
-#define TCP_SESION_H
+#ifndef TCP_SESSION_H
+#define TCP_SESSION_H
+
+#include "util/oc_features.h"
+
+#ifdef OC_TCP
 
 #include "port/oc_clock.h"
 #include "port/oc_connectivity.h"
-#include "util/oc_features.h"
 #include "ipcontext.h"
 #include "oc_endpoint.h"
 #include "tcpcontext.h"
+
 #include <stddef.h>
 #include <sys/select.h>
-
-#ifdef OC_TCP
 
 #ifdef __cplusplus
 extern "C" {
@@ -106,7 +108,7 @@ adapter_receive_state_t tcp_receive_message(ip_context_t *dev, fd_set *fds,
  * deallocated (if it exists).
  */
 bool tcp_end_session(const oc_endpoint_t *endpoint, bool notify_session_end,
-                     oc_endpoint_t *session_endpoint);
+                     oc_endpoint_t *session_endpoint) OC_NONNULL(1);
 
 /**
  * @brief Handle data received on the signal pipe.
@@ -119,6 +121,7 @@ void tcp_session_handle_signal(void);
 void tcp_session_shutdown(const ip_context_t *dev);
 
 #ifdef OC_HAS_FEATURE_TCP_ASYNC_CONNECT
+
 /**
  * @brief Iterate over TCP sessions waiting for connection. Deallocate expired
  * sessions. Retry the connection process for sessions that haven't reached the
@@ -155,4 +158,4 @@ bool tcp_process_waiting_sessions(fd_set *fds);
 
 #endif /* OC_TCP */
 
-#endif /* TCP_SESION_H */
+#endif /* TCP_SESSION_H */

--- a/port/linux/tcpsession.h
+++ b/port/linux/tcpsession.h
@@ -105,7 +105,8 @@ adapter_receive_state_t tcp_receive_message(ip_context_t *dev, fd_set *fds,
  * @brief Schedule the session associated with the endpoint to be stopped and
  * deallocated (if it exists).
  */
-bool tcp_end_session(const oc_endpoint_t *endpoint, bool notify_session_end);
+bool tcp_end_session(const oc_endpoint_t *endpoint, bool notify_session_end,
+                     oc_endpoint_t *session_endpoint);
 
 /**
  * @brief Handle data received on the signal pipe.

--- a/port/oc_connectivity.h
+++ b/port/oc_connectivity.h
@@ -158,11 +158,14 @@ int oc_send_buffer(oc_message_t *message);
 void oc_send_discovery_request(oc_message_t *message);
 
 /**
- * @brief end session for the specific endpoint
+ * @brief end TCP session for the specific endpoint.
  *
  * @param endpoint the endpoint to close the session for
+ *
+ * @deprecated replaced by oc_close_session in v2.2.5.14
  */
-void oc_connectivity_end_session(const oc_endpoint_t *endpoint);
+void oc_connectivity_end_session(const oc_endpoint_t *endpoint)
+  OC_DEPRECATED("replaced by oc_close_session in v2.2.5.14");
 
 #ifdef OC_DNS_LOOKUP
 /**

--- a/port/oc_connectivity_internal.h
+++ b/port/oc_connectivity_internal.h
@@ -98,6 +98,17 @@ void handle_session_event_callback(const oc_endpoint_t *endpoint,
                                    oc_session_state_t state);
 #endif /* OC_SESSION_EVENTS */
 
+/**
+ * @brief end TCP session for the specific endpoint.
+ *
+ * @param endpoint the endpoint to close the session for
+ * @param notify_session_end send the notification about the disconnection
+ * session.
+ * @return bool true if the session will be closed
+ */
+bool oc_connectivity_end_session_v1(const oc_endpoint_t *endpoint,
+                                    bool notify_session_end);
+
 #ifdef __cplusplus
 }
 #endif

--- a/port/oc_connectivity_internal.h
+++ b/port/oc_connectivity_internal.h
@@ -104,10 +104,12 @@ void handle_session_event_callback(const oc_endpoint_t *endpoint,
  * @param endpoint the endpoint to close the session for
  * @param notify_session_end send the notification about the disconnection
  * session.
+ * @param session_endpoint the endpoint of the session with session id
  * @return bool true if the session will be closed
  */
 bool oc_connectivity_end_session_v1(const oc_endpoint_t *endpoint,
-                                    bool notify_session_end);
+                                    bool notify_session_end,
+                                    oc_endpoint_t *session_endpoint);
 
 #ifdef __cplusplus
 }

--- a/port/oc_connectivity_internal.h
+++ b/port/oc_connectivity_internal.h
@@ -130,6 +130,17 @@ void oc_tcp_set_connect_retry(uint8_t max_count, uint16_t timeout);
 
 #endif /* OC_HAS_FEATURE_TCP_ASYNC_CONNECT */
 
+/**
+ * @brief Get state of TCP connection for given session id.
+ *
+ * @param session_id session id
+ * @return OC_TCP_SOCKET_STATE_CONNECTED TCP connection exists and it is ongoing
+ * @return OC_TCP_SOCKET_STATE_CONNECTING TCP connection is waiting to be
+ * established
+ * @return -1 otherwise
+ */
+int oc_tcp_session_state(uint32_t session_id);
+
 #endif /* OC_TCP */
 
 #ifdef __cplusplus

--- a/port/windows/ipadapter.c
+++ b/port/windows/ipadapter.c
@@ -1685,12 +1685,20 @@ oc_connectivity_shutdown(size_t device)
 void
 oc_connectivity_end_session(const oc_endpoint_t *endpoint)
 {
+  oc_connectivity_end_session_v1(endpoint, true);
+}
+
+bool
+oc_connectivity_end_session_v1(const oc_endpoint_t *endpoint,
+                               bool notify_session_end)
+{
   if (endpoint->flags & TCP) {
     ip_context_t *dev = get_ip_context_for_device(endpoint->device);
-    if (dev != NULL) {
-      oc_tcp_end_session(endpoint);
+    if (dev) {
+      return oc_tcp_end_session(endpoint, notify_session_end);
     }
   }
+  return false;
 }
 #endif /* OC_TCP */
 

--- a/port/windows/ipadapter.c
+++ b/port/windows/ipadapter.c
@@ -1685,17 +1685,20 @@ oc_connectivity_shutdown(size_t device)
 void
 oc_connectivity_end_session(const oc_endpoint_t *endpoint)
 {
-  oc_connectivity_end_session_v1(endpoint, true);
+  while (oc_connectivity_end_session_v1(endpoint, true, NULL)) {
+    // no-op
+  }
 }
 
 bool
 oc_connectivity_end_session_v1(const oc_endpoint_t *endpoint,
-                               bool notify_session_end)
+                               bool notify_session_end,
+                               oc_endpoint_t *session_endpoint)
 {
   if (endpoint->flags & TCP) {
     ip_context_t *dev = get_ip_context_for_device(endpoint->device);
     if (dev) {
-      return oc_tcp_end_session(endpoint, notify_session_end);
+      return oc_tcp_end_session(endpoint, notify_session_end, session_endpoint);
     }
   }
   return false;

--- a/port/windows/tcpadapter.c
+++ b/port/windows/tcpadapter.c
@@ -238,6 +238,9 @@ add_new_session_locked(SOCKET sock, ip_context_t *dev, oc_endpoint_t *endpoint,
   session->csm_state = state;
   session->sock_event = sock_event;
   session->notify_session_end = true;
+  if (session->endpoint.session_id == 0) {
+    session->endpoint.session_id = oc_tcp_get_new_session_id();
+  }
 
   oc_list_add(session_list, session);
 
@@ -318,11 +321,15 @@ find_session_by_endpoint_locked(const oc_endpoint_t *endpoint)
 }
 
 bool
-oc_tcp_end_session(const oc_endpoint_t *endpoint, bool notify_session_end)
+oc_tcp_end_session(const oc_endpoint_t *endpoint, bool notify_session_end,
+                   oc_endpoint_t *session_endpoint)
 {
   oc_tcp_adapter_mutex_lock();
   tcp_session_t *session = find_session_by_endpoint_locked(endpoint);
   if (session) {
+    if (session_endpoint) {
+      memcpy(session_endpoint, &session->endpoint, sizeof(oc_endpoint_t));
+    }
     free_tcp_session_async_locked(session, notify_session_end);
   }
   oc_tcp_adapter_mutex_unlock();

--- a/port/windows/tcpadapter.h
+++ b/port/windows/tcpadapter.h
@@ -33,7 +33,8 @@ void oc_tcp_connectivity_shutdown(ip_context_t *dev);
 int oc_tcp_send_buffer(ip_context_t *dev, oc_message_t *message,
                        const struct sockaddr_storage *receiver);
 
-bool oc_tcp_end_session(const oc_endpoint_t *endpoint, bool notify_session_end);
+bool oc_tcp_end_session(const oc_endpoint_t *endpoint, bool notify_session_end,
+                        oc_endpoint_t *session_endpoint);
 
 void oc_tcp_adapter_mutex_init(void);
 

--- a/port/windows/tcpadapter.h
+++ b/port/windows/tcpadapter.h
@@ -33,7 +33,7 @@ void oc_tcp_connectivity_shutdown(ip_context_t *dev);
 int oc_tcp_send_buffer(ip_context_t *dev, oc_message_t *message,
                        const struct sockaddr_storage *receiver);
 
-void oc_tcp_end_session(const oc_endpoint_t *endpoint);
+bool oc_tcp_end_session(const oc_endpoint_t *endpoint, bool notify_session_end);
 
 void oc_tcp_adapter_mutex_init(void);
 

--- a/security/oc_tls_internal.h
+++ b/security/oc_tls_internal.h
@@ -160,7 +160,7 @@ oc_tls_pki_verification_params_t oc_tls_peer_pki_default_verification_params(
  * @brief Remove and deallocate the peer for the endpoint.
  *
  * @param endpoint the endpoint
- * @param notify_session_end notify session end event
+ * @param notify_session_end send session end notification
  */
 void oc_tls_remove_peer(const oc_endpoint_t *endpoint, bool notify_session_end);
 

--- a/security/oc_tls_internal.h
+++ b/security/oc_tls_internal.h
@@ -160,8 +160,9 @@ oc_tls_pki_verification_params_t oc_tls_peer_pki_default_verification_params(
  * @brief Remove and deallocate the peer for the endpoint.
  *
  * @param endpoint the endpoint
+ * @param notify_session_end notify session end event
  */
-void oc_tls_remove_peer(const oc_endpoint_t *endpoint);
+void oc_tls_remove_peer(const oc_endpoint_t *endpoint, bool notify_session_end);
 
 /**
  * @brief Remove TLS peers matching filter.

--- a/security/unittest/acltest.cpp
+++ b/security/unittest/acltest.cpp
@@ -320,7 +320,7 @@ TEST_F(TestAcl, oc_sec_check_acl_FailInsecureDOC)
   resource.device = kDeviceID;
   EXPECT_FALSE(oc_sec_check_acl(OC_GET, &resource, &ep));
 
-  oc_tls_remove_peer(&ep);
+  oc_tls_remove_peer(&ep, true);
 }
 
 #ifdef OC_HAS_FEATURE_RESOURCE_ACCESS_IN_RFOTM
@@ -397,7 +397,7 @@ TEST_F(TestAcl, oc_sec_check_acl_DOCAccessToDCR)
 
   EXPECT_TRUE(oc_sec_check_acl(OC_GET, resource, &ep));
 
-  oc_tls_remove_peer(&ep);
+  oc_tls_remove_peer(&ep, true);
 }
 
 TEST_F(TestAcl, oc_sec_check_acl_GETinRFOTM)
@@ -643,7 +643,7 @@ TEST_F(TestAcl, oc_sec_check_acl_AccessToSVRBySubject)
   EXPECT_FALSE(oc_sec_check_acl(OC_FETCH, doxm, &ep));
   oc_sec_acl_clear(kDeviceID, nullptr, nullptr);
 
-  oc_tls_remove_peer(&ep);
+  oc_tls_remove_peer(&ep, true);
 }
 
 TEST_F(TestAcl, oc_sec_check_acl_AccessToSVRByPSK)
@@ -731,7 +731,7 @@ TEST_F(TestAcl, oc_sec_check_acl_AccessToSVRByPSK)
   oc_sec_acl_clear(kDeviceID, nullptr, nullptr);
 
   peer->ssl_ctx.session = nullptr;
-  oc_tls_remove_peer(&ep);
+  oc_tls_remove_peer(&ep, true);
 }
 
 #if defined(OC_DYNAMIC_ALLOCATION) && defined(OC_PKI)
@@ -781,7 +781,7 @@ TEST_F(TestAcl, oc_sec_check_acl_AccessToSVRByOwnerRoleCred)
   ASSERT_NE(-1, credid);
   checkAccessToResource(doxm, &ep);
 
-  oc_tls_remove_peer(&ep);
+  oc_tls_remove_peer(&ep, true);
 }
 
 TEST_F(TestAcl, oc_sec_check_acl_AccessToSVRByNonOwnerRoleCred)
@@ -839,7 +839,7 @@ TEST_F(TestAcl, oc_sec_check_acl_AccessToSVRByNonOwnerRoleCred)
   checkAccessToResource(doxm, &ep, false, true, true, false);
 
   oc_sec_acl_clear(kDeviceID, nullptr, nullptr);
-  oc_tls_remove_peer(&ep);
+  oc_tls_remove_peer(&ep, true);
 }
 
 #endif /* OC_DYNAMIC_ALLOCATION && OC_PKI */

--- a/security/unittest/rolestest.cpp
+++ b/security/unittest/rolestest.cpp
@@ -79,7 +79,7 @@ public:
   void TearDown() override
   {
     for (auto &peer : peers_) {
-      oc_tls_remove_peer(&peer->endpoint);
+      oc_tls_remove_peer(&peer->endpoint, true);
     }
     peers_.clear();
 

--- a/security/unittest/tlstest.cpp
+++ b/security/unittest/tlstest.cpp
@@ -176,7 +176,7 @@ TEST_F(TestEventsWithServer, DropOutputMessages)
   oc_send_message(msg);
   EXPECT_LT(0, countInboundOrOutboundEvents());
 
-  oc_tls_remove_peer(&ep);
+  oc_tls_remove_peer(&ep, true);
   ASSERT_EQ(0, countInboundOrOutboundEvents());
 }
 
@@ -208,7 +208,7 @@ TEST_F(TestEventsWithServer, DropOutputMessagesTCP)
   oc_send_message(msg);
   EXPECT_LT(0, countInboundOrOutboundEvents());
 
-  oc_tls_remove_peer(&ep);
+  oc_tls_remove_peer(&ep, true);
   ASSERT_EQ(0, countInboundOrOutboundEvents());
 }
 #endif /* OC_TCP */

--- a/swig/swig_interfaces/oc_connectivity.i
+++ b/swig/swig_interfaces/oc_connectivity.i
@@ -58,6 +58,7 @@ void jni_connectivity_shutdown(size_t device)
 %}
 %ignore oc_send_discovery_request;
 %ignore oc_connectivity_end_session;
+%ignore oc_connectivity_end_session_v1;
 %ignore oc_dns_lookup;
 %ignore oc_connectivity_get_endpoints;
 %ignore handle_network_interface_event_callback;


### PR DESCRIPTION
This pull request introduces a significant update to the oc_tls.c file within the security module, focusing on the management of TCP client disconnect notifications. A new boolean parameter, notify_session_end, has been added to several function signatures including oc_tls_free_peer, oc_tls_remove_peer, and oc_tls_close_peer. This parameter allows for controlled notification of session ends, thereby enhancing the flexibility and robustness of session handling across the TLS code.

## Key Changes:

- The oc_tls_free_peer function now includes an additional boolean parameter notify_session_end to decide if the session end should be notified.
- Similar updates have been made to oc_tls_remove_peer and oc_tls_close_peer, incorporating the notify_session_end parameter to manage session notifications effectively.
- These changes ensure that the session end notification can be managed more precisely, improving the overall stability and functionality of the TLS handling.

This update aims to provide better control over how session ends are notified, which is crucial for maintaining stable and secure communications in networked applications.

